### PR TITLE
Tooltip fixes

### DIFF
--- a/.changeset/khaki-clouds-camp.md
+++ b/.changeset/khaki-clouds-camp.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Fixes for Tooltip for an overflowing "target" and a misaligned tooltip.

--- a/packages/components/src/tooltip.styles.ts
+++ b/packages/components/src/tooltip.styles.ts
@@ -4,6 +4,7 @@ import focusOutline from './styles/focus-outline.js';
 export default [
   css`
     .component {
+      display: inline-block;
       position: relative;
     }
 
@@ -11,8 +12,8 @@ export default [
       background-color: transparent;
       border-width: 0;
 
-      /* Additional whitespace and the tooltip won't be vertically centered. */
-      line-height: 0;
+      /* Additional whitespace from line height and the tooltip won't be vertically centered. */
+      display: inline-flex;
       padding: 0;
       position: relative;
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Tooltip's `0` line height can lead to overflow in some cases. Better to use `display: flex` instead. Additionally, Tooltip should be inline so it doesn't fill it's container and the tooltip itself is always positioned against its target.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.
- I have added the component to `exports` in `packages/components/package.json` (if applicable).

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

## `.target { display: flex }`

### Before

<img width="2257" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/e9a89d62-395a-4750-9ec6-5decc5cdd168">


### After

<img width="2259" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/f32f6241-4666-47be-8bac-90acac012591">



## `.component { display: inline-block }`

### Before 

<img width="2260" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/70d91672-4a3e-4cda-8469-208d7c5636ab">

### After

<img width="2259" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/ef791533-b42b-4f05-9b20-35dbc1c9eb96">
