### PR TITLE
Add a lint rule for prefixing classes with "Cs"

### DIFF
--- a/packages/components/eslint.config.js
+++ b/packages/components/eslint.config.js
@@ -29,6 +29,8 @@ export default [
     rules: {
       '@crowdstrike/glide-core-eslint-plugin/no-cs-prefixed-event-name':
         'error',
+      '@crowdstrike/glide-core-eslint-plugin/prefixed-lit-element-class-declaration':
+        'error',
       '@stylistic/lines-between-class-members': [
         'error',
         'always',

--- a/packages/eslint-plugin/eslint.config.js
+++ b/packages/eslint-plugin/eslint.config.js
@@ -13,7 +13,11 @@ export default [
   ...compat.plugins('sort-imports-es6-autofix'),
   eslintConfigPrettier,
   {
+    ignores: ['dist'],
+  },
+  {
     rules: {
+      'unicorn/no-null': 'off',
       'prefer-const': 'error',
       'sort-imports-es6-autofix/sort-imports-es6': [
         2,

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,7 +1,9 @@
 import { noPrefixedEventName } from './rules/no-cs-prefixed-event-name.js';
+import { prefixedClassDeclaration } from './rules/prefixed-lit-element-class-declaration.js';
 
 const rules = {
   'no-cs-prefixed-event-name': noPrefixedEventName,
+  'prefixed-lit-element-class-declaration': prefixedClassDeclaration,
 };
 
 export default { rules };

--- a/packages/eslint-plugin/src/rules/prefixed-lit-element-class-declaration.spec.ts
+++ b/packages/eslint-plugin/src/rules/prefixed-lit-element-class-declaration.spec.ts
@@ -1,0 +1,47 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { prefixedClassDeclaration } from './prefixed-lit-element-class-declaration.js';
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run(
+  'prefixed-lit-element-class-declaration',
+  prefixedClassDeclaration,
+  {
+    valid: [
+      {
+        code: 'export default class CsAccordion extends LitElement {}',
+      },
+      {
+        code: 'export default class NonLitElement {}',
+      },
+      {
+        code: 'class CsAccordion extends LitElement {}',
+      },
+      {
+        code: 'class NonLitElement {}',
+      },
+    ],
+    invalid: [
+      {
+        code: 'export default class Accordion extends LitElement {}',
+        output: 'export default class CsAccordion extends LitElement {}',
+        errors: [
+          {
+            messageId: 'addPrefix',
+          },
+        ],
+      },
+      {
+        code: 'class Component extends LitElement {}',
+        output: 'class CsComponent extends LitElement {}',
+        errors: [
+          {
+            messageId: 'addPrefix',
+          },
+        ],
+      },
+    ],
+  },
+);

--- a/packages/eslint-plugin/src/rules/prefixed-lit-element-class-declaration.ts
+++ b/packages/eslint-plugin/src/rules/prefixed-lit-element-class-declaration.ts
@@ -1,0 +1,54 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/CrowdStrike/glide-core/blob/main/packages/eslint-plugin/src/rules/${name}.ts`,
+);
+
+export const prefixedClassDeclaration = createRule({
+  name: 'prefixed-lit-element-class-declaration',
+  meta: {
+    docs: {
+      description:
+        'Ensures all web components that extend a LitElement are prefixed with "Cs".',
+      recommended: 'recommended',
+    },
+    type: 'suggestion',
+    messages: {
+      addPrefix:
+        'Prefer elements extending LitElement to be prefixed with "Cs".',
+    },
+    schema: [],
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create: (context) => {
+    return {
+      ClassDeclaration(node) {
+        if (
+          node.id?.type === 'Identifier' &&
+          node.superClass?.type === 'Identifier' &&
+          node.superClass?.name === 'LitElement' &&
+          !node.id?.name?.startsWith('Cs')
+        ) {
+          context.report({
+            node,
+            messageId: 'addPrefix',
+            fix: function (fixer) {
+              const nodeId = node.id;
+
+              if (!nodeId) {
+                console.error(
+                  `Error attempting to lint fix: "${nodeId}". Please report this error to @crowdstrike/glide-core.`,
+                );
+                return null;
+              }
+
+              return fixer.replaceText(nodeId, `Cs${node.id?.name}`);
+            },
+          });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
## 🚀 Description

Adds a lint rule so that we consistently name class declarations the same. Downstream of https://github.com/CrowdStrike/glide-core/pull/37, please review that first if you haven't already.

I'd also like to lint imports in test files, but I'll do that in a separate PR and use the existing files to use as a test bed for `lint --fix`

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

<img width="1126" alt="Screenshot 2024-04-15 at 2 15 44 PM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/f2d1ca33-d032-4bec-9f60-03b5210d8b25">
