### PR TITLE
Synchronize story controls with component state

### DIFF
--- a/packages/components/src/accordion.stories.ts
+++ b/packages/components/src/accordion.stories.ts
@@ -1,5 +1,7 @@
 import './accordion.js';
 import './icons/storybook.js';
+import { STORY_ARGS_UPDATED } from '@storybook/core-events';
+import { addons } from '@storybook/preview-api';
 import { html } from 'lit-html';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
@@ -14,11 +16,25 @@ const meta: Meta = {
       },
     },
   },
-  render: (arguments_) => html`
-    <cs-accordion label=${arguments_.label} ?open=${arguments_.open}
-      >${arguments_['slot="default"']}</cs-accordion
-    >
-  `,
+  render: (arguments_, context) => {
+    context.canvasElement.addEventListener('toggle', (event) => {
+      if (event instanceof CustomEvent) {
+        addons.getChannel().emit(STORY_ARGS_UPDATED, {
+          storyId: context.id,
+          args: {
+            ...arguments_,
+            open: event.detail.newState === 'open',
+          },
+        });
+      }
+    });
+
+    return html`
+      <cs-accordion label=${arguments_.label} ?open=${arguments_.open}
+        >${arguments_['slot="default"']}</cs-accordion
+      >
+    `;
+  },
   args: {
     label: 'Accordion',
     open: false,
@@ -83,34 +99,82 @@ export const Default: StoryObj = {};
 
 export const WithPrefixIcon: StoryObj = {
   name: 'Default (With Prefix Icon)',
-  render: (arguments_) =>
-    html` <cs-accordion label=${arguments_.label} ?open=${arguments_.open}>
+  render: (arguments_, context) => {
+    context.canvasElement.addEventListener('toggle', (event) => {
+      if (event instanceof CustomEvent) {
+        addons.getChannel().emit(STORY_ARGS_UPDATED, {
+          storyId: context.id,
+          args: {
+            ...arguments_,
+            open: event.detail.newState === 'open',
+          },
+        });
+      }
+    });
+
+    return html` <cs-accordion
+      label=${arguments_.label}
+      ?open=${arguments_.open}
+    >
       <cs-example-icon slot="prefix" name="share"></cs-example-icon>
 
       ${arguments_['slot="default"']}
-    </cs-accordion>`,
+    </cs-accordion>`;
+  },
 };
 
 export const WithSuffix: StoryObj = {
   name: 'Default (With Suffix Icons)',
-  render: (arguments_) =>
-    html` <cs-accordion label=${arguments_.label} ?open=${arguments_.open}>
+  render: (arguments_, context) => {
+    context.canvasElement.addEventListener('toggle', (event) => {
+      if (event instanceof CustomEvent) {
+        addons.getChannel().emit(STORY_ARGS_UPDATED, {
+          storyId: context.id,
+          args: {
+            ...arguments_,
+            open: event.detail.newState === 'open',
+          },
+        });
+      }
+    });
+
+    return html` <cs-accordion
+      label=${arguments_.label}
+      ?open=${arguments_.open}
+    >
       ${arguments_['slot="default"']}
 
       <cs-example-icon slot="suffix" name="pencil"></cs-example-icon>
       <cs-example-icon slot="suffix" name="settings"></cs-example-icon>
-    </cs-accordion>`,
+    </cs-accordion>`;
+  },
 };
 
 export const WithPrefixAndSuffix: StoryObj = {
   name: 'Default (With Prefix & Suffix Icons)',
-  render: (arguments_) =>
-    html` <cs-accordion label=${arguments_.label} ?open=${arguments_.open}>
+  render: (arguments_, context) => {
+    context.canvasElement.addEventListener('toggle', (event) => {
+      if (event instanceof CustomEvent) {
+        addons.getChannel().emit(STORY_ARGS_UPDATED, {
+          storyId: context.id,
+          args: {
+            ...arguments_,
+            open: event.detail.newState === 'open',
+          },
+        });
+      }
+    });
+
+    return html` <cs-accordion
+      label=${arguments_.label}
+      ?open=${arguments_.open}
+    >
       <cs-example-icon slot="prefix" name="share"></cs-example-icon>
 
       ${arguments_['slot="default"']}
 
       <cs-example-icon slot="suffix" name="pencil"></cs-example-icon>
       <cs-example-icon slot="suffix" name="settings"></cs-example-icon>
-    </cs-accordion>`,
+    </cs-accordion>`;
+  },
 };

--- a/packages/components/src/accordion.ts
+++ b/packages/components/src/accordion.ts
@@ -159,6 +159,7 @@ export default class CsAccordion extends LitElement {
 
         this.dispatchEvent(
           new CustomEvent('toggle', {
+            bubbles: true,
             detail: {
               newState: 'open',
               oldState: 'closed',
@@ -191,6 +192,7 @@ export default class CsAccordion extends LitElement {
 
           this.dispatchEvent(
             new CustomEvent('toggle', {
+              bubbles: true,
               detail: {
                 newState: 'closed',
                 oldState: 'open',

--- a/packages/components/src/button-group.stories.ts
+++ b/packages/components/src/button-group.stories.ts
@@ -64,7 +64,7 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail:
-            'event: "input" | "change", listener: (event: CustomEvent<{ value: string }>) => void',
+            'event: "change" | "input", listener: (event: CustomEvent<{ value: string }>) => void',
         },
       },
       type: { name: 'function' },

--- a/packages/components/src/checkbox.stories.ts
+++ b/packages/components/src/checkbox.stories.ts
@@ -1,3 +1,5 @@
+import { STORY_ARGS_UPDATED } from '@storybook/core-events';
+import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit-html';
 import CsCheckbox from './checkbox.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
@@ -142,7 +144,19 @@ const meta: Meta = {
       document.documentElement.scrollTop = 0;
     }
   },
-  render(arguments_) {
+  render(arguments_, context) {
+    context.canvasElement.addEventListener('change', (event) => {
+      if (event.target instanceof CsCheckbox) {
+        addons.getChannel().emit(STORY_ARGS_UPDATED, {
+          storyId: context.id,
+          args: {
+            ...arguments_,
+            checked: event.target.checked,
+          },
+        });
+      }
+    });
+
     return html`<form style="padding: 1.5rem;">
       <cs-checkbox
         label=${arguments_.label || nothing}

--- a/packages/components/src/dropdown.stories.ts
+++ b/packages/components/src/dropdown.stories.ts
@@ -1,5 +1,7 @@
 import './dropdown.option.js';
 import './icons/storybook.js';
+import { STORY_ARGS_UPDATED } from '@storybook/core-events';
+import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit-html';
 import CsDropdown from './dropdown.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
@@ -161,7 +163,19 @@ const meta: Meta = {
       document.documentElement.scrollTop = 0;
     }
   },
-  render(arguments_) {
+  render(arguments_, context) {
+    context.canvasElement.addEventListener('click', (event) => {
+      if (event.target instanceof CsDropdown) {
+        addons.getChannel().emit(STORY_ARGS_UPDATED, {
+          storyId: context.id,
+          args: {
+            ...arguments_,
+            open: event.target.open,
+          },
+        });
+      }
+    });
+
     /* eslint-disable unicorn/explicit-length-check */
     return html`<form style="height: 11rem;">
       <cs-dropdown
@@ -193,7 +207,19 @@ export const SingleSelectionHorizontal: StoryObj = {};
 
 export const SingleSelectionHorizontalWithIcon: StoryObj = {
   name: 'Single Selection (Horizontal With Icon)',
-  render(arguments_) {
+  render(arguments_, context) {
+    context.canvasElement.addEventListener('click', (event) => {
+      if (event.target instanceof CsDropdown) {
+        addons.getChannel().emit(STORY_ARGS_UPDATED, {
+          storyId: context.id,
+          args: {
+            ...arguments_,
+            open: event.target.open,
+          },
+        });
+      }
+    });
+
     /* eslint-disable unicorn/explicit-length-check */
     return html`<form style="height: 11rem;">
       <cs-dropdown
@@ -249,7 +275,19 @@ export const SingleSelectionVerticalWithIcon: StoryObj = {
     orientation: 'vertical',
   },
   name: 'Single Selection (Vertical With Icon)',
-  render(arguments_) {
+  render(arguments_, context) {
+    context.canvasElement.addEventListener('click', (event) => {
+      if (event.target instanceof CsDropdown) {
+        addons.getChannel().emit(STORY_ARGS_UPDATED, {
+          storyId: context.id,
+          args: {
+            ...arguments_,
+            open: event.target.open,
+          },
+        });
+      }
+    });
+
     /* eslint-disable unicorn/explicit-length-check */
     return html`<form style="height: 11rem;">
       <cs-dropdown

--- a/packages/components/src/menu.stories.ts
+++ b/packages/components/src/menu.stories.ts
@@ -1,9 +1,11 @@
-import './button.js';
 import './icons/storybook.js';
 import './menu.button.js';
 import './menu.js';
 import './menu.link.js';
+import { STORY_ARGS_UPDATED } from '@storybook/core-events';
+import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit-html';
+import CsButton from './button.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
 const meta: Meta = {
@@ -60,7 +62,23 @@ const meta: Meta = {
       link.addEventListener('click', (event) => event.preventDefault());
     }
   },
-  render(arguments_) {
+  render(arguments_, context) {
+    context.canvasElement.addEventListener('click', (event) => {
+      if (event.target instanceof CsButton) {
+        const menu = context.canvasElement.querySelector('cs-menu');
+
+        if (menu) {
+          addons.getChannel().emit(STORY_ARGS_UPDATED, {
+            storyId: context.id,
+            args: {
+              ...arguments_,
+              open: menu.open,
+            },
+          });
+        }
+      }
+    });
+
     /* eslint-disable unicorn/explicit-length-check */
     return html`<div style="height: 8rem;">
       <cs-menu
@@ -88,7 +106,23 @@ export const Menu: StoryObj = {};
 
 export const MenuWithIcon: StoryObj = {
   name: 'Menu (With Icon)',
-  render(arguments_) {
+  render(arguments_, context) {
+    context.canvasElement.addEventListener('click', (event) => {
+      if (event.target instanceof CsButton) {
+        const menu = context.canvasElement.querySelector('cs-menu');
+
+        if (menu) {
+          addons.getChannel().emit(STORY_ARGS_UPDATED, {
+            storyId: context.id,
+            args: {
+              ...arguments_,
+              open: menu.open,
+            },
+          });
+        }
+      }
+    });
+
     return html`<div style="height: 10rem;">
       <cs-menu
         label=${arguments_.label || nothing}


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

1. Open the [Accordion](https://glide-core.crowdstrike-ux.workers.dev/).
2. Note the state of the Storybook control for `open`.

It should be "True". Instead it's "False".  This PR fixes that.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.
- I have added the component to `exports` in `packages/components/package.json` (if applicable).

## 🔬 How to Test

For each Accordion, Checkbox, Dropdown, and Menu story, interact with the component and make sure the state of the corresponding control is updated after successive interactions.


## 📸 Images/Videos of Functionality

N/A
