### PR TITLE
Add owSlotType

### DIFF
--- a/packages/components/src/button.ts
+++ b/packages/components/src/button.ts
@@ -112,12 +112,14 @@ export default class CsButton extends LitElement {
 
   #onPrefixSlotChange() {
     const assignedNodes = this.#prefixSlotElement.value?.assignedNodes();
+
     this.hasPrefixSlot =
       assignedNodes && assignedNodes.length > 0 ? true : false;
   }
 
   #onSuffixSlotChange() {
     const assignedNodes = this.#suffixSlotElement.value?.assignedNodes();
+
     this.hasSuffixSlot =
       assignedNodes && assignedNodes.length > 0 ? true : false;
   }

--- a/packages/components/src/library/ow.shim.ts
+++ b/packages/components/src/library/ow.shim.ts
@@ -12,5 +12,6 @@ const shim = new Proxy(() => {}, {
 }) as unknown as typeof Ow;
 
 export const owSlot = shim;
+export const owSlotType = shim;
 
 export default shim;

--- a/packages/components/src/library/ow.test.ts
+++ b/packages/components/src/library/ow.test.ts
@@ -1,7 +1,7 @@
 import { LitElement } from 'lit';
 import { assert, expect, fixture, html } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
-import { owSlot } from './ow.js';
+import { owSlot, owSlotType } from './ow.js';
 
 @customElement('cs-slot')
 export default class CsSlot extends LitElement {
@@ -30,7 +30,7 @@ it('throws when a slot lacks a specific node', async () => {
 
   assert(slot);
 
-  expect(() => owSlot(slot, [HTMLButtonElement])).to.throw();
+  expect(() => owSlotType(slot, [HTMLButtonElement])).to.throw();
 });
 
 it('does not throw when a slot has a node', async () => {
@@ -53,5 +53,14 @@ it('does not throw when a slot has a specific node', async () => {
 
   assert(slot);
 
-  expect(() => owSlot(slot, [Text])).to.not.throw();
+  expect(() => owSlotType(slot, [Text])).to.not.throw();
+});
+
+it('does not throw when a slot has no nodes', async () => {
+  const component = await fixture<CsSlot>(html`<cs-slot></cs-slot>`);
+  const slot = component.shadowRoot?.querySelector('slot');
+
+  assert(slot);
+
+  expect(() => owSlotType(slot, [HTMLButtonElement])).to.not.throw();
 });

--- a/packages/components/src/library/ow.ts
+++ b/packages/components/src/library/ow.ts
@@ -1,16 +1,11 @@
 import ow from 'ow';
 
 /**
- * @description Asserts that a slot has at least one slotted node. Optionally asserts
- * that the slotted node is a certain type.
+ * @description Asserts that a slot has at least one slotted node.
  *
  * @param slot - The slot to assert against.
- * @param slotted - An optional array of constructors. Slotted nodes must extend one of them.
  */
-export function owSlot(
-  slot?: HTMLSlotElement,
-  slotted: (typeof Element | typeof Text)[] = [],
-) {
+export function owSlot(slot?: HTMLSlotElement) {
   ow(
     slot,
     ow.object.is((object) => object instanceof HTMLSlotElement),
@@ -26,6 +21,26 @@ export function owSlot(
           : 'Expected a default slot.',
       ),
   );
+}
+
+/**
+ * @description Asserts that slotted nodes are a certain type.
+ *
+ * @param slot - The slot to assert against.
+ * @param slotted - An array of constructors. Slotted nodes must extend one of them.
+ */
+export function owSlotType(
+  slot?: HTMLSlotElement,
+  slotted: (typeof Element | typeof Text)[] = [],
+) {
+  ow(
+    slot,
+    ow.object.is((object) => object instanceof HTMLSlotElement),
+  );
+
+  if (slot.assignedNodes().length === 0) {
+    return;
+  }
 
   if (slotted.length > 0) {
     const nodes = slot.assignedNodes().filter((node) => {

--- a/packages/components/src/menu.ts
+++ b/packages/components/src/menu.ts
@@ -3,7 +3,7 @@ import { autoUpdate, computePosition, flip, offset } from '@floating-ui/dom';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
-import { owSlot } from './library/ow.js';
+import { owSlot, owSlotType } from './library/ow.js';
 import CsMenuButton from './menu-button.js';
 import CsMenuLink from './menu-link.js';
 import styles from './menu.styles.js';
@@ -73,7 +73,8 @@ export default class CsMenu extends LitElement {
   }
 
   override firstUpdated() {
-    owSlot(this.#defaultSlotElementRef.value, [CsMenuButton, CsMenuLink]);
+    owSlot(this.#defaultSlotElementRef.value);
+    owSlotType(this.#defaultSlotElementRef.value, [CsMenuButton, CsMenuLink]);
     owSlot(this.#targetSlotElementRef.value);
 
     const firstOption = this.#optionElements.at(0);


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

I realized after merging https://github.com/CrowdStrike/glide-core/pull/34 that developers may want to separately assert whether a slot has nodes and whether its nodes are a certain type. 

This would be a case where a component has an optional slot that only accepts certain types of slotted content. To accommodate the case, I've broken down `owSlot` into `owSlot` and `owSlotType`.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
