### PR TITLE
Port over Button changes for Menu

### DIFF
--- a/.changeset/late-rules-explode.md
+++ b/.changeset/late-rules-explode.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': minor
+---
+
+Reflect Button's `ariaExpanded` and `ariaHasPopup` properties.

--- a/packages/components/src/button.styles.ts
+++ b/packages/components/src/button.styles.ts
@@ -3,6 +3,11 @@ import { focusOutline } from './styles.js';
 
 export default [
   css`
+    :host {
+      /* Contains elements with "padding" and "width". Inline by default. */
+      display: inline-block;
+    }
+
     .button {
       align-items: center;
       border-color: transparent;

--- a/packages/components/src/button.test.ts
+++ b/packages/components/src/button.test.ts
@@ -145,7 +145,7 @@ it('renders with a suffix slot', async () => {
   expect(document.querySelector('[data-suffix]')).to.be.ok;
 });
 
-it('renders with a prefix and suffix slot', async () => {
+it('renders with a prefix and suffix slot when both are present initially', async () => {
   const element = await fixture<Button>(html`
     <cs-button>
       <span slot="prefix" data-prefix>prefix</span>
@@ -162,12 +162,39 @@ it('renders with a prefix and suffix slot', async () => {
   expect(document.querySelector('[data-suffix]')).to.be.ok;
 });
 
-it('renders without prefix and suffix classes after both slots are removed', async () => {
+it('renders with prefix and suffix classes when both are dynamically added', async () => {
+  const element = await fixture<Button>(html`
+    <cs-button> Button </cs-button>
+  `);
+
+  const prefix = document.createElement('span');
+  prefix.setAttribute('slot', 'prefix');
+  prefix.dataset.prefix = undefined;
+  prefix.textContent = 'prefix';
+  element.append(prefix);
+
+  const suffix = document.createElement('span');
+  suffix.setAttribute('slot', 'suffix');
+  prefix.dataset.suffix = undefined;
+  suffix.textContent = 'suffix';
+  element.append(suffix);
+
+  await elementUpdated(element);
+
+  expect([
+    ...element.shadowRoot!.querySelector('button')!.classList,
+  ]).to.deep.equal(['button', 'primary', 'large', 'has-prefix', 'has-suffix']);
+
+  expect(document.querySelector('[data-prefix]')).to.be.ok;
+  expect(document.querySelector('[data-suffix]')).to.be.ok;
+});
+
+it('renders without prefix and suffix classes after both are removed', async () => {
   const element = await fixture<Button>(html`
     <cs-button>
-      <span slot="prefix" data-prefix>prefix</span>
+      <span slot="prefix">prefix</span>
       Button
-      <span slot="suffix" data-suffix>suffix</span>
+      <span slot="suffix">suffix</span>
     </cs-button>
   `);
 

--- a/packages/components/src/button.ts
+++ b/packages/components/src/button.ts
@@ -26,6 +26,12 @@ export default class CsButton extends LitElement {
 
   static override styles = styles;
 
+  @property({ reflect: true })
+  override ariaExpanded: string | null = null;
+
+  @property({ reflect: true })
+  override ariaHasPopup: string | null = null;
+
   /** Sets the disabled attribute on the button. */
   @property({ type: Boolean, reflect: true }) disabled = false;
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- Ports over from `glide` some Button changes to support Menu.
- Adds a missing Button test.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
