### PR TITLE
Restrict exports

### DIFF
--- a/.changeset/sour-kids-decide.md
+++ b/.changeset/sour-kids-decide.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': minor
+---
+
+Disallow importing from `library/` and `styles/`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@
 - I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
 - I have scheduled a Design Review for these changes, if one is required.
 - I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.
+- I have added the component to `exports` in `packages/components/package.json` (if applicable).
 
 ## 🔬 How to Test
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -18,12 +18,6 @@
     "!dist/*.test.js",
     "!dist/*.stories.js"
   ],
-  "exports": {
-    "./*": {
-      "import": "./dist/*",
-      "types": "./dist/*.d.ts"
-    }
-  },
   "scripts": {
     "start": "per-env",
     "start:development": "storybook dev --config-dir .storybook --disable-telemetry --port 6006",
@@ -47,6 +41,92 @@
     "test:development:serve": "npx http-server dist/coverage/lcov-report --silent",
     "test:development:web-test-runner": "web-test-runner --watch",
     "test:production": "web-test-runner"
+  },
+  "engines": {
+    "node": ">= 20",
+    "pnpm": ">= 8"
+  },
+  "volta": {
+    "node": "20.12.2",
+    "pnpm": "9.0.6"
+  },
+  "exports": {
+    "./accordion.js": {
+      "import": "./dist/accordion.js",
+      "types": "./dist/accordion.d.ts"
+    },
+    "./button-group.js": {
+      "import": "./dist/button-group.js",
+      "types": "./dist/button-group.d.ts"
+    },
+    "./button-group.button.js": {
+      "import": "./dist/button-group.button.js",
+      "types": "./dist/button-group.button.d.ts"
+    },
+    "./button.js": {
+      "import": "./dist/button.js",
+      "types": "./dist/button.d.ts"
+    },
+    "./checkbox.js": {
+      "import": "./dist/checkbox.js",
+      "types": "./dist/checkbox.d.ts"
+    },
+    "./drawer.js": {
+      "import": "./dist/drawer.js",
+      "types": "./dist/drawer.d.ts"
+    },
+    "./dropdown.js": {
+      "import": "./dist/dropdown.js",
+      "types": "./dist/dropdown.d.ts"
+    },
+    "./dropdown.option.js": {
+      "import": "./dist/dropdown.option.js",
+      "types": "./dist/dropdown.option.d.ts"
+    },
+    "./icon-button.js": {
+      "import": "./dist/icon-button.js",
+      "types": "./dist/icon-button.d.ts"
+    },
+    "./menu.js": {
+      "import": "./dist/menu.js",
+      "types": "./dist/menu.d.ts"
+    },
+    "./menu.button.js": {
+      "import": "./dist/menu.button.js",
+      "types": "./dist/menu.button.d.ts"
+    },
+    "./menu.link.js": {
+      "import": "./dist/menu.link.js",
+      "types": "./dist/menu.link.d.ts"
+    },
+    "./tab.js": {
+      "import": "./dist/tab.js",
+      "types": "./dist/tab.d.ts"
+    },
+    "./tab.group.js": {
+      "import": "./dist/tab.group.js",
+      "types": "./dist/tab.group.d.ts"
+    },
+    "./tab.panel.js": {
+      "import": "./dist/tab.panel.js",
+      "types": "./dist/tab.panel.d.ts"
+    },
+    "./toggle.js": {
+      "import": "./dist/toggle.js",
+      "types": "./dist/toggle.d.ts"
+    },
+    "./tooltip.js": {
+      "import": "./dist/tooltip.js",
+      "types": "./dist/tooltip.d.ts"
+    },
+    "./tree.js": {
+      "import": "./dist/tree.js",
+      "types": "./dist/tree.d.ts"
+    },
+    "./tree-item.js": {
+      "import": "./dist/tree-item.js",
+      "types": "./dist/tree-item.d.ts"
+    }
   },
   "dependencies": {
     "@floating-ui/dom": "^1.5.4",
@@ -110,13 +190,5 @@
   },
   "peerDependencies": {
     "lit": "^3.1.0"
-  },
-  "engines": {
-    "node": ">= 20",
-    "pnpm": ">= 8"
-  },
-  "volta": {
-    "node": "20.12.2",
-    "pnpm": "9.0.6"
   }
 }

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -9,10 +9,14 @@
     "url": "https://github.com/CrowdStrike/glide-core.git",
     "directory": "packages/styles"
   },
-  "main": "./index.css",
   "files": [
     "index.css"
   ],
+  "exports": {
+    ".": {
+      "import": "./index.css"
+    }
+  },
   "type": "module",
   "scripts": {
     "format": "per-env",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
 packages:
   - 'packages/*'
-  - 'storybook'


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

I spent a few minutes looking into replacing Esbuild with Rollup before I realized that not only will creating a bundle per component require inline Ow, which is 10 KB, it will require inlining Floating UI and any other dependencies we bring in. 
This would include internal dependencies. Any component, for example that imports Tooltip would have a copy of Tooltip in its bundle. All of this together would blow up the size of components by quite a bit.

A better solution, perhaps, is to use the `exports` field of `package.json` to selectively expose only what we want to. Manifests aren't great; they require constant upkeep. But `exports` seems to be the way to go if we want to stop consumers from importing internal files.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

I ran `pnpm link` and imported `@crowdstrike/glide-core-components` into a dummy project. I then imported a few components into that project and checked that it compiled without error. It's a lot. But you're welcome to do the same. Another set of eyes of this certainly wouldn't hurt.

## 📸 Images/Videos of Functionality

N/A