### PR TITLE
Deploy on release instead of "main" merge

### DIFF
--- a/.github/workflows/on-merge-branch-changeset-release-main.yml
+++ b/.github/workflows/on-merge-branch-changeset-release-main.yml
@@ -1,9 +1,11 @@
-name: On Push Branch "Main"
+name: On Merge Branch "changeset-release/main"
 
 on:
-  push:
+  pull_request:
     branches:
-      - main
+      - changeset-release/main
+    types:
+      - closed
 
 env:
   CI: true
@@ -23,9 +25,9 @@ jobs:
   # https://github.com/changesets/action
   release:
     name: Release
+    if: github.event.pull_request.merged == true
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     needs:
       - install_dependencies
 
@@ -33,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm
       - run: NODE_ENV=production pnpm --filter "@crowdstrike/glide-core-components" start
-      - name: Create Release Pull Request or Publish to npm
+      - name: Create Release Pull Request or Publish to NPM
         id: changesets
         uses: changesets/action@v1
         with:
@@ -60,10 +62,12 @@ jobs:
 
   deploy:
     name: Deploy
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     needs:
       - install_dependencies
       - build
+      - release
     steps:
       - uses: actions/download-artifact@v4
       - name: Install AWS CLI


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

We currently deploy `main` every time we merge into it, while we publish manually and intermittently. This creates a situation we our deployed Storybook instance may not exactly represent our published packages. This PR attempts to correct that by deploying `main` only on publish.

It's a tricky one to test without a merge. So I'm open to ideas. I'm also happy to quickly follow up with another PR should this one not behave as expected.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

A short prayer should be sufficient.

## 📸 Images/Videos of Functionality

N/A

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
