### PR TITLE
Update stories using the select type to the radio type

### DIFF
--- a/packages/components/src/button.stories.ts
+++ b/packages/components/src/button.stories.ts
@@ -27,7 +27,7 @@ const meta: Meta = {
   },
   argTypes: {
     variant: {
-      control: { type: 'select' },
+      control: { type: 'radio' },
       options: ['primary', 'secondary', 'tertiary'],
       table: {
         defaultValue: {

--- a/packages/components/src/dropdown.stories.ts
+++ b/packages/components/src/dropdown.stories.ts
@@ -97,7 +97,7 @@ const meta: Meta = {
       },
     },
     size: {
-      control: { type: 'select' },
+      control: { type: 'radio' },
       options: ['small', 'large'],
       table: {
         defaultValue: { summary: '"large"' },

--- a/packages/components/src/menu.stories.ts
+++ b/packages/components/src/menu.stories.ts
@@ -47,7 +47,7 @@ const meta: Meta = {
       },
     },
     size: {
-      control: { type: 'select' },
+      control: { type: 'radio' },
       options: ['small', 'large'],
       table: {
         defaultValue: { summary: '"large"' },

--- a/packages/components/src/tooltip.stories.ts
+++ b/packages/components/src/tooltip.stories.ts
@@ -35,7 +35,7 @@ const meta: Meta = {
       type: { name: 'string', required: true },
     },
     placement: {
-      control: { type: 'select' },
+      control: { type: 'radio' },
       options: ['bottom', 'left', 'right', 'top'],
       table: {
         defaultValue: { summary: '"bottom"' },


### PR DESCRIPTION
## 🚀 Description

Another quick pre-sprint demo fix.  I noticed that icon button uses a radio for variant, so figured we should be consistent. We have a task to write a lint rule around this, but this is a quick one-liner I wanted to get in before demos.

| First Header  | Second Header |
| ------------- | ------------- |
| <img width="1031" alt="Screenshot 2024-04-25 at 8 50 22 AM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/a57a7d46-316a-484b-b29e-2dc8c953ba59"> | <img width="1024" alt="Screenshot 2024-04-25 at 8 50 08 AM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/da83acaa-0588-4ef5-a131-c6a6c2201025">  |
| `variant` as a select 👎   | `variant` as a radio 👍   |

I updated the other stories as well for consistency.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

See above

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
