### PR TITLE
Allow Button to participate in forms

### DIFF
--- a/.changeset/nine-panthers-worry.md
+++ b/.changeset/nine-panthers-worry.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Updated `<cs-button` to properly participate in forms when `type="submit"` or `type="reset"`.

--- a/packages/components/src/button.test.ts
+++ b/packages/components/src/button.test.ts
@@ -1,6 +1,12 @@
 import './button.js';
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
-import type Button from './button.js';
+import {
+  elementUpdated,
+  expect,
+  fixture,
+  html,
+  oneEvent,
+} from '@open-wc/testing';
+import type Button from './button.ts';
 
 it('renders and sets default attributes', async () => {
   const element = await fixture<Button>(html` <cs-button>Button</cs-button> `);
@@ -172,4 +178,52 @@ it('renders without prefix and suffix classes after both slots are removed', asy
   expect([
     ...element.shadowRoot!.querySelector('button')!.classList,
   ]).to.deep.equal(['button', 'primary', 'large']);
+});
+
+it('dispatches an event when clicked and type="button"', async () => {
+  const element = await fixture<HTMLFormElement>(html`
+    <cs-button type="button"> Button </cs-button>
+  `);
+
+  const clickEvent = oneEvent(element, 'click');
+
+  element.shadowRoot?.querySelector<HTMLButtonElement>('button')?.click();
+
+  const event = await clickEvent;
+  expect(event instanceof Event).to.be.true;
+});
+
+it('participates in a form when type="reset"', async () => {
+  const form = document.createElement('form');
+
+  const element = await fixture<HTMLFormElement>(
+    html` <cs-button type="reset"> Button </cs-button> `,
+    {
+      parentNode: form,
+    },
+  );
+
+  const formResetEvent = oneEvent(form, 'reset');
+
+  element.shadowRoot?.querySelector<HTMLButtonElement>('button')?.click();
+
+  const event = await formResetEvent;
+  expect(event instanceof Event).to.be.true;
+});
+
+it('participates in a form when type="submit"', async () => {
+  const form = document.createElement('form');
+
+  const element = await fixture<HTMLFormElement>(
+    html` <cs-button type="submit"> Button </cs-button> `,
+    {
+      parentNode: form,
+    },
+  );
+
+  const formSubmitEvent = oneEvent(form, 'submit');
+  element.shadowRoot?.querySelector<HTMLButtonElement>('button')?.click();
+
+  const event = await formSubmitEvent;
+  expect(event instanceof Event).to.be.true;
 });

--- a/packages/components/src/button.ts
+++ b/packages/components/src/button.ts
@@ -18,6 +18,7 @@ declare global {
 @customElement('cs-button')
 export default class CsButton extends LitElement {
   static override styles = styles;
+  static formAssociated = true;
 
   /** Sets the disabled attribute on the button. */
   @property({ type: Boolean, reflect: true }) disabled = false;
@@ -37,6 +38,32 @@ export default class CsButton extends LitElement {
   @state()
   private hasSuffixSlot = false;
 
+  constructor() {
+    super();
+    this.#internals = this.attachInternals();
+  }
+
+  get form() {
+    return this.#internals.form;
+  }
+
+  #handleClick() {
+    if (this.type === 'button') {
+      return;
+    }
+
+    if (this.type === 'submit') {
+      this.form?.requestSubmit();
+      return;
+    }
+
+    if (this.type === 'reset') {
+      this.form?.reset();
+      return;
+    }
+  }
+
+  #internals: ElementInternals;
   #prefixSlotElement = createRef<HTMLSlotElement>();
   #suffixSlotElement = createRef<HTMLSlotElement>();
 
@@ -66,6 +93,7 @@ export default class CsButton extends LitElement {
       })}
       type=${this.type}
       ?disabled=${this.disabled}
+      @click=${this.#handleClick}
     >
       <slot
         name="prefix"


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

It was reported that buttons were not participating in forms properly.  Given the following, the button would previously not call the submit handler when clicked.

```html
<form id="formElement">
  <label>
    Name
    <input type="text" />
  </label>
  <cs-button type="reset">Reset</cs-button>
  <cs-button type="submit">Submit</cs-button>
</form>
```

```js
const form = document.getElementById('formElement');
form.addEventListener('submit', (event) => {
  // This was never being called, despite clicking the button!
});

form.addEventListener('reset', (event) => {
  // Neither was this!
});
```

With these changes, buttons now behave as you'd expect.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- New functionality is covered with tests.
  -  These tests were previously failing before the changes in `button.ts`

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
