### PR TITLE
Tweak top-level .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,7 @@
+# TODO
+# The top-level Prettier shouldn't format individual packages, which 
+# have their own Prettier configurations. Add `packages/*` and `storybook` 
+# to this file if this bug is fixed: https://github.com/prettier/prettier-vscode/issues/3003
+
 LICENSE
-packages/*
-storybook
 pnpm-lock.yaml


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

The top-level `.prettierignore` is causing VS Code's Prettier plugin to ignore `packages/*` and `storybook` altogether. 

This shouldn't be the case because those directories have their own Prettier configurations. But apparently VS Code's Prettier plugin has a [bug](https://github.com/prettier/prettier-vscode/issues/3003) where it doesn't use the closest `.prettierignore` and instead looks to the top-level of the repository for one.

The only solution I found was to remove `packages/*` and `storybook`  from the top-level `.prettierignore`.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A
