### PR TITLE
Adjust pattern for closing the shadow root

### DIFF
--- a/.changeset/cuddly-pans-repair.md
+++ b/.changeset/cuddly-pans-repair.md
@@ -1,0 +1,13 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Updated `<cs-button` to default to a closed shadow root, removing the webdriver workaround.
+
+You can reopen the shadow root in tests if needed:
+
+```ts
+// test.ts
+import Button from '@crowdstrike/glide-core-components/button.js';
+Button.shadowRootOptions.mode = 'open';
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,13 +252,20 @@ Our components extend `LitElement`, whose shadow root is open by default.
 We recommend closing it:
 
 ```ts
+// component.ts
 static shadowRootOptions: ShadowRootInit = {
   ...LitElement.shadowRootOptions,
-  mode: window.navigator.webdriver ? 'open' : 'closed',
+  mode:'closed',
 };
 ```
 
-> Use `window.navigator.webdriver` if you need the shadow root open for tests.
+You can reopen the shadow root in tests if needed:
+
+```ts
+// test.ts
+import Component from './component.js';
+Component.shadowRootOptions.mode = 'open';
+```
 
 Closing the shadow root does mean that Lit will no longer attach it the host (`this`).
 That's what we want.
@@ -266,6 +273,7 @@ But you may still need to access it from within your component.
 If so, you can implement `createRenderRoot` and attach `shadowRoot` privately to the host:
 
 ```ts
+// component.ts
 #shadowRoot?: ShadowRoot;
 
 protected createRenderRoot() {

--- a/packages/components/src/button.test.ts
+++ b/packages/components/src/button.test.ts
@@ -6,7 +6,9 @@ import {
   html,
   oneEvent,
 } from '@open-wc/testing';
-import type Button from './button.ts';
+import Button from './button.js';
+
+Button.shadowRootOptions.mode = 'open';
 
 it('renders and sets default attributes', async () => {
   const element = await fixture<Button>(html` <cs-button>Button</cs-button> `);
@@ -247,6 +249,8 @@ it('participates in a form when type="submit"', async () => {
       parentNode: form,
     },
   );
+
+  form.addEventListener('submit', (event) => event.preventDefault());
 
   const formSubmitEvent = oneEvent(form, 'submit');
   element.shadowRoot?.querySelector<HTMLButtonElement>('button')?.click();

--- a/packages/components/src/button.ts
+++ b/packages/components/src/button.ts
@@ -21,7 +21,7 @@ export default class CsButton extends LitElement {
 
   static override shadowRootOptions: ShadowRootInit = {
     ...LitElement.shadowRootOptions,
-    mode: window.navigator.webdriver ? 'open' : 'closed',
+    mode: 'closed',
   };
 
   static override styles = styles;


### PR DESCRIPTION
## 🚀 Description

Big hat tip ( 🎩 ) to @clintcs for this.  This came about as I'm working on the Drawer component. Essentially moving to this pattern means we'll get better code coverage without having to ignore the line and the ternary checking if we're in a webdriver mode.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Green build 🟢 

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
