### PR TITLE
Update chevron-down storybook icon

### DIFF
--- a/packages/components/src/button.stories.ts
+++ b/packages/components/src/button.stories.ts
@@ -85,7 +85,7 @@ export const PrimaryWithPrefixIcon: StoryObj = {
 
       <cs-example-icon
         slot="prefix"
-        name="caret-down"
+        name="chevron-down"
         aria-hidden="true"
       ></cs-example-icon>
     </cs-button>
@@ -104,7 +104,7 @@ export const PrimaryWithSuffixIcon: StoryObj = {
 
       <cs-example-icon
         slot="suffix"
-        name="caret-down"
+        name="chevron-down"
         aria-hidden="true"
       ></cs-example-icon>
     </cs-button>
@@ -128,7 +128,7 @@ export const PrimaryWithPrefixAndSuffixIcons: StoryObj = {
       ></cs-example-icon>
       <cs-example-icon
         slot="suffix"
-        name="caret-down"
+        name="chevron-down"
         aria-hidden="true"
       ></cs-example-icon>
     </cs-button>
@@ -156,7 +156,7 @@ export const SecondaryWithPrefixIcon: StoryObj = {
 
       <cs-example-icon
         slot="prefix"
-        name="caret-down"
+        name="chevron-down"
         aria-hidden="true"
       ></cs-example-icon>
     </cs-button>
@@ -178,7 +178,7 @@ export const SecondaryWithSuffixIcon: StoryObj = {
 
       <cs-example-icon
         slot="suffix"
-        name="caret-down"
+        name="chevron-down"
         aria-hidden="true"
       ></cs-example-icon>
     </cs-button>
@@ -205,7 +205,7 @@ export const SecondaryWithPrefixAndSuffixIcons: StoryObj = {
       ></cs-example-icon>
       <cs-example-icon
         slot="suffix"
-        name="caret-down"
+        name="chevron-down"
         aria-hidden="true"
       ></cs-example-icon>
     </cs-button>
@@ -233,7 +233,7 @@ export const TertiaryWithPrefixIcon: StoryObj = {
 
       <cs-example-icon
         slot="prefix"
-        name="caret-down"
+        name="chevron-down"
         aria-hidden="true"
       ></cs-example-icon>
     </cs-button>
@@ -255,7 +255,7 @@ export const TertiaryWithSuffixIcon: StoryObj = {
 
       <cs-example-icon
         slot="suffix"
-        name="caret-down"
+        name="chevron-down"
         aria-hidden="true"
       ></cs-example-icon>
     </cs-button>
@@ -282,7 +282,7 @@ export const TertiaryWithPrefixAndSuffixIcons: StoryObj = {
       ></cs-example-icon>
       <cs-example-icon
         slot="suffix"
-        name="caret-down"
+        name="chevron-down"
         aria-hidden="true"
       ></cs-example-icon>
     </cs-button>

--- a/packages/components/src/icons/storybook.ts
+++ b/packages/components/src/icons/storybook.ts
@@ -89,13 +89,19 @@ const ICONS = {
     />
     <circle cx="12" cy="8" r="1" fill="currentColor" />
   `,
-  'caret-down': svg`
-    <path d="M6,9.1,9,12l3,2.9L15,12l3-2.9" />
-  `,
   calendar: svg`
     <path
       d="M5 5h14a2 2 0 012 2v12a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2zm11-2v4M8 3v4m-5 3h18M7.858 13.954h.1m4.342 0h.1m4.3 0h.1M7.827 17.4h.1m4.373 0h.1m4.269 0h.1"
     ></path>
+  `,
+  'chevron-down': svg`
+    <path
+      d="M6 9L12 15L18 9"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
   `,
   clipboard: svg`
     <path


### PR DESCRIPTION
## 🚀 Description

Very minor change, but design noticed our storybook icon for the chevron doesn't have the stroke-width set, so it appeared thinner than they were expecting.  This fixes that.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

| Before  | After |
| ------------- | ------------- |
| <img width="123" alt="Screenshot 2024-05-17 at 12 12 31 PM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/2d42e824-da31-473c-95f5-e6ab8afdb83c">  | <img width="118" alt="Screenshot 2024-05-17 at 12 12 16 PM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/6d3c139d-02eb-4faf-a80a-ac2cee9473c7">  |







