### PR TITLE
Prevent Tooltip from getting a line height

### DIFF
--- a/.changeset/flat-feet-hide.md
+++ b/.changeset/flat-feet-hide.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Prevent Tooltip from getting a line height.

--- a/packages/components/src/tooltip.styles.ts
+++ b/packages/components/src/tooltip.styles.ts
@@ -4,7 +4,8 @@ import focusOutline from './styles/focus-outline.js';
 export default [
   css`
     .component {
-      display: inline-block;
+      /* https://github.com/CrowdStrike/glide-core/pull/119#issuecomment-2113314591 */
+      display: flex;
       position: relative;
     }
 
@@ -13,7 +14,7 @@ export default [
       border-width: 0;
 
       /* Additional whitespace from line height and the tooltip won't be vertically centered. */
-      display: inline-flex;
+      display: flex;
       padding: 0;
       position: relative;
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Fixes a bug [reported](https://github.com/CrowdStrike/glide-core/pull/119#issuecomment-2113192488) by @abhiStriker.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

Feel free to `pnpm link` and test against Glide Internals!

## 📸 Images/Videos of Functionality

## Before

<img width="1031" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/a4225392-fb8d-4e0c-a491-71a50f4378c1">


## After

<img width="1022" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/c3d8d627-d011-41c4-bce3-ca2d4afa91d1">

