### PR TITLE
Add icon-button component

### DIFF
--- a/.changeset/four-worms-yawn.md
+++ b/.changeset/four-worms-yawn.md
@@ -1,0 +1,12 @@
+---
+'@crowdstrike/glide-core-styles': minor
+'@crowdstrike/glide-core-components': patch
+---
+
+Updated CSS Variables in `@glide-core-styles` to align with Figma.
+
+- Removed `--cs-icon-display`.
+- Added `--cs-icon-active`, `--cs-icon-primary-hover`, and `--cs-icon-tertiary-disabled`.
+- Updated `--cs-icon-default` and `--cs-icon-primary` color values.
+
+Added the `<cs-icon-button>` component.

--- a/packages/components/src/icon-button.stories.ts
+++ b/packages/components/src/icon-button.stories.ts
@@ -1,0 +1,97 @@
+import './icon-button.js';
+import { html } from 'lit-html';
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+const meta: Meta = {
+  title: 'Icon Button',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'A button element with a default slot for an icon.',
+      },
+    },
+  },
+  render: (arguments_) => html`
+    <cs-icon-button
+      label=${arguments_.label}
+      variant=${arguments_.variant}
+      ?disabled=${arguments_.disabled}
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="2"
+        stroke="currentColor"
+        height="16"
+        width="16"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"
+        />
+      </svg>
+    </cs-icon-button>
+  `,
+  args: {
+    disabled: false,
+    label: 'For screenreaders',
+  },
+  argTypes: {
+    'slot="default"': {
+      control: { type: '' },
+      table: {
+        type: { summary: 'html', detail: 'Put the icon in here.' },
+      },
+      type: { name: 'string', required: true },
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      table: {
+        defaultValue: {
+          summary: 'boolean',
+        },
+        type: { summary: 'boolean' },
+      },
+    },
+    label: {
+      control: { type: 'text' },
+      table: {
+        type: { summary: 'string' },
+      },
+      type: { name: 'string', required: true },
+    },
+    variant: {
+      control: { type: 'radio' },
+      defaultValue: 'primary',
+      options: ['primary', 'secondary', 'tertiary'],
+      table: {
+        defaultValue: {
+          summary: '"primary"',
+        },
+        type: { summary: '"primary" | "secondary" | "tertiary"' },
+      },
+    },
+  },
+};
+
+export default meta;
+
+export const Primary: StoryObj = {
+  args: {
+    variant: 'primary',
+  },
+};
+
+export const Secondary: StoryObj = {
+  args: {
+    variant: 'secondary',
+  },
+};
+
+export const Tertiary: StoryObj = {
+  args: {
+    variant: 'tertiary',
+  },
+};

--- a/packages/components/src/icon-button.styles.ts
+++ b/packages/components/src/icon-button.styles.ts
@@ -1,0 +1,110 @@
+import { css } from 'lit';
+import { focusOutline } from './styles.js';
+
+export default [
+  css`
+    :host {
+      /* Contains elements with "padding" and "width". Inline by default. */
+      display: inline-block;
+    }
+
+    .button {
+      align-items: center;
+      block-size: 1.625rem;
+      border-color: transparent;
+      border-radius: var(--cs-spacing-xs);
+      border-style: solid;
+      border-width: 1px;
+      cursor: pointer;
+      display: inline-flex;
+      inline-size: 1.625rem;
+      justify-content: center;
+      padding-inline: 0;
+      transition-duration: 150ms;
+      transition-property: color, background-color, border-color, fill, stroke;
+      transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+
+      &:focus {
+        outline: none;
+      }
+
+      &:focus-visible {
+        ${focusOutline};
+        outline-offset: 3px;
+      }
+
+      &:disabled {
+        cursor: default;
+        opacity: 1;
+      }
+
+      &.primary {
+        background-color: var(--cs-surface-primary);
+        border-color: transparent;
+        color: var(--cs-icon-selected);
+
+        &:disabled {
+          background-color: var(--cs-surface-base-gray-light);
+          border-color: transparent;
+          color: var(--cs-icon-tertiary-disabled);
+        }
+
+        &:not(:disabled):active {
+          background-color: var(--cs-surface-selected);
+          border-color: transparent;
+          color: var(--cs-icon-selected);
+        }
+
+        &:not(:active):hover:not(:disabled) {
+          background-color: var(--cs-surface-hover);
+          border-color: transparent;
+          box-shadow: var(--cs-glow-sm);
+          color: var(--cs-icon-primary);
+        }
+      }
+
+      &.secondary {
+        background-color: var(--cs-surface-page);
+        border-color: var(--cs-border-primary);
+        color: var(--cs-icon-primary);
+
+        &:disabled {
+          background-color: transparent;
+          border-color: var(--cs-border-base-light);
+          color: var(--cs-icon-tertiary-disabled);
+        }
+
+        &:not(:disabled):active {
+          background-color: var(--cs-surface-selected);
+          border-color: transparent;
+          color: var(--cs-icon-selected);
+        }
+
+        &:not(:active):hover:not(:disabled) {
+          background-color: var(--cs-surface-hover);
+          border-color: transparent;
+          box-shadow: var(--cs-glow-sm);
+          color: var(--cs-icon-primary);
+        }
+      }
+
+      &.tertiary {
+        background-color: transparent;
+        border-color: transparent;
+        color: var(--cs-icon-default);
+
+        &:disabled {
+          color: var(--cs-icon-tertiary-disabled);
+        }
+
+        &:not(:disabled):active {
+          color: var(--cs-icon-active);
+        }
+
+        &:not(:active):hover:not(:disabled) {
+          color: var(--cs-icon-primary-hover);
+        }
+      }
+    }
+  `,
+];

--- a/packages/components/src/icon-button.test.ts
+++ b/packages/components/src/icon-button.test.ts
@@ -1,0 +1,112 @@
+import './icon-button.js';
+import { expect, fixture, html } from '@open-wc/testing';
+import IconButton from './icon-button.js';
+
+IconButton.shadowRootOptions.mode = 'open';
+
+const icon = html`<svg
+  width="16"
+  height="16"
+  stroke="currentColor"
+  fill="none"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  stroke-width="2"
+  viewBox="0 0 24 24"
+  aria-hidden="true"
+>
+  <path d="M16.51 9.873l-4.459 4.31-4.458-4.31"></path>
+</svg>`;
+
+it('registers', async () => {
+  expect(window.customElements.get('cs-icon-button')).to.equal(IconButton);
+});
+
+it('is accessible', async () => {
+  const element = await fixture<IconButton>(
+    html`<cs-icon-button label="test-icon-button">${icon}</cs-icon-button>`,
+  );
+
+  await expect(element).to.be.accessible();
+});
+
+it('has defaults', async () => {
+  const element = await fixture<IconButton>(
+    html`<cs-icon-button label="test-icon-button">${icon}</cs-icon-button>`,
+  );
+
+  expect(element.shadowRoot?.querySelector('button')?.type).to.equal('button');
+  expect(element.shadowRoot?.querySelector('button')?.disabled).to.equal(false);
+
+  expect([
+    ...element.shadowRoot!.querySelector('button')!.classList,
+  ]).to.deep.equal(['button', 'primary']);
+});
+
+it('uses the provided "label" for the aria-label', async () => {
+  const element = await fixture<IconButton>(
+    html`<cs-icon-button label="test-icon-button">${icon}</cs-icon-button>`,
+  );
+
+  expect(
+    element.shadowRoot?.querySelector('button')?.getAttribute('aria-label'),
+  ).to.equal('test-icon-button');
+});
+
+it('renders a default slot', async () => {
+  const element = await fixture<IconButton>(
+    html`<cs-icon-button label="test-icon-button"
+      ><span data-content>Inner content</span></cs-icon-button
+    >`,
+  );
+
+  expect(element.querySelector('[data-content]')).to.be.ok;
+  expect(element.querySelector('[data-content]')).to.be.visible;
+});
+
+it('renders a primary variant', async () => {
+  const element = await fixture<IconButton>(
+    html`<cs-icon-button label="test-icon-button" variant="primary"
+      >${icon}</cs-icon-button
+    >`,
+  );
+
+  expect([
+    ...element.shadowRoot!.querySelector('button')!.classList,
+  ]).to.deep.equal(['button', 'primary']);
+});
+
+it('renders a secondary variant', async () => {
+  const element = await fixture<IconButton>(
+    html`<cs-icon-button label="test-icon-button" variant="secondary"
+      >${icon}</cs-icon-button
+    >`,
+  );
+
+  expect([
+    ...element.shadowRoot!.querySelector('button')!.classList,
+  ]).to.deep.equal(['button', 'secondary']);
+});
+
+it('renders a tertiary variant', async () => {
+  const element = await fixture<IconButton>(
+    html`<cs-icon-button label="test-icon-button" variant="tertiary"
+      >${icon}</cs-icon-button
+    >`,
+  );
+
+  expect([
+    ...element.shadowRoot!.querySelector('button')!.classList,
+  ]).to.deep.equal(['button', 'tertiary']);
+});
+
+it('sets the disabled attribute', async () => {
+  const element = await fixture<IconButton>(
+    html`<cs-icon-button label="test-icon-button" disabled
+      >${icon}</cs-icon-button
+    >`,
+  );
+
+  expect(element.disabled).to.equal(true);
+  expect(element.shadowRoot?.querySelector('button')?.disabled).to.equal(true);
+});

--- a/packages/components/src/icon-button.ts
+++ b/packages/components/src/icon-button.ts
@@ -1,0 +1,56 @@
+import { LitElement, html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { customElement, property } from 'lit/decorators.js';
+import styles from './icon-button.styles.js';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cs-icon-button': CsIconButton;
+  }
+}
+
+/**
+ * @slot - Reserved for the icon to display inside of the button.
+ */
+@customElement('cs-icon-button')
+export default class CsIconButton extends LitElement {
+  static override shadowRootOptions: ShadowRootInit = {
+    ...LitElement.shadowRootOptions,
+    mode: 'closed',
+  };
+
+  static override styles = styles;
+
+  @property({ reflect: true })
+  override ariaExpanded: string | null = null;
+
+  @property({ reflect: true })
+  override ariaHasPopup: string | null = null;
+
+  @property({ type: Boolean, reflect: true }) disabled = false;
+
+  /** Text read aloud for screenreaders. For accessibility, this should always be provided. */
+  @property()
+  label: string = '';
+
+  @property({ attribute: 'variant', reflect: true })
+  variant: 'primary' | 'secondary' | 'tertiary' = 'primary';
+
+  override render() {
+    return html`
+      <button
+        aria-label=${this.label}
+        class=${classMap({
+          button: true,
+          primary: this.variant === 'primary',
+          secondary: this.variant === 'secondary',
+          tertiary: this.variant === 'tertiary',
+        })}
+        type="button"
+        ?disabled=${this.disabled}
+      >
+        <slot></slot>
+      </button>
+    `;
+  }
+}

--- a/packages/styles/index.css
+++ b/packages/styles/index.css
@@ -34,10 +34,12 @@
   --cs-heading-xxxs-font-variant: normal;
   --cs-heading-xxxs-font-weight: var(--cs-font-weight-bold);
   --cs-heading-xxxs-line-height: 1.7;
-  --cs-icon-default: #000000;
-  --cs-icon-display: #212121;
-  --cs-icon-primary: #00000080;
+  --cs-icon-active: #0073e6;
+  --cs-icon-default: #212121;
+  --cs-icon-primary: #054fb9;
+  --cs-icon-primary-hover: #0461cf;
   --cs-icon-selected: #ffffff;
+  --cs-icon-tertiary-disabled: #c9c9c9;
   --cs-shadow-lg: 0px 4px 14px 0px #00000040;
   --cs-shadow-sm: 0px 2.275px 8.342px 0px rgba(181, 181, 181, 0.25);
   --cs-shadow-xl: 0px 4px 60px 0px #adadad;


### PR DESCRIPTION
## 🚀 Description

Adds the `<cs-icon-button` component.

## 📋 Checklist

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

**Test 1**
- Visit https://glide-core.crowdstrike-ux.workers.dev/add-icon-button?path=/docs/icon-button--overview
- Verify the primary, secondary, and tertiary variants
- Verify each variant can be disabled

**Test 2**
- Visit https://glide-core.crowdstrike-ux.workers.dev/add-icon-button?path=/docs/icon-button--overview
- With voiceover enabled, ensure the `label` is read aloud to screenreaders

## 📸 Images/Videos of Functionality

<img width="1097" alt="Screenshot 2024-04-05 at 10 28 03 AM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/5ecea314-438a-4e8e-a701-b65f014563ea">