### PR TITLE
Add a Drawer component

### DIFF
--- a/.changeset/giant-cameras-explode.md
+++ b/.changeset/giant-cameras-explode.md
@@ -1,0 +1,33 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Added the `<cs-drawer` component.
+
+The Drawer can be opened via the `open` method:
+
+```html
+<script>
+  const drawer = context.canvasElement.querySelector('cs-drawer');
+  drawer?.open();
+</script>
+
+<cs-drawer>Content</cs-drawer>
+```
+
+It is closed via the `close` method:
+
+```html
+<script>
+  const drawer = context.canvasElement.querySelector('cs-drawer');
+  drawer?.close();
+</script>
+
+<cs-drawer>Content</cs-drawer>
+```
+
+A custom width can be set via the `--cs-drawer-width` CSS custom property:
+
+```html
+<cs-drawer style="--cs-drawer-width: 20rem;">Content</cs-drawer>
+```

--- a/packages/components/.storybook/overrides.css
+++ b/packages/components/.storybook/overrides.css
@@ -1,0 +1,5 @@
+.docs-story {
+  & > div {
+    padding: 0;
+  }
+}

--- a/packages/components/.storybook/preview.js
+++ b/packages/components/.storybook/preview.js
@@ -1,6 +1,8 @@
 /** @type { import('@storybook/web-components').Preview } */
 import '@crowdstrike/glide-core-styles';
 
+import './overrides.css';
+
 const preview = {
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },

--- a/packages/components/src/drawer.stories.ts
+++ b/packages/components/src/drawer.stories.ts
@@ -1,0 +1,112 @@
+import './button.js';
+import './drawer.js';
+import { html } from 'lit-html';
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+const meta: Meta = {
+  decorators: [(story) => html`<div style="height: 12.5rem;">${story()}</div>`],
+  title: 'Drawer',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'A Drawer element with a default slot for content.',
+      },
+      story: {
+        autoplay: true,
+      },
+    },
+  },
+  play(context) {
+    let isOpen = false;
+
+    const button = context.canvasElement.querySelector('cs-button');
+    const drawer = context.canvasElement.querySelector('cs-drawer');
+
+    if (!button || !drawer) {
+      return;
+    }
+
+    button.addEventListener('click', () => {
+      if (isOpen) {
+        drawer?.close();
+        return;
+      }
+
+      drawer?.open();
+    });
+
+    drawer.addEventListener('open', () => (isOpen = true));
+
+    drawer.addEventListener('close', () => (isOpen = false));
+  },
+  render: (arguments_) => html`
+    <cs-button>Toggle</cs-button>
+
+    <cs-drawer>
+      <div style="padding: 0.5rem">${arguments_['slot="default"']}</div>
+    </cs-drawer>
+  `,
+  args: {
+    'slot="default"': 'Drawer content',
+  },
+  argTypes: {
+    'slot="default"': {
+      control: { type: 'text' },
+      table: {
+        type: { summary: 'string | html' },
+      },
+      type: { name: 'string', required: true },
+    },
+    'open()': {
+      table: {
+        type: {
+          summary: 'method',
+          detail: 'Opens the Drawer.',
+        },
+      },
+    },
+    'close()': {
+      table: {
+        type: {
+          summary: 'method',
+          detail: 'Closes the Drawer.',
+        },
+      },
+    },
+    'addEventListener(event)': {
+      control: { type: '' },
+      table: {
+        type: {
+          summary: 'method',
+          detail: 'event: "open" | "close"',
+        },
+      },
+    },
+    '--cs-drawer-width': {
+      control: { type: '' },
+      table: {
+        type: {
+          summary: 'css property',
+          detail: 'Sets the width of the Drawer.',
+        },
+      },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: StoryObj = {};
+
+export const WithCSSVariable: StoryObj = {
+  name: 'Custom Width',
+  render: () => html`
+    <cs-button data-trigger>Open/Close</cs-button>
+
+    <!-- Use the the following CSS variable to adjust the width of the Drawer -->
+    <cs-drawer style="--cs-drawer-width: 20rem;">
+      <div style="padding: 0.5rem">Width of 20rem</div>
+    </cs-drawer>
+  `,
+};

--- a/packages/components/src/drawer.styles.ts
+++ b/packages/components/src/drawer.styles.ts
@@ -1,0 +1,38 @@
+import { css } from 'lit';
+
+export default [
+  css`
+    dialog {
+      all: unset;
+      background-color: var(--cs-surface-base-lighter);
+      block-size: 0;
+      border-end-start-radius: 0.625rem;
+      border-start-start-radius: 0.625rem;
+      box-shadow: var(--cs-shadow-xl);
+      font-family: var(--cs-body-xs-font-family);
+      inline-size: 0;
+      inset: 0;
+      max-inline-size: 100%;
+      opacity: 0;
+      position: absolute;
+      transform: translateX(100%);
+      transition:
+        transform 0.2s ease-out,
+        opacity 0.3s ease-out;
+      visibility: hidden;
+    }
+
+    .dialog-open {
+      block-size: auto;
+      inline-size: var(--cs-drawer-width, 27.375rem);
+      inset: 0 0 0 auto;
+      opacity: 1;
+      transform: none;
+      visibility: visible;
+    }
+
+    .dialog-closing {
+      transform: translateX(100%);
+    }
+  `,
+];

--- a/packages/components/src/drawer.test.accessibility.ts
+++ b/packages/components/src/drawer.test.accessibility.ts
@@ -1,0 +1,38 @@
+import './drawer.js';
+import { expect, fixture, html } from '@open-wc/testing';
+import Drawer from './drawer.js';
+
+Drawer.shadowRootOptions.mode = 'open';
+
+// NOTE: Due to https://github.com/modernweb-dev/web/issues/2520, we sometimes need
+// to manually dispatch the `transitionend` event in tests.
+
+it('is accessible', async () => {
+  const drawer = await fixture<Drawer>(
+    html`<cs-drawer>Drawer content</cs-drawer>`,
+  );
+
+  drawer.shadowRoot
+    ?.querySelector<HTMLDialogElement>('dialog')
+    ?.dispatchEvent(new TransitionEvent('transitionend'));
+
+  drawer.open();
+
+  await expect(drawer).to.be.accessible();
+});
+
+it('focuses the dialog upon opening', async () => {
+  const drawer = await fixture<Drawer>(
+    html`<cs-drawer>Drawer content</cs-drawer>`,
+  );
+
+  drawer.open();
+
+  drawer.shadowRoot
+    ?.querySelector<HTMLDialogElement>('dialog')
+    ?.dispatchEvent(new TransitionEvent('transitionend'));
+
+  expect(drawer.shadowRoot?.activeElement).to.equal(
+    drawer.shadowRoot?.querySelector('dialog'),
+  );
+});

--- a/packages/components/src/drawer.test.basics.ts
+++ b/packages/components/src/drawer.test.basics.ts
@@ -1,0 +1,41 @@
+import './drawer.js';
+import { expect, fixture, html } from '@open-wc/testing';
+import Drawer from './drawer.js';
+
+Drawer.shadowRootOptions.mode = 'open';
+
+it('registers', async () => {
+  expect(window.customElements.get('cs-drawer')).to.equal(Drawer);
+});
+
+it('has defaults', async () => {
+  const drawer = await fixture<Drawer>(
+    html`<cs-drawer>Drawer content</cs-drawer>`,
+  );
+
+  expect(drawer.hasAttribute('open')).to.be.false;
+});
+
+it('can have a default slot', async () => {
+  const drawer = await fixture<Drawer>(
+    html`<cs-drawer>Drawer content</cs-drawer>`,
+  );
+
+  drawer.open();
+
+  expect(drawer.textContent).to.equal('Drawer content');
+});
+
+it('sets the width of the element based on the "--cs-drawer-width" CSS variable', async () => {
+  const styledDiv = document.createElement('div');
+  styledDiv.setAttribute('style', '--cs-drawer-width: 750px');
+
+  const drawer = await fixture<Drawer>(
+    html`<cs-drawer>Drawer content</cs-drawer>`,
+    { parentNode: styledDiv },
+  );
+
+  drawer.open();
+
+  expect(drawer.shadowRoot?.querySelector('dialog')?.clientWidth).to.equal(750);
+});

--- a/packages/components/src/drawer.test.closing.ts
+++ b/packages/components/src/drawer.test.closing.ts
@@ -1,0 +1,60 @@
+import './drawer.js';
+import {
+  elementUpdated,
+  expect,
+  fixture,
+  html,
+  oneEvent,
+} from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
+import Drawer from './drawer.js';
+
+Drawer.shadowRootOptions.mode = 'open';
+
+// NOTE: Due to https://github.com/modernweb-dev/web/issues/2520, we sometimes need
+// to manually dispatch the `transitionend` event in tests.
+
+it('closes when the "Escape" key is pressed', async () => {
+  const drawer = await fixture<Drawer>(
+    html`<cs-drawer>Drawer content</cs-drawer>`,
+  );
+
+  drawer.open();
+
+  drawer.shadowRoot
+    ?.querySelector<HTMLDialogElement>('dialog')
+    ?.dispatchEvent(new TransitionEvent('transitionend'));
+
+  await elementUpdated(drawer);
+
+  await sendKeys({ press: 'Escape' });
+
+  setTimeout(() => {
+    drawer.shadowRoot
+      ?.querySelector<HTMLDialogElement>('dialog')
+      ?.dispatchEvent(new TransitionEvent('transitionend'));
+  });
+
+  await oneEvent(drawer, 'close');
+
+  expect(drawer.shadowRoot?.querySelector('dialog')?.open).to.be.false;
+});
+
+it('does not close when a key other than "Escape" is pressed', async () => {
+  const drawer = await fixture<Drawer>(
+    html`<cs-drawer>Drawer content</cs-drawer>`,
+  );
+
+  drawer.open();
+
+  drawer.shadowRoot
+    ?.querySelector<HTMLDialogElement>('dialog')
+    ?.dispatchEvent(new TransitionEvent('transitionend'));
+
+  await elementUpdated(drawer);
+
+  drawer.shadowRoot?.querySelector('dialog')?.focus();
+  await sendKeys({ press: 'Enter' });
+
+  expect(drawer.shadowRoot?.querySelector('dialog')?.open).to.be.true;
+});

--- a/packages/components/src/drawer.test.events.ts
+++ b/packages/components/src/drawer.test.events.ts
@@ -1,0 +1,88 @@
+import './drawer.js';
+import {
+  elementUpdated,
+  expect,
+  fixture,
+  html,
+  oneEvent,
+} from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
+import Drawer from './drawer.js';
+
+Drawer.shadowRootOptions.mode = 'open';
+
+// NOTE: Due to https://github.com/modernweb-dev/web/issues/2520, we sometimes need
+// to manually dispatch the `transitionend` event in tests.
+
+it('dispatches an "open" event when opened via the "open" method', async () => {
+  const drawer = await fixture<Drawer>(
+    html`<cs-drawer>Drawer content</cs-drawer>`,
+  );
+
+  const openEvent = oneEvent(drawer, 'open');
+
+  drawer.open();
+
+  drawer.shadowRoot
+    ?.querySelector<HTMLDialogElement>('dialog')
+    ?.dispatchEvent(new TransitionEvent('transitionend'));
+
+  await elementUpdated(drawer);
+
+  const event = await openEvent;
+  expect(event instanceof Event).to.be.true;
+});
+
+it('dispatches a "close" event when the "Escape" key is pressed', async () => {
+  const drawer = await fixture<Drawer>(
+    html`<cs-drawer>Drawer content</cs-drawer>`,
+  );
+
+  const closeEvent = oneEvent(drawer, 'close');
+
+  drawer.open();
+
+  drawer.shadowRoot
+    ?.querySelector<HTMLDialogElement>('dialog')
+    ?.dispatchEvent(new TransitionEvent('transitionend'));
+
+  await elementUpdated(drawer);
+
+  await sendKeys({ press: 'Escape' });
+
+  setTimeout(() => {
+    drawer.shadowRoot
+      ?.querySelector<HTMLDialogElement>('dialog')
+      ?.dispatchEvent(new TransitionEvent('transitionend'));
+  });
+
+  const event = await closeEvent;
+  expect(event instanceof Event).to.be.true;
+});
+
+it('dispatches a "close" event when closed via the "close" method', async () => {
+  const drawer = await fixture<Drawer>(
+    html`<cs-drawer>Drawer content</cs-drawer>`,
+  );
+
+  const closeEvent = oneEvent(drawer, 'close');
+
+  drawer.open();
+
+  drawer.shadowRoot
+    ?.querySelector<HTMLDialogElement>('dialog')
+    ?.dispatchEvent(new TransitionEvent('transitionend'));
+
+  await elementUpdated(drawer);
+
+  drawer.close();
+
+  setTimeout(() => {
+    drawer.shadowRoot
+      ?.querySelector<HTMLDialogElement>('dialog')
+      ?.dispatchEvent(new TransitionEvent('transitionend'));
+  });
+
+  const event = await closeEvent;
+  expect(event instanceof Event).to.be.true;
+});

--- a/packages/components/src/drawer.test.methods.ts
+++ b/packages/components/src/drawer.test.methods.ts
@@ -1,0 +1,52 @@
+import './drawer.js';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import Drawer from './drawer.js';
+
+Drawer.shadowRootOptions.mode = 'open';
+
+// NOTE: Due to https://github.com/modernweb-dev/web/issues/2520, we sometimes need
+// to manually dispatch the `transitionend` event in tests.
+
+it('opens the Drawer via the "open()" method and closes it via "close()"', async () => {
+  const drawer = await fixture<Drawer>(
+    html`<cs-drawer>Drawer content</cs-drawer>`,
+  );
+
+  drawer.open();
+
+  await elementUpdated(drawer);
+
+  drawer.shadowRoot
+    ?.querySelector('dialog')
+    ?.dispatchEvent(new TransitionEvent('transitionend'));
+
+  expect(drawer.shadowRoot?.querySelector('dialog')?.open).to.be.true;
+
+  drawer.close();
+
+  drawer.shadowRoot
+    ?.querySelector('dialog')
+    ?.dispatchEvent(new TransitionEvent('transitionend'));
+
+  await elementUpdated(drawer);
+
+  expect(drawer.shadowRoot?.querySelector('dialog')?.open).to.be.false;
+});
+
+it('remains open if "open()" is called an additional time after it is already opened', async () => {
+  const drawer = await fixture<Drawer>(
+    html`<cs-drawer>Drawer content</cs-drawer>`,
+  );
+
+  drawer.open();
+
+  await elementUpdated(drawer);
+
+  expect(drawer.shadowRoot?.querySelector('dialog')?.open).to.be.true;
+
+  drawer.open();
+
+  await elementUpdated(drawer);
+
+  expect(drawer.shadowRoot?.querySelector('dialog')?.open).to.be.true;
+});

--- a/packages/components/src/drawer.ts
+++ b/packages/components/src/drawer.ts
@@ -1,0 +1,126 @@
+import { LitElement, html } from 'lit';
+import { createRef, ref } from 'lit/directives/ref.js';
+import { customElement, state } from 'lit/decorators.js';
+import styles from './drawer.styles.js';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cs-drawer': CsDrawer;
+  }
+}
+
+/**
+ * @cssprop [--cs-drawer-width] - Sets the width of the Drawer when open.
+ *
+ * @event close - Emitted when the Drawer closes.
+ * @event open - Emitted when the Drawer opens.
+ *
+ * @method close - A method on the `cs-drawer` component to close the Drawer programmatically.
+ * @method open - A method on the `cs-drawer` component to open the Drawer programmatically.
+ *
+ * @slot - The content of the Drawer.
+ */
+@customElement('cs-drawer')
+export default class CsDrawer extends LitElement {
+  static override shadowRootOptions: ShadowRootInit = {
+    ...LitElement.shadowRootOptions,
+    mode: 'closed',
+  };
+
+  static override styles = styles;
+
+  close() {
+    if (this.currentState !== 'open') {
+      return;
+    }
+
+    this.#dialogRef?.value?.addEventListener(
+      'transitionend',
+      () => {
+        this.isOpen = false;
+
+        this.#dialogRef?.value?.classList?.remove('dialog-open');
+        this.#dialogRef?.value?.classList?.remove('dialog-closing');
+
+        this.currentState = 'closed';
+
+        this.dispatchEvent(new Event('close', { bubbles: false }));
+
+        document.documentElement.classList.remove('glide-lock-scroll');
+      },
+      { once: true },
+    );
+
+    this.#dialogRef?.value?.classList?.add('dialog-closing');
+    document.documentElement.classList.add('glide-lock-scroll');
+
+    this.currentState = 'closing';
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+
+    if (document.documentElement.classList.contains('glide-lock-scroll')) {
+      document.documentElement.classList.remove('glide-lock-scroll');
+    }
+  }
+
+  open() {
+    if (this.currentState !== 'closed') {
+      return;
+    }
+
+    this.#dialogRef?.value?.addEventListener(
+      'transitionend',
+      () => {
+        this.currentState = 'open';
+
+        // We set `tabindex="-1"` and call focus directly based on
+        // https://www.matuzo.at/blog/2023/focus-dialog/
+        // which came from https://adrianroselli.com/2020/10/dialog-focus-in-screen-readers.html
+        // This ensures our dialog behaves as expected for screenreaders.
+        this.#dialogRef?.value?.focus();
+
+        this.dispatchEvent(new Event('open', { bubbles: false }));
+
+        document.documentElement.classList.remove('glide-lock-scroll');
+      },
+      { once: true },
+    );
+
+    this.#dialogRef?.value?.classList?.add('dialog-open');
+    document.documentElement.classList.add('glide-lock-scroll');
+    this.currentState = 'opening';
+
+    this.isOpen = true;
+  }
+
+  override render() {
+    return html`
+      <dialog
+        tabindex="-1"
+        ?open=${this.isOpen}
+        @keydown=${this.#handleKeyDown}
+        ${ref(this.#dialogRef)}
+      >
+        <slot></slot>
+      </dialog>
+    `;
+  }
+
+  @state()
+  private currentState: 'opening' | 'closing' | 'open' | 'closed' = 'closed';
+
+  @state()
+  private isOpen = false;
+
+  #dialogRef = createRef<HTMLDialogElement>();
+
+  #handleKeyDown(event: KeyboardEvent) {
+    if (event.key !== 'Escape') {
+      return;
+    }
+
+    this.close();
+  }
+}

--- a/packages/components/web-test-runner.config.js
+++ b/packages/components/web-test-runner.config.js
@@ -6,8 +6,7 @@ import chalk from 'chalk';
 export default {
   coverage: true,
   coverageConfig: {
-    // https://github.com/modernweb-dev/web/issues/1400#issuecomment-1513857491
-    include: ['**'],
+    include: ['src/*.ts'],
 
     report: true,
     reportDir: 'dist/coverage',


### PR DESCRIPTION
## 🚀 Description

Adds a generic "Drawer" component.  Most a11y guidance came from https://adrianroselli.com/2020/10/dialog-focus-in-screen-readers.html.

I documented in the code, but we did end up hitting https://github.com/modernweb-dev/web/issues/2520.  Due to that, there are places where we have to dispatch a `transitionend` event manually.  It's important to note that this only happens in the test environment, not in browsers.


## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

**Test 1**
- Navigate to https://glide-core.crowdstrike-ux.workers.dev/add-drawer?path=/docs/drawer--overview
- Click the open button
- Verify the drawer opens
- Click the close button
- Verify the drawer closes

**Test 2**
- Navigate to https://glide-core.crowdstrike-ux.workers.dev/add-drawer?path=/docs/drawer--overview
- Click the open button
- Hit the Escape key on your keybaord
- Verify the drawer closes

**Test 3**
- Navigate to https://glide-core.crowdstrike-ux.workers.dev/add-drawer?path=/docs/drawer--overview
- Enable voiceover
- Click/Press the Enter key on your keyboard when focusing the Open button
- Verify the dialog content is read aloud

The Drawer should take up 100% of the height of the parent container.

## 📸 Images/Videos of Functionality


https://github.com/CrowdStrike/glide-core/assets/8069555/32413e27-a4e4-4ae2-8b7d-f97adb9df84c

<img width="1941" alt="Screenshot 2024-04-03 at 9 10 22 AM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/fc80c180-e8f2-4884-beeb-c85e6bc3249c">



