### PR TITLE
Update dist's type definitions location

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
     "start:development:typescript": "tsc --declaration --sourceMap --outDir dist --watch",
     "start:production": "npm-run-all --parallel --aggregate-output --print-label start:production:*",
     "start:production:storybook": "storybook build --config-dir .storybook --disable-telemetry --output-dir ./dist/storybook",
-    "start:production:typescript": "node ./esbuild.js && tsc --emitDeclarationOnly --declaration --outDir ./dist --rootDir .",
+    "start:production:typescript": "node ./esbuild.js && tsc --emitDeclarationOnly --declaration --outDir ./dist",
     "start:production:typescript:comment": "https://github.com/evanw/esbuild/issues/95#issuecomment-626069971",
     "format": "per-env",
     "format:development": "prettier . --write && stylelint '**/*.styles.ts' --custom-syntax postcss-lit --fix",


### PR DESCRIPTION
## 🚀 Description

I was messing around with production builds and noticed an issue with where our type definitions get placed.

<img width="543" alt="glide-core-dist-before" src="https://github.com/CrowdStrike/glide-core/assets/8069555/1488f51d-5288-4213-87bc-0cbb44c11fb6">

Based on this image, the types are being placed in `dist/src/*` rather than at `dist/*`.  When we publish, we actually ignore what is in `dist/src/*` at https://github.com/CrowdStrike/glide-core/blob/main/packages/components/package.json#L15.  This means our types don't get included in the `npm` package.

---

Compare the above structure to what we do for _local_ development with `tsc` only.  It's flattened as we'd expect.

<img width="530" alt="glide-core-dist-tsc" src="https://github.com/CrowdStrike/glide-core/assets/8069555/a26b864a-5d61-4a0b-8405-80a7131be1dd">

---

Due to that, I think this is the change we want, so that the type definitions are siblings to the source files.  Alternatively we could update `exports` at https://github.com/CrowdStrike/glide-core/blob/main/packages/components/package.json#L23 to be `./dist/src/*.d.ts`, but I think that may be a bit confusing.  This essentially reverts our command back to [this line](https://github.com/CrowdStrike/glide-core/commit/1879658a9dd0a7af14ec29bfbfb1101fcaa130f3#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cL25) minus the extra deleting (which is now covered via `files`).

<img width="533" alt="glide-core-dist-after" src="https://github.com/CrowdStrike/glide-core/assets/8069555/5d17863c-d516-4665-86cc-2f0534458019">

---

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Green build 🟢 

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
