### PR TITLE
Color adjustments for tag and tree.item

### DIFF
--- a/.changeset/giant-colts-wink.md
+++ b/.changeset/giant-colts-wink.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Minor color adjustments to cs-tag and cs-tree.item components

--- a/.changeset/great-lemons-arrive.md
+++ b/.changeset/great-lemons-arrive.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-styles': patch
+---
+
+Added the --cs-icon-hover variable

--- a/packages/components/src/tag.styles.ts
+++ b/packages/components/src/tag.styles.ts
@@ -123,7 +123,7 @@ export default [
       }
 
       &:hover {
-        color: var(--cs-text-primary-hover);
+        color: var(--cs-icon-primary-hover);
       }
 
       &:focus {

--- a/packages/components/src/tag.ts
+++ b/packages/components/src/tag.ts
@@ -67,14 +67,14 @@ export default class CsTag extends LitElement {
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
                 <path
                   d="M6 6L18 18"
-                  stroke="black"
+                  stroke="currentColor"
                   stroke-width="2"
                   stroke-linecap="round"
                   stroke-linejoin="round"
                 />
                 <path
                   d="M18 6L6 18"
-                  stroke="black"
+                  stroke="currentColor"
                   stroke-width="2"
                   stroke-linecap="round"
                   stroke-linejoin="round"

--- a/packages/components/src/tree.item.styles.ts
+++ b/packages/components/src/tree.item.styles.ts
@@ -94,7 +94,7 @@ export default [
     /* Nesting does not work with ::slotted */
     /* stylelint-disable-next-line csstools/use-nesting */
     .component.selected ::slotted([slot='menu']) {
-      --hovered-target-icon-color: var(--cs-text-primary-hover);
+      --hovered-target-icon-color: var(--cs-icon-hover);
     }
 
     ::slotted([slot='suffix']) {

--- a/packages/styles/index.css
+++ b/packages/styles/index.css
@@ -41,6 +41,7 @@
   --cs-heading-xxxs-line-height: 1.7;
   --cs-icon-active: #0073e6;
   --cs-icon-default: #212121;
+  --cs-icon-hover: #8babf1;
   --cs-icon-primary: #054fb9;
   --cs-icon-primary-hover: #0461cf;
   --cs-icon-selected: #ffffff;


### PR DESCRIPTION
## 🚀 Description

I'm working on updating button styling and some of the shared CSS variables I need to change for button also affected these two other components. As any developer would do, I began making sure that the color changes to these variables didn't have any negative impact on non-button components since we reuse these variables outside of buttons. After poking around in Figma, it appears the color variables + values have changed for a few of these, so I decided to do these changes in a separate PR while I wait for design to get back to me on some button changes.

## 📋 Checklist

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

### Tag

- Previously the stroke was always set to `black` rather than `currentColor`.  By switching to `currentColor`, the color will be determined by the parent.
- Due to not having `currentColor` the hover style never appeared and was always `black`
- I also updated the hover color to match that of the `tertiary` cs-icon-button variant for consistency

| Before  | After |
| ------------- | ------------- |
| <img width="321" alt="Screenshot 2024-05-17 at 12 31 39 PM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/3cc42192-ffa3-4002-86d2-c358dd3929dd">  | <img width="348" alt="Screenshot 2024-05-17 at 12 31 13 PM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/9c928a20-104b-42c9-820c-c4e1449f1de1"> |

#### Tree Item

A very subtle change, where the icon color was updated `--cs-icon-hover: #8babf1;` according to Figma. @danwenzel let me know if you see otherwise!

| Before  | After |
| ------------- | ------------- |
| <img width="1585" alt="Screenshot 2024-05-17 at 12 34 26 PM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/e52b1058-8200-4adf-91fe-9acdfacf8270">  | <img width="1618" alt="Screenshot 2024-05-17 at 12 34 47 PM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/73b479c1-b2ee-40bc-ba24-e9ca2ca8f4b6"> |




