### PR TITLE
Enable TypeScript ESLint's typechecking rules

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -160,8 +160,6 @@
     "@stylistic/eslint-plugin": "^1.7.0",
     "@types/mocha": "^10.0.6",
     "@types/sinon": "^17.0.3",
-    "@typescript-eslint/eslint-plugin": "^6.21.0",
-    "@typescript-eslint/parser": "^6.21.0",
     "@web/dev-server-esbuild": "^0.3.6",
     "@web/dev-server-rollup": "^0.6.1",
     "@web/test-runner": "^0.18.0",
@@ -198,7 +196,8 @@
     "stylelint-use-logical": "^2.1.2",
     "stylelint-use-nesting": "^5.1.1",
     "ts-lit-plugin": "^2.0.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "typescript-eslint": "^7.8.0"
   },
   "peerDependencies": {
     "lit": "^3.1.0"

--- a/packages/components/src/button-group.button.test.events.ts
+++ b/packages/components/src/button-group.button.test.events.ts
@@ -87,7 +87,7 @@ it('emits an input event when a space key is pressed and is not already selected
     await sendKeys({ press: ' ' });
   });
 
-  const inputEvent = await oneEvent(buttonElement!, 'input');
+  const inputEvent = await oneEvent(buttonElement, 'input');
 
   expect(inputEvent instanceof Event).to.be.true;
 });

--- a/packages/components/src/button-group.button.ts
+++ b/packages/components/src/button-group.button.ts
@@ -47,7 +47,7 @@ export default class CsButtonGroupButton extends LitElement {
   @property({ type: Boolean })
   vertical = false;
 
-  override async connectedCallback() {
+  override connectedCallback() {
     super.connectedCallback();
 
     // determine position in group and style appropriately

--- a/packages/components/src/button-group.ts
+++ b/packages/components/src/button-group.ts
@@ -38,7 +38,7 @@ export default class CsButtonGroup extends LitElement {
   label? = '';
 
   @queryAssignedElements({ selector: 'cs-button-group-button' })
-  listItems!: Array<CsButtonGroupButton>;
+  listItems!: CsButtonGroupButton[];
 
   @property()
   variant?: ButtonGroupVariant;

--- a/packages/components/src/button.ts
+++ b/packages/components/src/button.ts
@@ -105,10 +105,8 @@ export default class CsButton extends LitElement {
       return;
     }
 
-    if (this.type === 'reset') {
-      this.form?.reset();
-      return;
-    }
+    this.form?.reset();
+    return;
   }
 
   #onKeydown(event: KeyboardEvent) {

--- a/packages/components/src/dropdown.stories.ts
+++ b/packages/components/src/dropdown.stories.ts
@@ -284,21 +284,19 @@ export const SingleSelectionVerticalWithIcon: StoryObj = {
         ?required=${arguments_.required}
       >
         <cs-dropdown-option label="Edit" value="edit">
-          <cs-dropdown-option label="Edit" value="edit">
-            <cs-example-icon slot="icon" name="pencil"></cs-example-icon>
-          </cs-dropdown-option>
+          <cs-example-icon slot="icon" name="pencil"></cs-example-icon>
+        </cs-dropdown-option>
 
-          <cs-dropdown-option label="Move" value="move">
-            <cs-example-icon slot="icon" name="move"></cs-example-icon>
-          </cs-dropdown-option>
+        <cs-dropdown-option label="Move" value="move">
+          <cs-example-icon slot="icon" name="move"></cs-example-icon>
+        </cs-dropdown-option>
 
-          <cs-dropdown-option label="Share" value="share">
-            <cs-example-icon slot="icon" name="share"></cs-example-icon>
-          </cs-dropdown-option>
+        <cs-dropdown-option label="Share" value="share">
+          <cs-example-icon slot="icon" name="share"></cs-example-icon>
+        </cs-dropdown-option>
 
-          <cs-dropdown-option label="Settings" value="settings">
-            <cs-example-icon slot="icon" name="settings"></cs-example-icon>
-          </cs-dropdown-option>
+        <cs-dropdown-option label="Settings" value="settings">
+          <cs-example-icon slot="icon" name="settings"></cs-example-icon>
         </cs-dropdown-option>
 
         ${arguments_['slot="tooltip"']

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -76,6 +76,7 @@ export default class CsDropdown extends LitElement {
 
   // Read-only. Doesn't throw.
   // https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/validationMessage
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   set validationMessage(_) {}
 
   checkValidity() {
@@ -111,7 +112,7 @@ export default class CsDropdown extends LitElement {
   override firstUpdated() {
     const firstOption = this.#optionElements.at(0);
 
-    if (this.selectedOption && this.selectedOption.value) {
+    if (this.selectedOption?.value) {
       this.selectedOption.privateActive = true;
       this.value = [this.selectedOption.value];
     } else if (firstOption) {
@@ -156,10 +157,7 @@ export default class CsDropdown extends LitElement {
       option.hasAttribute('selected'),
     );
 
-    this.value =
-      lastSelectedOption && lastSelectedOption.value
-        ? [lastSelectedOption.value]
-        : [];
+    this.value = lastSelectedOption?.value ? [lastSelectedOption.value] : [];
   }
 
   override render() {
@@ -241,7 +239,7 @@ export default class CsDropdown extends LitElement {
           @keydown=${this.#onButtonKeydown}
           ${ref(this.#buttonElementRef)}
         >
-          ${this.selectedOption?.label || this.placeholder}
+          ${this.selectedOption?.label ?? this.placeholder}
 
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
             <path

--- a/packages/components/src/icon-button.ts
+++ b/packages/components/src/icon-button.ts
@@ -32,7 +32,7 @@ export default class CsIconButton extends LitElement {
 
   /** Text read aloud for screenreaders. For accessibility, this should always be provided. */
   @property()
-  label: string = '';
+  label = '';
 
   @property({ attribute: 'variant', reflect: true })
   variant: 'primary' | 'secondary' | 'tertiary' = 'primary';

--- a/packages/components/src/input.ts
+++ b/packages/components/src/input.ts
@@ -146,7 +146,7 @@ export default class CsInput extends LitElement {
   }
 
   formResetCallback() {
-    this.value = this.getAttribute('value') || '';
+    this.value = this.getAttribute('value') ?? '';
   }
 
   get isTypeSearch() {

--- a/packages/components/src/library/ow.ts
+++ b/packages/components/src/library/ow.ts
@@ -101,6 +101,7 @@ export function owSlotType(
 // which we can't assume.
 //
 // https://github.com/sindresorhus/ow/blob/b48757a77047c26290332321290b714b7dc8c842/dev-only.js
+// eslint-disable-next-line @typescript-eslint/no-empty-function
 const shim = new Proxy(() => {}, {
   get: () => shim,
   apply: () => shim,

--- a/packages/components/src/menu.ts
+++ b/packages/components/src/menu.ts
@@ -84,10 +84,8 @@ export default class CsMenu extends LitElement {
       this.#targetElement.ariaHasPopup = 'true';
       this.#targetElement.ariaExpanded = this.open ? 'true' : 'false';
 
-      autoUpdate(
-        this.#targetElement,
-        this.#optionsElementRef.value,
-        async () => {
+      autoUpdate(this.#targetElement, this.#optionsElementRef.value, () => {
+        (async () => {
           if (this.#targetElement && this.#optionsElementRef.value) {
             const { x, y } = await computePosition(
               this.#targetElement,
@@ -113,8 +111,8 @@ export default class CsMenu extends LitElement {
               top: `${y}px`,
             });
           }
-        },
-      );
+        })();
+      });
     }
   }
 
@@ -179,6 +177,13 @@ export default class CsMenu extends LitElement {
 
   #targetSlotElementRef = createRef<HTMLSlotElement>();
 
+  get #optionElements() {
+    return [
+      ...this.querySelectorAll('cs-menu-button'),
+      ...this.querySelectorAll('cs-menu-link'),
+    ];
+  }
+
   // An arrow function field instead of a method so `this` is closed over and
   // set to the component instead of `document`.
   #onDocumentClick = (event: MouseEvent) => {
@@ -200,13 +205,6 @@ export default class CsMenu extends LitElement {
 
       option.focus();
     }
-  }
-
-  get #optionElements() {
-    return [
-      ...this.querySelectorAll('cs-menu-button'),
-      ...this.querySelectorAll('cs-menu-link'),
-    ];
   }
 
   #onOptionsClick() {

--- a/packages/components/src/status-indicator.test.basics.ts
+++ b/packages/components/src/status-indicator.test.basics.ts
@@ -138,5 +138,6 @@ it('sets the size of the element based on the "--size" CSS variable', async () =
   expect(component.shadowRoot?.querySelector('svg')?.clientHeight).to.equal(
     750,
   );
+
   expect(component.shadowRoot?.querySelector('svg')?.clientWidth).to.equal(750);
 });

--- a/packages/components/src/tab.group.ts
+++ b/packages/components/src/tab.group.ts
@@ -47,10 +47,10 @@ export default class CsTabGroup extends LitElement {
   @state() activeTab?: CsTab;
 
   @queryAssignedElements()
-  panelElements!: Array<CsTabPanel>;
+  panelElements!: CsTabPanel[];
 
   @queryAssignedElements({ slot: 'nav' })
-  tabElements!: Array<CsTab>;
+  tabElements!: CsTab[];
 
   override firstUpdated() {
     owSlotType(this.#navSlotElementRef.value, [CsTab]);
@@ -191,14 +191,12 @@ export default class CsTabGroup extends LitElement {
   }
 
   #setupTabs() {
-    for (let index = 0; index < this.tabElements.length; index++) {
-      const slotElement = this.tabElements[index];
-      const tab = slotElement as CsTab;
-      tab.variant = this.variant;
+    for (const tabElement of this.tabElements) {
+      tabElement.variant = this.variant;
 
       for (const panel of this.panelElements) {
-        tab.setAttribute('aria-controls', panel.getAttribute('id')!);
-        panel.setAttribute('aria-labelledby', tab.getAttribute('id')!);
+        tabElement.setAttribute('aria-controls', panel.getAttribute('id')!);
+        panel.setAttribute('aria-labelledby', tabElement.getAttribute('id')!);
       }
     }
   }

--- a/packages/components/src/tag.stories.ts
+++ b/packages/components/src/tag.stories.ts
@@ -16,7 +16,7 @@ const meta: Meta = {
   render: (arguments_) => html`
     <cs-tag
       removable-label=${arguments_['removable-label'] || nothing}
-      size=${arguments_['size']}
+      size=${arguments_.size}
     >
       ${arguments_['slot="default"']}
     </cs-tag>

--- a/packages/components/src/textarea.ts
+++ b/packages/components/src/textarea.ts
@@ -42,7 +42,7 @@ export default class CsTextarea extends LitElement {
   placeholder?: string = '';
 
   @property({ reflect: true, type: Number })
-  rows: number = 2;
+  rows = 2;
 
   @property({ type: Boolean })
   required = false;
@@ -242,7 +242,7 @@ ${this.value}</textarea
       return false;
     }
 
-    return this.value.length > this.maxCharacterCount!;
+    return this.value.length > this.maxCharacterCount;
   }
 
   #onChange(event: Event) {

--- a/packages/components/src/tooltip.stories.ts
+++ b/packages/components/src/tooltip.stories.ts
@@ -42,23 +42,26 @@ const meta: Meta = {
       },
     },
   },
-  render: (arguments_) => html`
-    <div
-      style="align-items: center; display: flex; height: 8rem; justify-content: center;"
-    >
-      <cs-tooltip placement=${arguments_.placement}>
-        ${unsafeHTML(arguments_['slot="default"'])}
+  render: (arguments_) => {
+    /* eslint-disable @typescript-eslint/no-unsafe-argument */
+    return html`
+      <div
+        style="align-items: center; display: flex; height: 8rem; justify-content: center;"
+      >
+        <cs-tooltip placement=${arguments_.placement}>
+          ${unsafeHTML(arguments_['slot="default"'])}
 
-        <span
-          slot="target"
-          style="display: inline-block; line-height: 0;"
-          tabindex="0"
-        >
-          <cs-example-icon name="info"></cs-example-icon>
-        </span>
-      </cs-tooltip>
-    </div>
-  `,
+          <span
+            slot="target"
+            style="display: inline-block; line-height: 0;"
+            tabindex="0"
+          >
+            <cs-example-icon name="info"></cs-example-icon>
+          </span>
+        </cs-tooltip>
+      </div>
+    `;
+  },
 };
 
 export default meta;

--- a/packages/components/src/tooltip.ts
+++ b/packages/components/src/tooltip.ts
@@ -35,44 +35,46 @@ export default class CsTooltip extends LitElement {
   @property()
   placement?: 'bottom' | 'left' | 'right' | 'top';
 
-  override async firstUpdated() {
+  override firstUpdated() {
     if (this.#targetElementRef.value && this.#tooltipElementRef.value) {
       autoUpdate(
         this.#targetElementRef.value,
         this.#tooltipElementRef.value,
-        async () => {
-          if (this.#targetElementRef.value && this.#tooltipElementRef.value) {
-            const { placement, x, y } = await computePosition(
-              this.#targetElementRef.value,
-              this.#tooltipElementRef.value,
-              {
-                placement: this.placement || 'bottom',
-                middleware: [
-                  offset({
-                    mainAxis:
-                      Number.parseFloat(
-                        window
-                          .getComputedStyle(document.body)
-                          .getPropertyValue('--cs-spacing-xxs'),
-                      ) *
-                        16 +
-                      this.#triangleSize.width,
-                  }),
-                  flip({
-                    fallbackStrategy: 'initialPlacement',
-                  }),
-                  shift(),
-                ],
-              },
-            );
+        () => {
+          (async () => {
+            if (this.#targetElementRef.value && this.#tooltipElementRef.value) {
+              const { placement, x, y } = await computePosition(
+                this.#targetElementRef.value,
+                this.#tooltipElementRef.value,
+                {
+                  placement: this.placement ?? 'bottom',
+                  middleware: [
+                    offset({
+                      mainAxis:
+                        Number.parseFloat(
+                          window
+                            .getComputedStyle(document.body)
+                            .getPropertyValue('--cs-spacing-xxs'),
+                        ) *
+                          16 +
+                        this.#triangleSize.width,
+                    }),
+                    flip({
+                      fallbackStrategy: 'initialPlacement',
+                    }),
+                    shift(),
+                  ],
+                },
+              );
 
-            Object.assign(this.#tooltipElementRef.value.style, {
-              left: `${x}px`,
-              top: `${y}px`,
-            });
+              Object.assign(this.#tooltipElementRef.value.style, {
+                left: `${x}px`,
+                top: `${y}px`,
+              });
 
-            this.effectivePlacement = placement;
-          }
+              this.effectivePlacement = placement;
+            }
+          })();
         },
       );
     }

--- a/packages/components/src/tree.item.test.basics.ts
+++ b/packages/components/src/tree.item.test.basics.ts
@@ -3,7 +3,7 @@ import TreeItem from './tree.item.js';
 
 TreeItem.shadowRootOptions.mode = 'open';
 
-it('registers', async () => {
+it('registers', () => {
   expect(window.customElements.get('cs-tree-item')).to.equal(TreeItem);
 });
 

--- a/packages/components/src/tree.item.ts
+++ b/packages/components/src/tree.item.ts
@@ -44,13 +44,13 @@ export default class CsTreeItem extends LitElement {
   @property({ type: Boolean }) selected = false;
 
   @queryAssignedElements({ slot: 'prefix' })
-  prefixSlotAssignedElements!: Array<HTMLElement>;
+  prefixSlotAssignedElements!: HTMLElement[];
 
   @queryAssignedElements()
-  slotElements!: Array<CsTreeItem>;
+  slotElements!: CsTreeItem[];
 
   @queryAssignedElements({ slot: 'suffix' })
-  suffixSlotAssignedElements!: Array<HTMLElement>;
+  suffixSlotAssignedElements!: HTMLElement[];
 
   override firstUpdated() {
     this.#setupChildren();

--- a/packages/components/src/tree.ts
+++ b/packages/components/src/tree.ts
@@ -30,7 +30,7 @@ export default class CsTree extends LitElement {
   @state() privateTabIndex = 0;
 
   @queryAssignedElements()
-  slotElements!: Array<CsTreeItem>;
+  slotElements!: CsTreeItem[];
 
   override disconnectedCallback() {
     super.disconnectedCallback();
@@ -121,7 +121,7 @@ export default class CsTree extends LitElement {
     let itemToFocus;
 
     if (event.target === this) {
-      itemToFocus = this.selectedItem || this.slotElements[0];
+      itemToFocus = this.selectedItem ?? this.slotElements[0];
     } else if (event.target instanceof CsTreeItem) {
       itemToFocus = event.target;
       this.privateTabIndex = -1;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,12 +84,6 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^6.21.0
-        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(typescript@5.4.2)
-      '@typescript-eslint/parser':
-        specifier: ^6.21.0
-        version: 6.21.0(eslint@8.57.0)(typescript@5.4.2)
       '@web/dev-server-esbuild':
         specifier: ^0.3.6
         version: 0.3.6
@@ -201,6 +195,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.4.2
+      typescript-eslint:
+        specifier: ^7.8.0
+        version: 7.8.0(eslint@8.57.0)(typescript@5.4.2)
 
   packages/eslint-plugin:
     devDependencies:
@@ -2131,11 +2128,32 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/eslint-plugin@7.8.0':
+    resolution: {integrity: sha512-gFTT+ezJmkwutUPmB0skOj3GZJtlEGnlssems4AjkVweUPGj7jRwwqg0Hhg7++kPGJqKtTYx+R05Ftww372aIg==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^7.0.0
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/parser@6.21.0':
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/parser@7.8.0':
+    resolution: {integrity: sha512-KgKQly1pv0l4ltcftP59uQZCi4HUYswCLbTqVZEJu7uLX8CTLyswqMLqLN+2QFz4jCptqWVV4SB7vdxcH2+0kQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -2156,11 +2174,25 @@ packages:
     resolution: {integrity: sha512-ngttyfExA5PsHSx0rdFgnADMYQi+Zkeiv4/ZxGYUWd0nLs63Ha0ksmp8VMxAIC0wtCFxMos7Lt3PszJssG/E6w==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
+  '@typescript-eslint/scope-manager@7.8.0':
+    resolution: {integrity: sha512-viEmZ1LmwsGcnr85gIq+FCYI7nO90DVbE37/ll51hjv9aG+YZMb4WDE2fyWpUR4O/UrhGRpYXK/XajcGTk2B8g==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
   '@typescript-eslint/type-utils@6.21.0':
     resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/type-utils@7.8.0':
+    resolution: {integrity: sha512-H70R3AefQDQpz9mGv13Uhi121FNMh+WEaRqcXTX09YEDky21km4dV1ZXJIp8QjXc4ZaVkXVdohvWDzbnbHDS+A==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -2172,6 +2204,10 @@ packages:
 
   '@typescript-eslint/types@7.6.0':
     resolution: {integrity: sha512-h02rYQn8J+MureCvHVVzhl69/GAfQGPQZmOMjG1KfCl7o3HtMSlPaPUAPu6lLctXI5ySRGIYk94clD/AUMCUgQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/types@7.8.0':
+    resolution: {integrity: sha512-wf0peJ+ZGlcH+2ZS23aJbOv+ztjeeP8uQ9GgwMJGVLx/Nj9CJt17GWgWWoSmoRVKAX2X+7fzEnAjxdvK2gqCLw==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
   '@typescript-eslint/typescript-estree@6.21.0':
@@ -2192,6 +2228,15 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@7.8.0':
+    resolution: {integrity: sha512-5pfUCOwK5yjPaJQNy44prjCwtr981dO8Qo9J9PwYXZ0MosgAbfEMB008dJ5sNo3+/BN6ytBPuSvXUg9SAqB0dg==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/utils@6.21.0':
     resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -2204,12 +2249,22 @@ packages:
     peerDependencies:
       eslint: ^8.56.0
 
+  '@typescript-eslint/utils@7.8.0':
+    resolution: {integrity: sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+
   '@typescript-eslint/visitor-keys@6.21.0':
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
   '@typescript-eslint/visitor-keys@7.6.0':
     resolution: {integrity: sha512-4eLB7t+LlNUmXzfOu1VAIAdkjbu5xNSerURS9X/S5TUKWFRpXRQZbmtPqgKmYx8bj3J0irtQXSiWAOY82v+cgw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@7.8.0':
+    resolution: {integrity: sha512-q4/gibTNBQNA0lGyYQCmWRS5D15n8rXh4QjK3KV+MBPlTYHpfBUT3D3PaPR/HeNiI9W6R7FvlkcGhNyAoP+caA==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
   '@ungap/structured-clone@1.2.0':
@@ -5645,6 +5700,16 @@ packages:
     resolution: {integrity: sha512-yMi0PlwuznKHxKmcpoOdeLwxBoVPkqZxd7q2FgMkmD3bNwvF5VW0+UlUQ1k1vmktTu4Yu13Q0RIxEP8+B+wloA==}
     engines: {node: '>= 0.4'}
 
+  typescript-eslint@7.8.0:
+    resolution: {integrity: sha512-sheFG+/D8N/L7gC3WT0Q8sB97Nm573Yfr+vZFzl/4nBdYcmviBPtwGSX9TJ7wpVg28ocerKVOt+k2eGmHzcgVA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
@@ -8377,12 +8442,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(typescript@5.4.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 7.8.0(eslint@8.57.0)(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 7.8.0
+      '@typescript-eslint/type-utils': 7.8.0(eslint@8.57.0)(typescript@5.4.2)
+      '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@5.4.2)
+      '@typescript-eslint/visitor-keys': 7.8.0
+      debug: 4.3.4
+      eslint: 8.57.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      semver: 7.6.0
+      ts-api-utils: 1.3.0(typescript@5.4.2)
+    optionalDependencies:
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.2)
       '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.4
+      eslint: 8.57.0
+    optionalDependencies:
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.4.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.8.0
+      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.2)
+      '@typescript-eslint/visitor-keys': 7.8.0
       debug: 4.3.4
       eslint: 8.57.0
     optionalDependencies:
@@ -8413,6 +8511,11 @@ snapshots:
       '@typescript-eslint/types': 7.6.0
       '@typescript-eslint/visitor-keys': 7.6.0
 
+  '@typescript-eslint/scope-manager@7.8.0':
+    dependencies:
+      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/visitor-keys': 7.8.0
+
   '@typescript-eslint/type-utils@6.21.0(eslint@8.57.0)(typescript@5.4.2)':
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.2)
@@ -8425,9 +8528,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@7.8.0(eslint@8.57.0)(typescript@5.4.2)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.2)
+      '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@5.4.2)
+      debug: 4.3.4
+      eslint: 8.57.0
+      ts-api-utils: 1.3.0(typescript@5.4.2)
+    optionalDependencies:
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@6.21.0': {}
 
   '@typescript-eslint/types@7.6.0': {}
+
+  '@typescript-eslint/types@7.8.0': {}
 
   '@typescript-eslint/typescript-estree@6.21.0(typescript@5.4.2)':
     dependencies:
@@ -8448,6 +8565,21 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.6.0
       '@typescript-eslint/visitor-keys': 7.6.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.4
+      semver: 7.6.0
+      ts-api-utils: 1.3.0(typescript@5.4.2)
+    optionalDependencies:
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@7.8.0(typescript@5.4.2)':
+    dependencies:
+      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/visitor-keys': 7.8.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -8487,6 +8619,20 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@7.8.0(eslint@8.57.0)(typescript@5.4.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 7.8.0
+      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.2)
+      eslint: 8.57.0
+      semver: 7.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/visitor-keys@6.21.0':
     dependencies:
       '@typescript-eslint/types': 6.21.0
@@ -8495,6 +8641,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@7.6.0':
     dependencies:
       '@typescript-eslint/types': 7.6.0
+      eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@7.8.0':
+    dependencies:
+      '@typescript-eslint/types': 7.8.0
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}
@@ -12476,6 +12627,17 @@ snapshots:
       has-proto: 1.0.3
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
+
+  typescript-eslint@7.8.0(eslint@8.57.0)(typescript@5.4.2):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 7.8.0(@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(typescript@5.4.2)
+      '@typescript-eslint/parser': 7.8.0(eslint@8.57.0)(typescript@5.4.2)
+      '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@5.4.2)
+      eslint: 8.57.0
+    optionalDependencies:
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@4.9.5: {}
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Some TypeScript ESLint's rules rely on type information and must be specially enabled. This PR enables them.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.
- I have added the component to `exports` in `packages/components/package.json` (if applicable).

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A