### PR TITLE
Remove label attribute from cs-menu

### DIFF
--- a/packages/components/src/menu.stories.ts
+++ b/packages/components/src/menu.stories.ts
@@ -63,11 +63,7 @@ const meta: Meta = {
   render(arguments_) {
     /* eslint-disable unicorn/explicit-length-check */
     return html`<div style="height: 8rem;">
-      <cs-menu
-        label=${arguments_.label || nothing}
-        size=${arguments_.size || nothing}
-        ?open=${arguments_.open}
-      >
+      <cs-menu size=${arguments_.size || nothing} ?open=${arguments_.open}>
         <cs-menu-link label="One" url="/one"> </cs-menu-link>
         <cs-menu-link label="Two" url="/two"> </cs-menu-link>
         <!--
@@ -90,11 +86,7 @@ export const MenuWithIcon: StoryObj = {
   name: 'Menu (With Icon)',
   render(arguments_) {
     return html`<div style="height: 10rem;">
-      <cs-menu
-        label=${arguments_.label || nothing}
-        size=${arguments_.size || nothing}
-        ?open=${arguments_.open}
-      >
+      <cs-menu size=${arguments_.size || nothing} ?open=${arguments_.open}>
         <cs-menu-link label="Edit" url="/edit">
           <cs-example-icon slot="icon" name="pencil"></cs-example-icon>
         </cs-menu-link>

--- a/packages/components/src/menu.test.basics.ts
+++ b/packages/components/src/menu.test.basics.ts
@@ -15,14 +15,11 @@ it('has defaults', async () => {
   // idea is that this test shouldn't fail to typecheck if these templates are
   // eventually typechecked, which means supplying all required attributes and slots.
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
   );
-
-  expect(menu.getAttribute('label')).to.equal('Menu');
-  expect(menu.label).to.equal('Menu');
 
   expect(menu.getAttribute('size')).to.equal('large');
   expect(menu.size).to.equal('large');
@@ -39,21 +36,9 @@ it('is accessible', async () => {
   await expect(menu).to.be.accessible();
 });
 
-it('can have a label', async () => {
-  const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
-      <button slot="target">Target</button>
-      <cs-menu-link label="Link"></cs-menu-link>
-    </cs-menu>`,
-  );
-
-  expect(menu.getAttribute('label')).to.equal('Menu');
-  expect(menu.label).to.equal('Menu');
-});
-
 it('can have a default slot', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -68,7 +53,7 @@ it('can have a default slot', async () => {
 
 it('can have a target slot', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -115,7 +100,7 @@ it('throws if it does not have a "target" slot', async () => {
 
 it('sets accessibility attributes on the target', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,

--- a/packages/components/src/menu.test.focus.ts
+++ b/packages/components/src/menu.test.focus.ts
@@ -5,7 +5,7 @@ import type CsMenu from './menu.js';
 
 it('focuses the target on `focus()`', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -20,7 +20,7 @@ it('focuses the target on `focus()`', async () => {
 
 it('focuses the active option on open via click', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -37,7 +37,7 @@ it('focuses the active option on open via click', async () => {
 
 it('focuses the active option on open via Space', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -56,7 +56,7 @@ it('focuses the active option on open via Space', async () => {
 
 it('focuses the target on close via click', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu" open>
+    html`<cs-menu open>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -69,7 +69,7 @@ it('focuses the target on close via click', async () => {
 
 it('focuses the target on close via Escape', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu" open>
+    html`<cs-menu open>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -85,7 +85,7 @@ it('focuses the target on close via Escape', async () => {
 
 it('focuses the target when an option is selected via click', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu" open>
+    html`<cs-menu open>
       <button slot="target">Target</button>
 
       <cs-menu-link label="Link"></cs-menu-link>
@@ -103,7 +103,7 @@ it('focuses the target when an option is selected via click', async () => {
 
 it('focuses the target when an option is selected via Enter', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -124,7 +124,7 @@ it('focuses the target when an option is selected via Enter', async () => {
 
 it('focuses the target when an option is selected via Space', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,

--- a/packages/components/src/menu.test.interactions.ts
+++ b/packages/components/src/menu.test.interactions.ts
@@ -6,7 +6,7 @@ import type CsMenu from './menu.js';
 
 it('opens when clicked', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -18,7 +18,7 @@ it('opens when clicked', async () => {
 
 it('opens on Enter', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -32,7 +32,7 @@ it('opens on Enter', async () => {
 
 it('opens on ArrowUp', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -46,7 +46,7 @@ it('opens on ArrowUp', async () => {
 
 it('opens on ArrowDown', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -60,7 +60,7 @@ it('opens on ArrowDown', async () => {
 
 it('opens on Space', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -77,7 +77,7 @@ it('opens when opened programmatically via the click handler of another element'
   const div = document.createElement('div');
 
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -94,7 +94,7 @@ it('opens when opened programmatically via the click handler of another element'
 
 it('closes when clicked', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu" open>
+    html`<cs-menu open>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -106,7 +106,7 @@ it('closes when clicked', async () => {
 
 it('closes when something outside of it is clicked', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -119,7 +119,7 @@ it('closes when something outside of it is clicked', async () => {
 
 it('closes on Escape when the button has focus', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu" open>
+    html`<cs-menu open>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -133,7 +133,7 @@ it('closes on Escape when the button has focus', async () => {
 
 it('closes on Escape when an option has focus', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -150,7 +150,7 @@ it('closes on Escape when an option has focus', async () => {
 
 it('closes when an option is selected via click', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -165,7 +165,7 @@ it('closes when an option is selected via click', async () => {
 
 it('closes when an option is selected via Enter', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -182,7 +182,7 @@ it('closes when an option is selected via Enter', async () => {
 
 it('closes when an option is selected via Space', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -199,7 +199,7 @@ it('closes when an option is selected via Space', async () => {
 
 it('activates an option on "mouseover"', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu" open>
+    <cs-menu open>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -215,7 +215,7 @@ it('activates an option on "mouseover"', async () => {
 
 it('activates a menu button option on "mouseover"', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu" open>
+    <cs-menu open>
       <button slot="target">Target</button>
       <cs-menu-button label="One"></cs-menu-button>
       <cs-menu-button label="Two"></cs-menu-button>
@@ -231,7 +231,7 @@ it('activates a menu button option on "mouseover"', async () => {
 
 it('activates the first option by default', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu" open>
+    <cs-menu open>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -246,7 +246,7 @@ it('activates the first option by default', async () => {
 
 it('activates the first menu-button option by default', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu" open>
+    <cs-menu open>
       <button slot="target">Target</button>
       <cs-menu-button label="One"></cs-menu-button>
       <cs-menu-button label="Two"></cs-menu-button>
@@ -261,7 +261,7 @@ it('activates the first menu-button option by default', async () => {
 
 it('activates the next option on ArrowDown', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu">
+    <cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -283,7 +283,7 @@ it('activates the next option on ArrowDown', async () => {
 
 it('activates the previous option on ArrowUp', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu">
+    <cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -303,7 +303,7 @@ it('activates the previous option on ArrowUp', async () => {
 
 it('activates the first option on Home', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu">
+    <cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -323,7 +323,7 @@ it('activates the first option on Home', async () => {
 
 it('activates the first option on PageUp', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu">
+    <cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -343,7 +343,7 @@ it('activates the first option on PageUp', async () => {
 
 it('activates the first option on ArrowUp + Meta', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu">
+    <cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -365,7 +365,7 @@ it('activates the first option on ArrowUp + Meta', async () => {
 
 it('activates the last option on End', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu">
+    <cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -385,7 +385,7 @@ it('activates the last option on End', async () => {
 
 it('activates the last option on PageDown', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu">
+    <cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -405,7 +405,7 @@ it('activates the last option on PageDown', async () => {
 
 it('activates the last option on Meta + ArrowDown', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu">
+    <cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -427,7 +427,7 @@ it('activates the last option on Meta + ArrowDown', async () => {
 
 it('sets `aria-expanded` on open', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu">
+    html`<cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -441,7 +441,7 @@ it('sets `aria-expanded` on open', async () => {
 
 it('sets `aria-expanded` on close', async () => {
   const menu = await fixture<CsMenu>(
-    html`<cs-menu label="Menu" open>
+    html`<cs-menu open>
       <button slot="target">Target</button>
       <cs-menu-link label="Link"></cs-menu-link>
     </cs-menu>`,
@@ -456,7 +456,7 @@ it('sets `aria-expanded` on close', async () => {
 
 it('does not wrap on ArrowUp', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu">
+    <cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>
@@ -471,7 +471,7 @@ it('does not wrap on ArrowUp', async () => {
 
 it('does not wrap on ArrowDown', async () => {
   const menu = await fixture<CsMenu>(html`
-    <cs-menu label="Menu">
+    <cs-menu>
       <button slot="target">Target</button>
       <cs-menu-link label="One"></cs-menu-link>
       <cs-menu-link label="Two"></cs-menu-link>

--- a/packages/components/src/menu.ts
+++ b/packages/components/src/menu.ts
@@ -43,9 +43,6 @@ export default class CsMenu extends LitElement {
   }
 
   @property({ reflect: true })
-  label?: string;
-
-  @property({ reflect: true })
   size: 'small' | 'large' = 'large';
 
   override connectedCallback() {


### PR DESCRIPTION


<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

The `label` attribute for `CsMenu` was not being used.

Probably a leftover from a previous iteration in the old repo.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.
- I have added the component to `exports` in `packages/components/package.json` (if applicable).

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
