### PR TITLE
Add input to package.json exports

### DIFF
--- a/.changeset/chilly-panthers-exercise.md
+++ b/.changeset/chilly-panthers-exercise.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Resolved a bug preventing input from being imported in projects

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -87,6 +87,10 @@
       "import": "./dist/icon-button.js",
       "types": "./dist/icon-button.d.ts"
     },
+    "./input.js": {
+      "import": "./dist/input.js",
+      "types": "./dist/input.d.ts"
+    },
     "./menu.js": {
       "import": "./dist/menu.js",
       "types": "./dist/menu.d.ts"


### PR DESCRIPTION
## 🚀 Description

Adds input to `exports` in the `package.json` so it can be imported.  I noticed when [playing](https://github.com/ynotdraw/polaris-ember-testing/commit/9dea7bc07a001e8f83a908b2a0bfff4fd6043338) with our latest release in an Ember app that I couldn't import input.  This fixes that!

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.
- I have added the component to `exports` in `packages/components/package.json` (if applicable).

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A
