### PR TITLE
Docs(Tag story): correct typo

### DIFF
--- a/packages/components/src/tag.stories.ts
+++ b/packages/components/src/tag.stories.ts
@@ -108,7 +108,7 @@ export const Removable: StoryObj = {
 };
 
 export const RemovableWithIcon: StoryObj = {
-  name: 'Tag (With Removeable Label and Prefix Icon)',
+  name: 'Tag (With Removable Label and Prefix Icon)',
   render: (arguments_) => html`
     <cs-tag removable-label="Tag">
       <span slot="prefix">


### PR DESCRIPTION
A fast follow to some typo corrections I had stashed and forgot to apply in `cs-tag`'s story. 

I don't believe this merits a changeset.
