### PR TITLE
Add "padding-line-between-statements" lint rule

### DIFF
--- a/packages/components/eslint.config.js
+++ b/packages/components/eslint.config.js
@@ -33,6 +33,54 @@ export default [
         'error',
       '@crowdstrike/glide-core-eslint-plugin/prefixed-lit-element-class-declaration':
         'error',
+      '@stylistic/padding-line-between-statements': [
+        'error',
+        {
+          blankLine: 'always',
+          prev: '*',
+          next: 'multiline-block-like',
+        },
+        {
+          blankLine: 'always',
+          prev: 'multiline-block-like',
+          next: '*',
+        },
+        {
+          blankLine: 'always',
+          prev: '*',
+          next: 'multiline-const',
+        },
+        {
+          blankLine: 'always',
+          prev: 'multiline-const',
+          next: '*',
+        },
+        {
+          blankLine: 'always',
+          prev: '*',
+          next: 'multiline-expression',
+        },
+        {
+          blankLine: 'always',
+          prev: 'multiline-expression',
+          next: '*',
+        },
+        {
+          blankLine: 'always',
+          prev: '*',
+          next: 'multiline-let',
+        },
+        {
+          blankLine: 'always',
+          prev: 'multiline-let',
+          next: '*',
+        },
+        {
+          blankLine: 'never',
+          prev: 'case',
+          next: 'case',
+        },
+      ],
       '@stylistic/lines-between-class-members': [
         'error',
         'always',

--- a/packages/components/src/accordion.test.basics.ts
+++ b/packages/components/src/accordion.test.basics.ts
@@ -91,6 +91,7 @@ it('does not apply prefix classes when no prefix slot is provided', async () => 
   expect([
     ...component.shadowRoot!.querySelector('[data-test="label"]')!.classList,
   ]).to.deep.equal(['heading-box']);
+
   expect([
     ...component.shadowRoot!.querySelector('[role="region"]')!.classList,
   ]).to.deep.equal(['content']);
@@ -136,6 +137,7 @@ it('renders without prefix and suffix classes after both are removed', async () 
   expect([
     ...component.shadowRoot!.querySelector('[data-test="label"]')!.classList,
   ]).to.deep.equal(['heading-box']);
+
   expect([
     ...component.shadowRoot!.querySelector('[role="region"]')!.classList,
   ]).to.deep.equal(['content']);

--- a/packages/components/src/accordion.test.events.ts
+++ b/packages/components/src/accordion.test.events.ts
@@ -16,11 +16,13 @@ it('dispatches a "toggle" event when the Accordion opens', async () => {
   const component = await fixture<CsAccordion>(
     html`<cs-accordion label="label"></cs-accordion>`,
   );
+
   component.addEventListener('toggle', () => (hasToggleBeenCalled = true));
 
   const summary = component.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="summary"]',
   );
+
   expect(summary).to.be.ok;
 
   summary?.click();
@@ -36,11 +38,13 @@ it('dispatches a "toggle" event when the Accordion closes', async () => {
   const component = await fixture<CsAccordion>(
     html`<cs-accordion label="label" open></cs-accordion>`,
   );
+
   component.addEventListener('toggle', () => (hasToggleBeenCalled = true));
 
   const summary = component.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="summary"]',
   );
+
   expect(summary).to.be.ok;
 
   summary?.click();

--- a/packages/components/src/accordion.ts
+++ b/packages/components/src/accordion.ts
@@ -122,12 +122,14 @@ export default class CsAccordion extends LitElement {
 
   #onPrefixSlotChange() {
     const assignedNodes = this.#prefixSlotElementRef.value?.assignedNodes();
+
     this.hasPrefixSlot =
       assignedNodes && assignedNodes.length > 0 ? true : false;
   }
 
   #onSuffixSlotChange() {
     const assignedNodes = this.#suffixSlotElementRef.value?.assignedNodes();
+
     this.hasSuffixSlot =
       assignedNodes && assignedNodes.length > 0 ? true : false;
   }

--- a/packages/components/src/button-group.button.test.basics.ts
+++ b/packages/components/src/button-group.button.test.basics.ts
@@ -23,6 +23,7 @@ it('renders an li with role "radio"', async () => {
   const element = await fixture(
     html`<cs-button-group-button value="value">Button</cs-button-group-button>`,
   );
+
   const liElement = element.shadowRoot?.querySelector('li');
 
   expect(liElement).to.have.attribute('role', 'radio');
@@ -32,6 +33,7 @@ it('renders "aria-checked" equal to "false" and "tabindex" equal to "-1" by defa
   const element = await fixture(
     html`<cs-button-group-button value="value">Button</cs-button-group-button>`,
   );
+
   const liElement = element.shadowRoot?.querySelector('li');
 
   expect(liElement).to.not.be.null;
@@ -45,6 +47,7 @@ it('renders "aria-checked" equal to "true" and "tabindex" equal to "0" when attr
       >Button</cs-button-group-button
     >`,
   );
+
   const liElement = element.shadowRoot?.querySelector('li');
 
   expect(liElement).to.have.attribute('aria-checked', 'true');
@@ -58,7 +61,9 @@ it('renders two slots, where one has name "prefix", and the other is default wit
       >Button</cs-button-group-button
     >`,
   );
+
   const prefixSlot = element.shadowRoot?.querySelector('slot[name="prefix"]');
+
   const defaultSlot = element.shadowRoot?.querySelector(
     'slot:not([name="prefix"])',
   );
@@ -82,6 +87,7 @@ it('is has a disabled presentation when the "disabled" attribute is true', async
       >Button</cs-button-group-button
     >`,
   );
+
   const liElement = element.shadowRoot?.querySelector('li');
 
   expect(liElement).to.have.attribute('aria-disabled', 'true');
@@ -91,6 +97,7 @@ it('does not have a disabled presentation when "disabled" attribute is false', a
   const element = await fixture(
     html`<cs-button-group-button value="value">Button</cs-button-group-button>`,
   );
+
   const liElement = element.shadowRoot?.querySelector('li');
 
   expect(liElement).to.have.attribute('aria-disabled', 'false');
@@ -126,6 +133,7 @@ it('sets buttons as not tabbable by default', async () => {
   const element = await fixture(
     html`<cs-button-group-button value="value">Button</cs-button-group-button>`,
   );
+
   const liElement = element.shadowRoot?.querySelector('li');
 
   await expect(liElement).to.have.attribute('tabindex', '-1');
@@ -137,6 +145,7 @@ it('sets a "selected" button as tabbable', async () => {
       >Button</cs-button-group-button
     >`,
   );
+
   const liElement = element.shadowRoot?.querySelector('li');
 
   await expect(liElement).to.have.attribute('tabindex', '0');
@@ -148,6 +157,7 @@ it('has a presentation for variant "icon-only"', async () => {
       ><span slot="prefix">Prefix</span>Button</cs-button-group-button
     >`,
   );
+
   const liElement = element.shadowRoot?.querySelector('li');
 
   expect(liElement).to.have.class('icon-only');
@@ -157,6 +167,7 @@ it('does not apply class "icon-only" when variant "icon-only" is absent', async 
   const element = await fixture(
     html`<cs-button-group-button value="value">Button</cs-button-group-button>`,
   );
+
   const liElement = element.shadowRoot?.querySelector('li');
 
   expect(liElement).to.not.have.class('icon-only');
@@ -164,6 +175,7 @@ it('does not apply class "icon-only" when variant "icon-only" is absent', async 
 
 it('throws an error when no label is present and variant is `icon-only`', async () => {
   const spy = sinon.spy();
+
   try {
     await fixture(
       html`<cs-button-group-button value="value" selected variant="icon-only"
@@ -173,6 +185,7 @@ it('throws an error when no label is present and variant is `icon-only`', async 
   } catch {
     spy();
   }
+
   expect(spy.called).to.be.true;
 });
 
@@ -195,11 +208,13 @@ it('throws an error when prefix slot is empty and variant is `icon-only`', async
   } catch {
     spy();
   }
+
   expect(spy.called).to.be.true;
 });
 
 it('does not throw an error when prefix slot is empty and no variant is set', async () => {
   const spy = sinon.spy();
+
   try {
     await fixture(
       html`<cs-button-group-button value="value" selected
@@ -209,5 +224,6 @@ it('does not throw an error when prefix slot is empty and no variant is set', as
   } catch {
     spy();
   }
+
   expect(spy.notCalled).to.be.true;
 });

--- a/packages/components/src/button-group.button.test.events.ts
+++ b/packages/components/src/button-group.button.test.events.ts
@@ -10,13 +10,16 @@ it('emits a change event when clicked', async () => {
   const element = await fixture(
     html`<cs-button-group-button value="value">Button</cs-button-group-button>`,
   );
+
   const liElement = element.shadowRoot?.querySelector('li');
+
   // This pattern is adopted from https://open-wc.org/docs/testing/helpers/#testing-events
   // Without setTimeout the test fails. The suspicion is this is related to task scheduling,
   // however this can be investigated later.
   setTimeout(() => {
     liElement?.click();
   });
+
   const changeEvent = await oneEvent(element, 'change');
 
   expect(changeEvent instanceof Event).to.be.true;
@@ -26,10 +29,13 @@ it('emits an input event when clicked', async () => {
   const element = await fixture(
     html`<cs-button-group-button value="value">Button</cs-button-group-button>`,
   );
+
   const liElement = element.shadowRoot!.querySelector('li');
+
   setTimeout(() => {
     liElement?.click();
   });
+
   const inputEvent = await oneEvent(element, 'input');
 
   expect(inputEvent instanceof Event).to.be.true;
@@ -41,10 +47,13 @@ it('emits a change event when a space key is pressed and is not already selected
       >Button 1</cs-button-group-button
     >`,
   );
+
   buttonElement.focus();
+
   setTimeout(async () => {
     await sendKeys({ press: ' ' });
   });
+
   const changeEvent = await oneEvent(buttonElement, 'change');
 
   expect(changeEvent instanceof Event).to.be.true;
@@ -56,6 +65,7 @@ it('does not emit change event when a space key is pressed and is selected', asy
       >Button 1</cs-button-group-button
     > `,
   );
+
   const spy = sinon.spy();
   buttonElement.addEventListener('change', spy);
   buttonElement.focus();
@@ -70,10 +80,13 @@ it('emits an input event when a space key is pressed and is not already selected
       >Button 1</cs-button-group-button
     >`,
   );
+
   buttonElement.focus();
+
   setTimeout(async () => {
     await sendKeys({ press: ' ' });
   });
+
   const inputEvent = await oneEvent(buttonElement!, 'input');
 
   expect(inputEvent instanceof Event).to.be.true;
@@ -85,6 +98,7 @@ it('does not emit an input event when a space key is pressed and is selected', a
       >Button 1</cs-button-group-button
     >`,
   );
+
   buttonElement.focus();
   const spy = sinon.spy();
   buttonElement.addEventListener('input', spy);

--- a/packages/components/src/button-group.button.ts
+++ b/packages/components/src/button-group.button.ts
@@ -76,12 +76,14 @@ export default class CsButtonGroupButton extends LitElement {
       const firstEnabledSelectedButton = this.#buttonElements.find(
         (button) => !button.disabled && button.selected,
       );
+
       if (firstEnabledSelectedButton && firstEnabledSelectedButton === this) {
         this.isTabbable = true;
       } else if (!firstEnabledSelectedButton) {
         const firstEnabledButton = this.#buttonElements.find(
           (button) => !button.disabled,
         );
+
         if (firstEnabledButton && firstEnabledButton === this) {
           this.isTabbable = true;
         }
@@ -145,11 +147,13 @@ export default class CsButtonGroupButton extends LitElement {
   ): void {
     if (this.hasUpdated && changedProperties.has('selected')) {
       const value = changedProperties.get('selected');
+
       if (value === true) {
         this.isTabbable = false;
       } else if (value === false) {
         this.isTabbable = true;
         this.focus();
+
         for (const button of this.#buttonElements) {
           if (button !== this && button.selected) {
             button.selected = false;
@@ -179,6 +183,7 @@ export default class CsButtonGroupButton extends LitElement {
       this.closest('cs-button-group')?.querySelectorAll(
         'cs-button-group-button',
       ) ?? [];
+
     return [...elements];
   }
 
@@ -186,6 +191,7 @@ export default class CsButtonGroupButton extends LitElement {
     button.dispatchEvent(
       new CustomEvent('change', { bubbles: true, detail: button.value }),
     );
+
     button.dispatchEvent(
       new CustomEvent('input', { bubbles: true, detail: button.value }),
     );
@@ -205,6 +211,7 @@ export default class CsButtonGroupButton extends LitElement {
     ) {
       return;
     }
+
     switch (event.key) {
       case 'ArrowUp':
       case 'ArrowLeft': {
@@ -212,12 +219,14 @@ export default class CsButtonGroupButton extends LitElement {
         this.selected = false;
         // find the closest enabled button
         let sibling = this.previousElementSibling;
+
         while (
           !sibling ||
           (sibling instanceof CsButtonGroupButton && sibling.disabled)
         ) {
           if (sibling === null) {
             const lastButton = this.#buttonElements.at(-1);
+
             if (lastButton) {
               sibling = lastButton;
             }
@@ -225,10 +234,12 @@ export default class CsButtonGroupButton extends LitElement {
             sibling = sibling.previousElementSibling;
           }
         }
+
         if (sibling && sibling instanceof CsButtonGroupButton) {
           sibling.selected = true;
           this.#dispatchEvents(sibling);
         }
+
         break;
       }
       case 'ArrowDown':
@@ -237,12 +248,14 @@ export default class CsButtonGroupButton extends LitElement {
         this.selected = false;
         // find the closest enabled button
         let sibling = this.nextElementSibling;
+
         while (
           !sibling ||
           (sibling instanceof CsButtonGroupButton && sibling.disabled)
         ) {
           if (sibling === null) {
             const firstButton = this.#buttonElements.at(0);
+
             if (firstButton) {
               sibling = firstButton;
             }
@@ -250,18 +263,22 @@ export default class CsButtonGroupButton extends LitElement {
             sibling = sibling.nextElementSibling;
           }
         }
+
         if (sibling && sibling instanceof CsButtonGroupButton) {
           sibling.selected = true;
           this.#dispatchEvents(sibling);
         }
+
         break;
       }
       case ' ': {
         event.preventDefault();
+
         if (!this.disabled && !this.selected) {
           this.selected = true;
           this.#dispatchEvents();
         }
+
         break;
       }
     }

--- a/packages/components/src/button-group.test.basics.ts
+++ b/packages/components/src/button-group.test.basics.ts
@@ -31,6 +31,7 @@ it('renders a label and unordered list', async () => {
       ></cs-button-group
     >`,
   );
+
   const ulElement = element.shadowRoot?.querySelector('ul');
   const labelElement = element.shadowRoot?.querySelector('div.label');
 
@@ -47,6 +48,7 @@ it('does not render a label when not given', async () => {
       ></cs-button-group
     >`,
   );
+
   const ulElement = element.shadowRoot?.querySelector('ul');
   const labelElement = element.shadowRoot?.querySelector('label');
 
@@ -63,6 +65,7 @@ it('assigns buttons the correct positional presentation when in a group', async 
       <cs-button-group-button value="value-4">Button 4</cs-button-group-button>
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
 
   expect(buttonElements.length).to.equal(4);
@@ -130,6 +133,7 @@ it('reacts to "orientation" attribute when changed from "horizontal" to "vertica
       ></cs-button-group
     >`,
   );
+
   const buttonElement = document.querySelector('cs-button-group-button');
   const liElement = buttonElement?.shadowRoot?.querySelector('li');
 
@@ -260,6 +264,7 @@ it("has a tabble button if it's the first element in a button group", async () =
       <cs-button-group-button value="value-3">Button 3</cs-button-group-button>
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
 
   expect(buttonElements.length).to.equal(3);
@@ -287,6 +292,7 @@ it('has the first non-disabled button set as tabbable when in a group', async ()
       <cs-button-group-button value="value-3">Button 3</cs-button-group-button>
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
 
   expect(buttonElements.length).to.equal(3);
@@ -314,6 +320,7 @@ it('has the "selected" button as tabbable and others are not when in a group', a
       <cs-button-group-button value="value-3">Button 3</cs-button-group-button>
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
 
   expect(buttonElements.length).to.equal(3);
@@ -342,6 +349,7 @@ it('initially no button sets itself as tabbable if all are disabled in a group',
       >
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
 
   expect(buttonElements.length).to.equal(2);

--- a/packages/components/src/button-group.test.events.ts
+++ b/packages/components/src/button-group.test.events.ts
@@ -23,6 +23,7 @@ it('emits a change event when arrow keys are pressed', async () => {
       <cs-button-group-button value="value-3">Button 3</cs-button-group-button>
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
   await sendKeys({ press: 'Tab' });
 
@@ -61,6 +62,7 @@ it('emits an input event when arrow keys are pressed', async () => {
       <cs-button-group-button value="value-3">Button 3</cs-button-group-button>
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
   await sendKeys({ press: 'Tab' });
 
@@ -95,6 +97,7 @@ it('moves focus to previous button when left or up arrow keys are pressed', asyn
       >
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowLeft' });
@@ -115,6 +118,7 @@ it('moves focus to last button when left or up arrow keys are pressed on the fir
       <cs-button-group-button value="value-3">Button 3</cs-button-group-button>
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowLeft' });
@@ -138,6 +142,7 @@ it('moves focus to next button when right or down arrow keys are pressed', async
       <cs-button-group-button value="value-3">Button 3</cs-button-group-button>
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowRight' });
@@ -158,6 +163,7 @@ it('moves focus to first button when right or down arrow keys are pressed on the
       >
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowRight' });
@@ -184,6 +190,7 @@ it('moves focus to previous enabled button when pressing left or up arrow keys',
       >
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowLeft' });
@@ -210,6 +217,7 @@ it('moves focus to next enabled button when pressing right or down arrow keys', 
       <cs-button-group-button value="value-3">Button 3</cs-button-group-button>
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowRight' });
@@ -230,6 +238,7 @@ it('does not move focus if there is only one button when pressing arrow keys', a
       <cs-button-group-button value="value-1">Button 1</cs-button-group-button>
     </cs-button-group>`,
   );
+
   const buttonElement = document.querySelector('cs-button-group-button');
   await sendKeys({ press: 'Tab' });
 
@@ -256,6 +265,7 @@ it('changes the "selected" attribute when clicking', async () => {
       <cs-button-group-button value="value-3">Button 3</cs-button-group-button>
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
   const liElement = buttonElements[2].shadowRoot!.querySelector('li');
   expect(liElement).to.exist;
@@ -278,6 +288,7 @@ it('does not change focus nor the "selected" attribute when clicking a disabled 
       >
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
   await sendKeys({ press: 'Tab' });
   const liElement = buttonElements[0].shadowRoot!.querySelector('li');
@@ -300,6 +311,7 @@ it('changes the "selected" attribute when pressing arrow and space keys', async 
       <cs-button-group-button value="value-3">Button 3</cs-button-group-button>
     </cs-button-group>`,
   );
+
   const buttonElements = document.querySelectorAll('cs-button-group-button');
 
   await sendKeys({ press: 'Tab' });

--- a/packages/components/src/button-group.ts
+++ b/packages/components/src/button-group.ts
@@ -54,6 +54,7 @@ export default class CsButtonGroup extends LitElement {
         listItem.toggleAttribute('vertical');
       }
     }
+
     if (this.variant === 'icon-only') {
       for (const listItem of this.listItems) {
         listItem.setAttribute('variant', 'icon-only');
@@ -87,6 +88,7 @@ export default class CsButtonGroup extends LitElement {
   ): void {
     if (this.hasUpdated && changedProperties.has('variant')) {
       const value = changedProperties.get('variant');
+
       if (value === 'icon-only') {
         for (const listItem of this.listItems) {
           listItem.removeAttribute('variant');
@@ -100,6 +102,7 @@ export default class CsButtonGroup extends LitElement {
 
     if (this.hasUpdated && changedProperties.has('orientation')) {
       const value = changedProperties.get('orientation');
+
       if (value === 'vertical') {
         for (const listItem of this.listItems) {
           listItem.removeAttribute('vertical');

--- a/packages/components/src/button.test.ts
+++ b/packages/components/src/button.test.ts
@@ -34,6 +34,7 @@ it('has defaults', async () => {
 
   expect(button?.getAttribute('type')).to.equal('button');
   expect(button?.disabled).to.equal(false);
+
   expect([...button!.classList]).to.deep.equal([
     'component',
     'primary',

--- a/packages/components/src/checkbox.test.states.ts
+++ b/packages/components/src/checkbox.test.states.ts
@@ -100,6 +100,7 @@ it('is still indeterminate after being clicked when unchecked and disabled', asy
   const input = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
+
   expect(input?.indeterminate).to.be.true;
   expect(component.indeterminate).to.equal(true);
   expect(component.hasAttribute('indeterminate')).to.be.true;

--- a/packages/components/src/checkbox.test.validity.ts
+++ b/packages/components/src/checkbox.test.validity.ts
@@ -25,6 +25,7 @@ it('is valid but not aria-invalid after being checked when unchecked and require
   expect(component.validity?.valueMissing).to.be.false;
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
+
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
   ).to.equal('false');
@@ -39,6 +40,7 @@ it('is invalid but not aria-invalid if unchecked and required', async () => {
   expect(component.validity?.valueMissing).to.be.true;
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
+
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
   ).to.equal('false');
@@ -55,6 +57,7 @@ it('is invalid but not aria-invalid after being unchecked when required', async 
   expect(component.validity?.valueMissing).to.be.true;
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
+
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
   ).to.equal('false');
@@ -105,6 +108,7 @@ it('adds an error class and renders aria-invalid equal to true after `reportVali
     ?.classList.contains('error');
 
   expect(isErrorClass).to.be.true;
+
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
   ).to.equal('true');
@@ -120,6 +124,7 @@ it('does not add an error class and renders aria-invalid equal to false by defau
     ?.classList.contains('error');
 
   expect(isErrorClass).to.be.false;
+
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
   ).to.equal('false');
@@ -143,6 +148,7 @@ it('does not add an error class and renders aria-invalid equal to false after `r
     ?.classList.contains('error');
 
   expect(isErrorClass).to.be.false;
+
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
   ).to.equal('false');

--- a/packages/components/src/dropdown.option.ts
+++ b/packages/components/src/dropdown.option.ts
@@ -129,6 +129,7 @@ export default class CsDropdownOption extends LitElement {
   get #optionElements() {
     const elements =
       this.closest('cs-dropdown')?.querySelectorAll('cs-dropdown-option') ?? [];
+
     return [...elements];
   }
 

--- a/packages/components/src/icon-button.test.ts
+++ b/packages/components/src/icon-button.test.ts
@@ -38,6 +38,7 @@ it('has defaults', async () => {
   expect(component.shadowRoot?.querySelector('button')?.type).to.equal(
     'button',
   );
+
   expect(component.shadowRoot?.querySelector('button')?.disabled).to.equal(
     false,
   );
@@ -124,6 +125,7 @@ it('sets the disabled attribute', async () => {
   );
 
   expect(component.disabled).to.equal(true);
+
   expect(component.shadowRoot?.querySelector('button')?.disabled).to.equal(
     true,
   );

--- a/packages/components/src/input.test.basics.ts
+++ b/packages/components/src/input.test.basics.ts
@@ -116,8 +116,10 @@ it('emits input events when text is changed and reports a value through the even
 
   let inputEventCaught = false;
   let value = '';
+
   element.addEventListener('input', (event: Event) => {
     inputEventCaught = true;
+
     if (event.target instanceof Input) {
       value = event.target.value;
     }
@@ -137,6 +139,7 @@ it('clearable attribute allows for a button which can clear input', async () => 
   const element = await fixture<Input>(html`
     <cs-input label="Test" clearable></cs-input>
   `);
+
   const clearButton =
     element.shadowRoot?.querySelector<HTMLButtonElement>('.clear-icon-button');
 
@@ -181,6 +184,7 @@ it('max content input receives error styling when text count is greater than max
 
   const componentContainer =
     element.shadowRoot?.querySelector<HTMLDivElement>('.component');
+
   const maxCharacterCountContainer =
     element.shadowRoot?.querySelector<HTMLDivElement>('.character-count');
 

--- a/packages/components/src/input.test.events.ts
+++ b/packages/components/src/input.test.events.ts
@@ -13,6 +13,7 @@ import type Input from './input.js';
 
 it('dispatches a "change" event when typed in', async () => {
   const input = await fixture<Input>(html`<cs-input></cs-input>`);
+
   setTimeout(async () => {
     input.focus();
     await sendKeys({ type: 'testing' });
@@ -25,6 +26,7 @@ it('dispatches a "change" event when typed in', async () => {
 
 it('dispatches an "input" event when typed in', async () => {
   const input = await fixture<Input>(html`<cs-input></cs-input>`);
+
   setTimeout(() => {
     input.focus();
     sendKeys({ type: 'testing' });
@@ -36,6 +38,7 @@ it('dispatches an "input" event when typed in', async () => {
 
 it('dispatches an "invalid" event on submit when required and no value', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(html`<cs-input required></cs-input>`, {
     parentNode: form,
   });
@@ -48,6 +51,7 @@ it('dispatches an "invalid" event on submit when required and no value', async (
 
 it('dispatches an "invalid" event after `checkValidity` is called when required and no value', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(html`<cs-input required></cs-input>`, {
     parentNode: form,
   });
@@ -60,6 +64,7 @@ it('dispatches an "invalid" event after `checkValidity` is called when required 
 
 it('dispatches an "invalid" event after `reportValidity` is called when required and no value', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(html`<cs-input required></cs-input>`, {
     parentNode: form,
   });
@@ -72,9 +77,11 @@ it('dispatches an "invalid" event after `reportValidity` is called when required
 
 it('does not dispatch an "invalid" event after `checkValidity` is called when not required', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(html`<cs-input></cs-input>`, {
     parentNode: form,
   });
+
   const spy = sinon.spy();
 
   input.addEventListener('invalid', spy);
@@ -86,10 +93,12 @@ it('does not dispatch an "invalid" event after `checkValidity` is called when no
 
 it('does not dispatch an "invalid" event after `checkValidity` is called when required and no value but disabled', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(
     html`<cs-input disabled required></cs-input>`,
     { parentNode: form },
   );
+
   const spy = sinon.spy();
 
   input.addEventListener('invalid', spy);
@@ -101,9 +110,11 @@ it('does not dispatch an "invalid" event after `checkValidity` is called when re
 
 it('does not dispatch an "invalid" event when `reportValidity` is called when not required,', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(html`<cs-input></cs-input>`, {
     parentNode: form,
   });
+
   const spy = sinon.spy();
 
   input.addEventListener('invalid', spy);
@@ -115,10 +126,12 @@ it('does not dispatch an "invalid" event when `reportValidity` is called when no
 
 it('does not dispatch an "invalid" event when `reportValidity` is called when required and no value but disabled', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(
     html`<cs-input disabled required></cs-input>`,
     { parentNode: form },
   );
+
   const spy = sinon.spy();
 
   input.addEventListener('invalid', spy);

--- a/packages/components/src/input.test.focus.ts
+++ b/packages/components/src/input.test.focus.ts
@@ -41,6 +41,7 @@ it('blurs the input if `blur` is called', async () => {
 
 it('focuses the input after `reportValidity` is called when required and no value', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(html`<cs-input required></cs-input>`, {
     parentNode: form,
   });
@@ -53,6 +54,7 @@ it('focuses the input after `reportValidity` is called when required and no valu
 
 it('focuses the input after `requestSubmit` is called when required and no value', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(html`<cs-input required></cs-input>`, {
     parentNode: form,
   });
@@ -65,6 +67,7 @@ it('focuses the input after `requestSubmit` is called when required and no value
 
 it('does not focus the input after `checkValidity` is called', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(html`<cs-input required></cs-input>`, {
     parentNode: form,
   });

--- a/packages/components/src/input.test.validity.ts
+++ b/packages/components/src/input.test.validity.ts
@@ -44,6 +44,7 @@ it('is invalid after value is cleared when required', async () => {
 
   const clearButton =
     input.shadowRoot?.querySelector<HTMLButtonElement>('.clear-icon-button');
+
   clearButton?.click();
   await input.updateComplete;
 
@@ -66,6 +67,7 @@ it('is valid if no value and required but disabled', async () => {
 
 it('adds an error class after submit when empty and required', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(html`<cs-input required></cs-input>`, {
     parentNode: form,
   });
@@ -82,6 +84,7 @@ it('adds an error class after submit when empty and required', async () => {
 
 it('adds an error class after `reportValidity` is called when required', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(html`<cs-input required></cs-input>`, {
     parentNode: form,
   });
@@ -108,6 +111,7 @@ it('does not add an error class by default', async () => {
 
 it('does not add an error class after `reportValidity` is called when not required', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(html`<cs-input></cs-input>`, {
     parentNode: form,
   });
@@ -124,6 +128,7 @@ it('does not add an error class after `reportValidity` is called when not requir
 
 it('does not add an error class after `reportValidity` is called when required and has a value', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(
     html`<cs-input value="value" required></cs-input>`,
     { parentNode: form },
@@ -141,6 +146,7 @@ it('does not add an error class after `reportValidity` is called when required a
 
 it('does not add an error class after `reportValidity` is called when required but disabled', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(
     html`<cs-input disabled required></cs-input>`,
     { parentNode: form },
@@ -158,6 +164,7 @@ it('does not add an error class after `reportValidity` is called when required b
 
 it('does not add an error class after `checkValidity` is called when required', async () => {
   const form = document.createElement('form');
+
   const input = await fixture<Input>(html`<cs-input required></cs-input>`, {
     parentNode: form,
   });

--- a/packages/components/src/menu.test.focus.ts
+++ b/packages/components/src/menu.test.focus.ts
@@ -80,6 +80,7 @@ it('focuses the target on close via Escape', async () => {
   button?.dispatchEvent(
     new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
   );
+
   expect(document.activeElement).to.equal(button);
 });
 

--- a/packages/components/src/menu.test.interactions.ts
+++ b/packages/components/src/menu.test.interactions.ts
@@ -434,6 +434,7 @@ it('sets `aria-expanded` on open', async () => {
   );
 
   menu.querySelector('button')?.click();
+
   expect(menu.querySelector('button')?.getAttribute('aria-expanded')).to.equal(
     'true',
   );

--- a/packages/components/src/tab.group.test.ts
+++ b/packages/components/src/tab.group.test.ts
@@ -25,15 +25,18 @@ it('renders correct markup and sets correct attributes for the default case', as
 
   await expect(tabGroup).to.be.accessible();
   const [firstTab] = tabGroup.tabElements;
+
   expect(tabGroup.activeTab).to.equal(
     firstTab,
     'activeTab defaults to first tab',
   );
+
   expect(tabGroup.variant).to.equal('primary');
 
   expect([...tabGroup.shadowRoot!.firstElementChild!.classList]).to.deep.equal([
     'component',
   ]);
+
   expect([
     ...tabGroup.shadowRoot!.querySelector('.tab-group')!.classList,
   ]).to.deep.equal(['tab-group', 'primary']);
@@ -41,6 +44,7 @@ it('renders correct markup and sets correct attributes for the default case', as
   const slot = tabGroup.shadowRoot!.querySelector<HTMLSlotElement>(
     'slot:not([name="nav"])',
   );
+
   expect(slot).to.exist;
   expect(slot!.assignedElements.length).to.equal(0);
 });
@@ -93,10 +97,12 @@ it('can switch tabs', async () => {
 
   expect(firstTab.active).to.equal(true, 'first tab defaults to active');
   expect(secondTab.active).to.equal(false, 'other tabs default to not active');
+
   expect(isPanelHidden(firstPanel)).to.equal(
     false,
     'first panel is not hidden by default',
   );
+
   expect(isPanelHidden(secondPanel)).to.equal(
     true,
     'nonactive panel is hidden by default',
@@ -104,20 +110,26 @@ it('can switch tabs', async () => {
 
   secondTab.click();
   const triggeredEvent = await listener;
+
   await expect(firstTab.active).to.equal(
     false,
     'after clicking a different tab, previous tab is no longer active',
   );
+
   expect(secondTab.active).to.equal(true, 'clicked tab becomes active');
+
   expect(isPanelHidden(firstPanel)).to.equal(
     true,
     'after clicking a different tab, previous panel is hidden',
   );
+
   expect(isPanelHidden(secondPanel)).to.equal(
     false,
     `clicked tab's panel is no longer hidden`,
   );
+
   expect(triggeredEvent.type).to.equal('tab-show', 'correct tab event fires');
+
   expect(triggeredEvent.detail.panel).to.equal(
     '2',
     'Can get the panel name from the tab click event',
@@ -128,29 +140,36 @@ it('can switch tabs', async () => {
   // Should be focused on third tab. Press Enter on it
   await sendKeys({ press: 'Enter' });
   const secondTriggeredEvent = await listener;
+
   expect(secondTab.active).to.equal(
     false,
     'after pressing Enter on a different tab, previous tab is no longer active',
   );
+
   expect(thirdTab.active).to.equal(true, 'new tab becomes active');
+
   expect(isPanelHidden(secondPanel)).to.equal(
     true,
     'after pressing Enter on a different tab, previous panel is hidden',
   );
+
   expect(isPanelHidden(thirdPanel)).to.equal(
     false,
     `new tab's panel is no longer hidden`,
   );
+
   expect(secondTriggeredEvent.type).to.equal(
     'tab-show',
     'correct tab event fires for keydown',
   );
+
   expect(secondTriggeredEvent.detail.panel).to.equal(
     '2',
     'Can get the panel name from the tab show event',
   );
 
   disabledTab.click();
+
   expect(disabledTab.active).to.equal(
     false,
     'clicking on a disabled tab does not make it active',

--- a/packages/components/src/tab.group.ts
+++ b/packages/components/src/tab.group.ts
@@ -206,6 +206,7 @@ export default class CsTabGroup extends LitElement {
   #showTab(tab: CsTab) {
     this.activeTab = tab;
     this.#setActiveTab();
+
     this.dispatchEvent(
       new CustomEvent('tab-show', {
         detail: {

--- a/packages/components/src/tab.panel.ts
+++ b/packages/components/src/tab.panel.ts
@@ -37,6 +37,7 @@ export default class CsTabPanel extends LitElement {
   protected override firstUpdated(changes: PropertyValues): void {
     super.firstUpdated(changes);
     this.setAttribute('role', 'tabpanel');
+
     if (!this.hasAttribute('id')) {
       this.id = `cs-tab-panel-${CsTabPanel.instanceCount++}`;
     }
@@ -55,6 +56,7 @@ export default class CsTabPanel extends LitElement {
 
   protected override updated(changes: PropertyValues): void {
     super.updated(changes);
+
     if (changes.has('isActive')) {
       this.setAttribute('aria-hidden', this.isActive ? 'false' : 'true');
     }

--- a/packages/components/src/tab.test.ts
+++ b/packages/components/src/tab.test.ts
@@ -20,10 +20,12 @@ it('renders correct markup and sets correct attributes for the default case', as
     null,
     'does not set aria-disabled',
   );
+
   expect([...element.shadowRoot!.firstElementChild!.classList]).to.deep.equal([
     'component',
     'primary',
   ]);
+
   expect(element.shadowRoot!.querySelector('cs-icon-general-x-close-solid')).to
     .not.exist;
 });
@@ -82,6 +84,7 @@ it('renders the icon slot', async () => {
   const slotNodes = element
     .shadowRoot!.querySelector<HTMLSlotElement>('slot[name="icon"]')
     ?.assignedNodes();
+
   expect(slotNodes?.length).to.equal(1);
   expect(slotNodes?.at(0)?.textContent?.trim()).to.equal('Icon');
 });

--- a/packages/components/src/tab.ts
+++ b/packages/components/src/tab.ts
@@ -45,6 +45,7 @@ export default class CsTab extends LitElement {
   protected override firstUpdated(changes: PropertyValues): void {
     super.firstUpdated(changes);
     this.setAttribute('role', 'tab');
+
     if (!this.hasAttribute('id')) {
       this.id = `cs-tab-${CsTab.instanceCount++}`;
     }
@@ -70,9 +71,11 @@ export default class CsTab extends LitElement {
 
   protected override updated(changes: PropertyValues): void {
     super.updated(changes);
+
     if (changes.has('active')) {
       this.setAttribute('aria-selected', this.active ? 'true' : 'false');
     }
+
     if (changes.has('disabled')) {
       if (this.disabled) {
         this.setAttribute('aria-disabled', 'true');

--- a/packages/components/src/tag.test.basics.ts
+++ b/packages/components/src/tag.test.basics.ts
@@ -20,6 +20,7 @@ it('renders with default slot content', async () => {
   const element = await fixture(
     html`<cs-tag><span data-content>Tag</span></cs-tag>`,
   );
+
   expect(element).to.be.not.null;
 
   const container = element.shadowRoot?.querySelector('.component');
@@ -34,6 +35,7 @@ it('does not render an icon button when "removable-label" attribute is not set',
   const element = await fixture(
     html`<cs-tag><span data-content>Tag</span></cs-tag>`,
   );
+
   expect(element).to.not.have.attribute('removable-label');
 
   const iconButton = element.shadowRoot?.querySelector('button');
@@ -46,6 +48,7 @@ it('renders an icon button with aria-label when "removable-label" attribute is s
       ><span slot="prefix">Prefix</span><span data-content>Tag</span></cs-tag
     >`,
   );
+
   expect(element).to.be.not.null;
   expect(element).to.have.attribute('removable-label', 'test-aria-label');
 
@@ -61,12 +64,14 @@ it('renders the "prefix" slot and its content', async () => {
       ><span slot="prefix" data-prefix>test-prefix</span>Tag</cs-tag
     >`,
   );
+
   const prefixSlot = element.shadowRoot?.querySelector<HTMLSlotElement>(
     'slot[name="prefix"]',
   );
 
   expect(prefixSlot?.assignedNodes()?.length).to.be.equal(1);
   expect(document.querySelector('[data-prefix]')).to.be.not.null;
+
   expect(document.querySelector('[data-prefix]')?.textContent).to.be.equal(
     'test-prefix',
   );
@@ -78,6 +83,7 @@ it('renders correctly when the "size" attribute is set to "small"', async () => 
       ><span slot="prefix">Prefix</span><span data-content>Tag</span></cs-tag
     >`,
   );
+
   const container = element.shadowRoot?.querySelector('.component');
   const iconButton = element.shadowRoot?.querySelector('button');
 
@@ -91,6 +97,7 @@ it('renders correctly when the "size" attribute is set to "large"', async () => 
       ><span slot="prefix">Prefix</span><span data-content>Tag</span></cs-tag
     >`,
   );
+
   const container = element.shadowRoot?.querySelector('.component');
   const iconButton = element.shadowRoot?.querySelector('button');
 
@@ -158,6 +165,7 @@ it('toggles the "activate" and "deactivate" clases when the button is clicked', 
       ><span slot="prefix">Prefix</span>Tag</cs-tag
     >`,
   );
+
   const container = element.shadowRoot?.querySelector('.component');
   const iconButton = element.shadowRoot?.querySelector('button');
 
@@ -174,6 +182,7 @@ it('removes the tag from the DOM when the button is clicked', async () => {
       ><span slot="prefix">Prefix</span><span data-content>Tag</span></cs-tag
     >`,
   );
+
   const iconButton = element.shadowRoot?.querySelector('button');
 
   expect(element.shadowRoot?.querySelector('.component')).to.be.not.null;

--- a/packages/components/src/tag.test.events.ts
+++ b/packages/components/src/tag.test.events.ts
@@ -10,11 +10,13 @@ it('dispatches a "remove" event when the icon button is clicked', async () => {
       ><span slot="prefix">Prefix</span><span data-content>Tag</span></cs-tag
     >`,
   );
+
   const iconButton = element.shadowRoot?.querySelector('button');
 
   setTimeout(() => {
     iconButton?.click();
   });
+
   const event = await oneEvent(element, 'remove');
 
   expect(event?.type).to.be.equal('remove');

--- a/packages/components/src/tag.ts
+++ b/packages/components/src/tag.ts
@@ -102,6 +102,7 @@ export default class CsTag extends LitElement {
         this.remove();
       }, this.#delayToRemove),
     );
+
     this.#containerElementRef.value?.classList.toggle('activate');
     this.#containerElementRef.value?.classList.toggle('deactivate');
     this.dispatchEvent(new CustomEvent('remove', { composed: true }));

--- a/packages/components/src/toggle.test.focus.ts
+++ b/packages/components/src/toggle.test.focus.ts
@@ -4,9 +4,7 @@ import CsToggle from './toggle.js';
 CsToggle.shadowRootOptions.mode = 'open';
 
 it('focuses the input when `focus` is called', async () => {
-  const component = await fixture<CsToggle>(
-    html`<cs-toggle required></cs-toggle>`,
-  );
+  const component = await fixture<CsToggle>(html`<cs-toggle></cs-toggle>`);
 
   component.focus();
 

--- a/packages/components/src/tree.item.test.basics.ts
+++ b/packages/components/src/tree.item.test.basics.ts
@@ -55,15 +55,18 @@ it('can expand', async () => {
   expect([
     ...treeItem.shadowRoot!.querySelector('.component')!.classList,
   ]).to.deep.equal(['component']);
+
   expect([
     ...treeItem.shadowRoot!.querySelector('.expand-icon')!.classList,
   ]).to.deep.equal(['expand-icon']);
 
   treeItem.toggleExpand();
   await treeItem.updateComplete;
+
   expect([
     ...treeItem.shadowRoot!.querySelector('.component')!.classList,
   ]).to.deep.equal(['component', 'component-expanded']);
+
   expect([
     ...treeItem.shadowRoot!.querySelector('.expand-icon')!.classList,
   ]).to.deep.equal(['expand-icon', 'expand-icon-expanded']);

--- a/packages/components/src/tree.test.aria.ts
+++ b/packages/components/src/tree.test.aria.ts
@@ -37,9 +37,11 @@ it('sets roles tree and treeitem', async () => {
   expect(
     childItems[0].shadowRoot?.querySelector('.component')?.getAttribute('role'),
   ).to.equal('treeitem');
+
   expect(
     childItems[1].shadowRoot?.querySelector('.component')?.getAttribute('role'),
   ).to.equal('treeitem');
+
   expect(
     childItems[1].slotElements[0].shadowRoot
       ?.querySelector('.component')
@@ -112,13 +114,16 @@ it('sets aria-selected correctly', async () => {
       ?.querySelector('.component')
       ?.getAttribute('aria-selected'),
   ).to.equal('false', 'sets to string "false" if not selected');
+
   expect(
     childItems[2].shadowRoot
       ?.querySelector('.component')
       ?.getAttribute('aria-selected'),
   ).to.equal('true', 'sets to string "true" if starts as selected');
+
   component.selectItem(childItems[1]);
   await childItems[1].updateComplete;
+
   expect(
     childItems[1].shadowRoot
       ?.querySelector('.component')

--- a/packages/components/src/tree.test.focus.ts
+++ b/packages/components/src/tree.test.focus.ts
@@ -55,6 +55,7 @@ it('expands a tree item if right arrow is pressed', async () => {
   await sendKeys({ press: 'ArrowRight' });
   expect(childItems[0].expanded).to.equal(true);
   assert(document.activeElement instanceof TreeItem);
+
   expect(document.activeElement?.label).to.equal(
     childItems[0].label,
     'focus does not move',
@@ -75,6 +76,7 @@ it(`focuses on an expanded tree item's child if right arrow is pressed`, async (
   tree.dispatchEvent(new Event('focusin'));
   await sendKeys({ press: 'ArrowRight' });
   assert(document.activeElement instanceof TreeItem);
+
   expect(document.activeElement?.label).to.equal(
     childItems[0].slotElements[0].label,
   );
@@ -95,6 +97,7 @@ it('collapses an expanded tree item if left arrow is pressed', async () => {
   await sendKeys({ press: 'ArrowLeft' });
   expect(childItems[0].expanded).to.equal(false);
   assert(document.activeElement instanceof TreeItem);
+
   expect(document.activeElement?.label).to.equal(
     childItems[0].label,
     'focus does not move',
@@ -137,24 +140,28 @@ it('moves down the non-expanded tree items with down arrow', async () => {
 
   await sendKeys({ press: 'ArrowDown' });
   assert(document.activeElement instanceof TreeItem);
+
   expect(document.activeElement?.label).to.equal(
     childItems[0].slotElements[0].label,
     'moves to child item if expanded',
   );
 
   await sendKeys({ press: 'ArrowDown' });
+
   expect(document.activeElement?.label).to.equal(
     childItems[1].label,
     'moves from last child for next parent',
   );
 
   await sendKeys({ press: 'ArrowDown' });
+
   expect(document.activeElement?.label).to.equal(
     childItems[2].label,
     'Does not navigate to collapsed tree items',
   );
 
   await sendKeys({ press: 'ArrowDown' });
+
   expect(document.activeElement?.label).to.equal(
     childItems[2].label,
     'Does not move if at the last item',
@@ -182,12 +189,14 @@ it('moves up the non-expanded tree items with up arrow', async () => {
   expect(document.activeElement?.label).to.equal(childItems[1].label);
 
   await sendKeys({ press: 'ArrowUp' });
+
   expect(document.activeElement?.label).to.equal(
     childItems[0].label,
     'Does not navigate to collapsed tree items',
   );
 
   await sendKeys({ press: 'ArrowUp' });
+
   expect(document.activeElement?.label).to.equal(
     childItems[0].label,
     'Does not move if at the first item',
@@ -233,6 +242,7 @@ it('moves to the last item when End is pressed', async () => {
 
   await sendKeys({ press: 'End' });
   assert(document.activeElement instanceof TreeItem);
+
   expect(document.activeElement?.label).to.equal(
     childItems[1].slotElements[0].label,
   );

--- a/packages/components/src/tree.ts
+++ b/packages/components/src/tree.ts
@@ -95,6 +95,7 @@ export default class CsTree extends LitElement {
 
     return items.filter((item) => {
       const parent = item.parentElement?.closest('cs-tree-item');
+
       if (parent && (!parent.expanded || collapsedItems.has(parent))) {
         collapsedItems.add(item);
       }
@@ -155,8 +156,10 @@ export default class CsTree extends LitElement {
     ) {
       return;
     }
+
     const allFocusableItems = this.#getFocusableItems();
     const { focusedItem } = this;
+
     const indexOfFocusedItem = allFocusableItems.findIndex((item) =>
       item.matches(':focus'),
     );
@@ -175,6 +178,7 @@ export default class CsTree extends LitElement {
       } else {
         const parentTreeItem =
           focusedItem?.parentElement?.closest('cs-tree-item');
+
         this.#focusItem(parentTreeItem);
       }
     }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Adds a newline lint rule for multiline expressions and statements to make our code easier to read and more consistent.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.
- I have added the component to `exports` in `packages/components/package.json` (if applicable).

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A
