### PR TITLE
Add a root-level prettier config

### DIFF
--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -1,7 +1,7 @@
 name: Setup node and pnpm
 description: Setup node and install dependencies using pnpm
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - uses: actions/setup-node@v4
       name: Install Node.js

--- a/.github/workflows/on-push-branch-main.yml
+++ b/.github/workflows/on-push-branch-main.yml
@@ -38,7 +38,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm release
-          title: "Release Preview"
+          title: 'Release Preview'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+LICENSE
+packages/*
+storybook
+pnpm-lock.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ render() {
 
 ```ts
 // checkbox.styles.ts
-import { css } from "lit";
+import { css } from 'lit';
 
 export default css`
   .component {
@@ -142,7 +142,7 @@ Instead, we should stick with exposing styles via CSS variables until the need a
 
 ```ts
 // ✅ -- GOOD
-@customElement("cs-example")
+@customElement('cs-example')
 export default class Example extends LitElement {
   static override styles = css`
     .summary {
@@ -164,7 +164,7 @@ export default class Example extends LitElement {
 
 ```ts
 // ❌ -- BAD
-@customElement("cs-example")
+@customElement('cs-example')
 export default class Example extends LitElement {
   override render() {
     return html`
@@ -226,7 +226,7 @@ In this particular case, we still need to use TypeScript's `private`.
 
 ```ts
 // ✅ -- GOOD
-@customElement("cs-example")
+@customElement('cs-example')
 export default class Example extends LitElement {
   @state()
   // OK to use `private` in TS here
@@ -236,7 +236,7 @@ export default class Example extends LitElement {
 
 ```ts
 // ❌ -- BAD
-@customElement("cs-example")
+@customElement('cs-example')
 export default class Example extends LitElement {
   @state()
   // This doesn't work!
@@ -282,14 +282,14 @@ One may reach for [`query`](https://lit.dev/docs/api/decorators/#query); however
 ```ts
 // ✅ -- GOOD
 // Use a `ref` when accessing an element.
-import { createRef, ref } from "lit/directives/ref.js";
+import { createRef, ref } from 'lit/directives/ref.js';
 
-@customElement("cs-example")
+@customElement('cs-example')
 export default class Example extends LitElement {
   #buttonElement = createRef<HTMLButtonElement>();
 
   #onClick(Event: MouseEvent) {
-    this.#buttonElement.value?.classList?.add("clicked");
+    this.#buttonElement.value?.classList?.add('clicked');
   }
 
   override render() {
@@ -305,15 +305,15 @@ export default class Example extends LitElement {
 ```ts
 // ❌ -- BAD
 // Don't use `query` when accessing a single element.
-import { query } from "lit/decorators.js";
+import { query } from 'lit/decorators.js';
 
-@customElement("cs-example")
+@customElement('cs-example')
 export default class Example extends LitElement {
-  @query("button")
+  @query('button')
   #buttonElement!: HTMLButtonElement | undefined;
 
   #onClick(Event: MouseEvent) {
-    this.#buttonElement?.classList?.add("clicked");
+    this.#buttonElement?.classList?.add('clicked');
   }
 
   override render() {
@@ -372,7 +372,7 @@ Take for example the `open` attribute on a details element.
 
 ```ts
 // ✅ -- GOOD
-@customElement("cs-example")
+@customElement('cs-example')
 export default class Example extends LitElement {
   // We use an `open` attribute to match the `open` attribute
   // found on the details element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#open
@@ -393,7 +393,7 @@ export default class Example extends LitElement {
 
 ```ts
 // ❌ -- BAD
-@customElement("cs-example")
+@customElement('cs-example')
 export default class Example extends LitElement {
   // We would not want to inject "frameworkisms" into our
   // component API by naming this property `is-open`.  It may
@@ -401,7 +401,7 @@ export default class Example extends LitElement {
   // frameworks; however, it would be a surprise to consumers
   // as it would deviate from the native API for the
   // details element.
-  @property({ attribute: "is-open", type: Boolean, reflect: true }) isOpen =
+  @property({ attribute: 'is-open', type: Boolean, reflect: true }) isOpen =
     false;
 
   override render() {
@@ -457,11 +457,11 @@ components/
 
 ```js
 // ❌ -- BAD
-describe("Checkbox Basics", () => {});
-describe("Checkbox Events", () => {});
-describe("Checkbox Focus", () => {});
-describe("Checkbox Form", () => {});
-describe("Checkbox Validity", () => {});
+describe('Checkbox Basics', () => {});
+describe('Checkbox Events', () => {});
+describe('Checkbox Focus', () => {});
+describe('Checkbox Form', () => {});
+describe('Checkbox Validity', () => {});
 ```
 
 ### Prefer prefixing handlers with "on"
@@ -470,11 +470,11 @@ When writing internal handlers, we prefer prefixing our functions with "on".
 
 ```ts
 // ✅ -- GOOD
-@customElement("cs-example")
+@customElement('cs-example')
 export default class Example extends LitElement {
   // @click handler is prefixed with `on`
   #onClick(Event: MouseEvent) {
-    console.log("clicked");
+    console.log('clicked');
   }
 
   override render() {
@@ -489,11 +489,11 @@ export default class Example extends LitElement {
 
 ```ts
 // ❌ -- BAD
-@customElement("cs-example")
+@customElement('cs-example')
 export default class Example extends LitElement {
   // @click handler does not start with `on`
   #handleClick(Event: MouseEvent) {
-    console.log("clicked");
+    console.log('clicked');
   }
 
   override render() {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "start:development:comment": "`--parallel` output is interleaved and not as easy to read. But I was seeing the Storybook build hang without it. As a bonus it's faster.",
     "start:production": "pnpm --aggregate-output --filter '@crowdstrike/*' --parallel start",
     "format": "per-env",
-    "format:development": "pnpm --filter '@crowdstrike/*' format",
-    "format:production": "pnpm --aggregate-output --filter '@crowdstrike/*' --parallel format",
+    "format:development": "prettier . --write && pnpm --filter '@crowdstrike/*' format",
+    "format:production": "prettier . --check && pnpm --aggregate-output --filter '@crowdstrike/*' --parallel format",
     "lint": "per-env",
     "lint:development": "pnpm --filter '@crowdstrike/*' lint",
     "lint:production": "pnpm --aggregate-output --filter '@crowdstrike/*' --parallel lint",
@@ -31,7 +31,8 @@
     "husky": "^8.0.3",
     "is-ci": "^3.0.1",
     "lint-staged": "^14.0.1",
-    "per-env": "^1.0.2"
+    "per-env": "^1.0.2",
+    "prettier": "3.1.0"
   },
   "engines": {
     "node": "20.9.0",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,13 +21,13 @@
   Import the styles in your project:
 
   ```js
-  import "@crowdstrike/glide-core-styles";
+  import '@crowdstrike/glide-core-styles';
   ```
 
   Import the component you'd like to render:
 
   ```js
-  import "@crowdstrike/glide-core-components/button.js";
+  import '@crowdstrike/glide-core-components/button.js';
   ```
 
   Render the component in your markup:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       per-env:
         specifier: ^1.0.2
         version: 1.0.2
+      prettier:
+        specifier: 3.1.0
+        version: 3.1.0
 
   packages/components:
     devDependencies:

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,6 @@
+/** @type {import("prettier".Config)}  */
+const config = {
+  singleQuote: true,
+};
+
+export default config;


### PR DESCRIPTION
## 🚀 Description

**tl;dr**
We need to run prettier on our changeset markdown files, otherwise we get prettier errors when we run `--check`. 

**long version**
You may have noticed in a previous PR where I had to go in and format a CHANGELOG.md file: https://github.com/CrowdStrike/glide-core/pull/5/files#diff-b5aa808176801bfde2277ac886bbbdf0863de109950303cdb89e2d33ebe16a28

This was because Prettier in our `packages/*` directories runs against markdown files and was producing an error.  The issue was that we _don't_ run Prettier in the `.changeset/*` directory at the root level, which is where the CHANGELOG.md file is generated from.  Due to that, if one of our changesets [had double-quotes](https://github.com/CrowdStrike/glide-core/pull/2/files#diff-884e54f0463c8587f1e832e5872961091196076bb3579fdd60e6cc1a170deeebR17) in the description of a code block, when that changeset would merge into `main`, if you immediately pulled and ran `pnpm format` you'd notice that the CHANGELOG file gets updated.  This is unexpected!  Due to that, I've added a top-level prettier config that will run prettier on the files we care about to prevent this from happening.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- [x] I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- [x] I have added tests to cover new or updated functionality.
- [x] I have created or updated stories in Storybook to document the new functionality.
- [x] I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- [x] I have scheduled a Design Review for these changes, if one is required.
- [x] I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Green build 🟢 
- 
<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
