### PR TITLE
Fix an issue with cs-menu options wrapping

### DIFF
--- a/.changeset/twelve-walls-yawn.md
+++ b/.changeset/twelve-walls-yawn.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Adds a fix preventing cs-menu options from wrapping

--- a/packages/components/src/menu.styles.ts
+++ b/packages/components/src/menu.styles.ts
@@ -22,6 +22,7 @@ export default [
       border-radius: var(--cs-spacing-xs);
       box-shadow: var(--cs-shadow-lg);
       box-sizing: border-box;
+      inline-size: max-content;
       inset-block-start: 0;
       inset-inline-start: 0;
       margin-block: 0;


### PR DESCRIPTION
## 🚀 Description

Adds a fix preventing cs-menu options from wrapping. There are a couple of other menu improvements identified by Mary in another ticket, but this work will resolve an issue for @mayuri-todkar.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.
- I have added the component to `exports` in `packages/components/package.json` (if applicable).

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

| Before  | After |
| ------------- | ------------- |
| <img width="172" alt="Screenshot 2024-05-15 at 8 31 19 AM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/9884c5b7-6b69-40f6-9501-89ac2975a0c7">  | <img width="177" alt="Screenshot 2024-05-15 at 8 31 26 AM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/9c55e19b-448f-43c9-aed6-61d54e236196">  |
| Wrapping 👎  | Not wrapping 👍  |



