### PR TITLE
Add missing dependencies to docs

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -4,10 +4,10 @@ This package contains web components built with [Lit](https://lit.dev/).
 
 ## Installation
 
-Add the Glide Core components package as a dependency in your project:
+Add the Glide Core components package and Lit as a dependency in your project:
 
 ```bash
-pnpm i @crowdstrike/glide-core-components
+pnpm i @crowdstrike/glide-core-components lit
 ```
 
 To get the most out of Glide, you'll also want to install the `@crowdstrike/glide-core-styles` package. [Follow the instructions](https://github.com/crowdstrike/glide-core/blob/main/packages/styles/README.md) for that package and then return to the steps below.

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -4,7 +4,7 @@ This package contains the Glide Design System CSS.
 
 ## Installation
 
-Add the Glide Core Style package as a dependency in your project:
+Add the Glide Core Styles package as a dependency in your project:
 
 ```bash
 pnpm i @crowdstrike/glide-core-styles
@@ -17,3 +17,7 @@ In your application, you'll need to import the styles directly:
 ```js
 import '@crowdstrike/glide-core-styles';
 ```
+
+## Add the Nunito Sans Font
+
+The Glide Core Styles CSS has a dependency on the Nunito Sans font. Nunito Sans is available on [Google Fonts](https://fonts.google.com/specimen/Nunito+Sans?query=nunito+sans).


### PR DESCRIPTION
## 🚀 Description

When reading the docs I noticed the following:

- Installing `lit` was missing
- No mention of the dependency on Nunito Sans

This PR adds this information to the appropriate READMEs.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
