### PR TITLE
Bubble events consistently

### DIFF
--- a/.changeset/tiny-spiders-unite.md
+++ b/.changeset/tiny-spiders-unite.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': minor
+---
+
+Dialog's "close" and Accordion's "toggle" event no longer bubble.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@
   - [Typing property decorators](#typing-property-decorators)
   - [Avoid side effects in setters](#avoid-side-effects-in-setters)
   - [Prefer `.component` for the root element CSS selector](#prefer-component-for-the-root-element-css-selector)
+  - [Bubble events by default](#bubble-events-by-default)
 - [Questions](#questions)
   - [What is `per-env`?](#what-is-per-env)
 
@@ -545,6 +546,24 @@ render() {
   return html`<div></div>`;
 }
 ```
+
+### Bubble events by default
+
+Bubbling is what consumers expect because most events bubble.
+Bubbling also lets consumers use our components more flexibly by allowing [event delegation](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_delegation).
+
+```ts
+// ✅ -- GOOD
+this.dispatchEvent(new Event('change', { bubbles: true }));
+```
+
+```ts
+// ❌ -- BAD
+this.dispatchEvent(new Event('change');
+```
+
+There are some exceptions such as Modal, whose "close" event doesn't bubble similar to `<dialog>`.
+When deciding to bubble, consider whether the native equivalent bubbles.
 
 ## Questions
 

--- a/packages/components/src/accordion.stories.ts
+++ b/packages/components/src/accordion.stories.ts
@@ -14,23 +14,37 @@ const meta: Meta = {
       description: {
         component: 'An accordion component with optional slots for icons.',
       },
+      story: {
+        autoplay: true,
+      },
     },
   },
-  render: (arguments_, context) => {
-    context.canvasElement.addEventListener('toggle', (event) => {
-      if (event instanceof CustomEvent) {
-        addons.getChannel().emit(STORY_ARGS_UPDATED, {
-          storyId: context.id,
-          args: {
-            ...arguments_,
-            // Our events are untyped at the moment. So `detail` is typed as `any`.
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            open: event.detail.newState === 'open',
-          },
-        });
-      }
+  play(context) {
+    // eslint-disable-next-line no-underscore-dangle
+    let arguments_: Meta['args'] = context.args;
+
+    addons.getChannel().addListener('storyArgsUpdated', (event) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      arguments_ = event.args as typeof context.args;
     });
 
+    context.canvasElement
+      .querySelector('cs-accordion')
+      ?.addEventListener('toggle', (event) => {
+        if (event instanceof CustomEvent) {
+          addons.getChannel().emit(STORY_ARGS_UPDATED, {
+            storyId: context.id,
+            args: {
+              ...arguments_,
+              // Our events are untyped at the moment. So `detail` is typed as `any`.
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              open: event.detail.newState === 'open',
+            },
+          });
+        }
+      });
+  },
+  render: (arguments_) => {
     return html`
       <cs-accordion label=${arguments_.label} ?open=${arguments_.open}
         >${arguments_['slot="default"']}</cs-accordion
@@ -101,21 +115,7 @@ export const Default: StoryObj = {};
 
 export const WithPrefixIcon: StoryObj = {
   name: 'Default (With Prefix Icon)',
-  render: (arguments_, context) => {
-    context.canvasElement.addEventListener('toggle', (event) => {
-      if (event instanceof CustomEvent) {
-        addons.getChannel().emit(STORY_ARGS_UPDATED, {
-          storyId: context.id,
-          args: {
-            ...arguments_,
-            // Our events are untyped at the moment. So `detail` is typed as `any`.
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            open: event.detail.newState === 'open',
-          },
-        });
-      }
-    });
-
+  render: (arguments_) => {
     return html` <cs-accordion
       label=${arguments_.label}
       ?open=${arguments_.open}
@@ -129,21 +129,7 @@ export const WithPrefixIcon: StoryObj = {
 
 export const WithSuffix: StoryObj = {
   name: 'Default (With Suffix Icons)',
-  render: (arguments_, context) => {
-    context.canvasElement.addEventListener('toggle', (event) => {
-      if (event instanceof CustomEvent) {
-        addons.getChannel().emit(STORY_ARGS_UPDATED, {
-          storyId: context.id,
-          args: {
-            ...arguments_,
-            // Our events are untyped at the moment. So `detail` is typed as `any`.
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            open: event.detail.newState === 'open',
-          },
-        });
-      }
-    });
-
+  render: (arguments_) => {
     return html` <cs-accordion
       label=${arguments_.label}
       ?open=${arguments_.open}
@@ -158,21 +144,7 @@ export const WithSuffix: StoryObj = {
 
 export const WithPrefixAndSuffix: StoryObj = {
   name: 'Default (With Prefix & Suffix Icons)',
-  render: (arguments_, context) => {
-    context.canvasElement.addEventListener('toggle', (event) => {
-      if (event instanceof CustomEvent) {
-        addons.getChannel().emit(STORY_ARGS_UPDATED, {
-          storyId: context.id,
-          args: {
-            ...arguments_,
-            // Our events are untyped at the moment. So `detail` is typed as `any`.
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            open: event.detail.newState === 'open',
-          },
-        });
-      }
-    });
-
+  render: (arguments_) => {
     return html` <cs-accordion
       label=${arguments_.label}
       ?open=${arguments_.open}

--- a/packages/components/src/accordion.ts
+++ b/packages/components/src/accordion.ts
@@ -161,7 +161,6 @@ export default class CsAccordion extends LitElement {
 
         this.dispatchEvent(
           new CustomEvent('toggle', {
-            bubbles: true,
             detail: {
               newState: 'open',
               oldState: 'closed',
@@ -194,7 +193,6 @@ export default class CsAccordion extends LitElement {
 
           this.dispatchEvent(
             new CustomEvent('toggle', {
-              bubbles: true,
               detail: {
                 newState: 'closed',
                 oldState: 'open',

--- a/packages/components/src/drawer.ts
+++ b/packages/components/src/drawer.ts
@@ -44,7 +44,7 @@ export default class CsDrawer extends LitElement {
 
         this.currentState = 'closed';
 
-        this.dispatchEvent(new Event('close', { bubbles: false }));
+        this.dispatchEvent(new Event('close'));
 
         document.documentElement.classList.remove('glide-lock-scroll');
       },
@@ -81,7 +81,7 @@ export default class CsDrawer extends LitElement {
         // This ensures our dialog behaves as expected for screenreaders.
         this.#dialogElementRef?.value?.focus();
 
-        this.dispatchEvent(new Event('open', { bubbles: false }));
+        this.dispatchEvent(new Event('open'));
 
         document.documentElement.classList.remove('glide-lock-scroll');
       },

--- a/packages/components/src/input.ts
+++ b/packages/components/src/input.ts
@@ -462,7 +462,7 @@ export default class CsInput extends LitElement {
 
   #onClearClick(event: MouseEvent) {
     this.value = '';
-    this.dispatchEvent(new Event('clear'));
+    this.dispatchEvent(new Event('clear', { bubbles: true }));
     this.#inputElement?.focus();
     this.#setValidityToInputValidity();
 

--- a/packages/components/src/modal.ts
+++ b/packages/components/src/modal.ts
@@ -67,7 +67,7 @@ export default class CsModal extends LitElement {
     }
 
     document.documentElement.classList.remove('glide-lock-scroll');
-    this.dispatchEvent(new Event('close', { bubbles: false }));
+    this.dispatchEvent(new Event('close'));
     this.#componentElementRef.value?.close();
   }
 
@@ -273,7 +273,7 @@ export default class CsModal extends LitElement {
 
       if (!isClickInsideDialog) {
         document.documentElement.classList.remove('glide-lock-scroll');
-        this.dispatchEvent(new Event('close', { bubbles: false }));
+        this.dispatchEvent(new Event('close'));
         this.#componentElementRef.value?.close();
       }
     }
@@ -281,7 +281,7 @@ export default class CsModal extends LitElement {
 
   #onCloseButtonClick() {
     document.documentElement.classList.remove('glide-lock-scroll');
-    this.dispatchEvent(new Event('close', { bubbles: false }));
+    this.dispatchEvent(new Event('close'));
     this.#componentElementRef.value?.close();
   }
 
@@ -291,7 +291,7 @@ export default class CsModal extends LitElement {
     }
 
     document.documentElement.classList.remove('glide-lock-scroll');
-    this.dispatchEvent(new Event('close', { bubbles: false }));
+    this.dispatchEvent(new Event('close'));
     this.#componentElementRef.value?.close();
   }
 }

--- a/packages/components/src/tab.group.ts
+++ b/packages/components/src/tab.group.ts
@@ -207,6 +207,7 @@ export default class CsTabGroup extends LitElement {
 
     this.dispatchEvent(
       new CustomEvent('tab-show', {
+        bubbles: true,
         detail: {
           panel: tab.panel,
         },


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Let's consistently bubble our events and bubble by default:

- Bubbling is probably what consumers expect because most events bubble. For example, "click", "change", "keydown", and "input" all bubble.

- Bubbling also lets consumers use our components more flexibly. Imagine, for example, that a consumer has the followup markup:

    ```html
    <div>
      <cs-input clearable>
      <cs-input clearable>
    </div>
    ```

    Most consumers will probably add a listener to `<cs-input>`. But some may want to add a listener to the surrounding `<div>` to capture with a single listener every event or every event of a certain type. 
    
    However, Input's "clear" listener, for example, doesn't bubble and so a listener on the `<div>` won't work, though a "change" or "input" one will.

Events constructed from `Event` or `Custom Event` don't bubble by default. We'll have to add `{ bubbles: true }` to each of them. I've done that that here. I suppose this also warrants a new lint rule, which I'd be happy to make a ticket for.

An obvious exception to bubbling is the "close" event of Dialog. It's not clear to me why it doesn't. I went digging through the W3C mailing list and elsewhere. I couldn't find a reason. 

Whatever the reason, I've left our Modal alone so it matches `<dialog>`. I also removed `bubbles: true` (which I added) from Accordion. The native "toggle" on `<details>` event doesn't bubble.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

Not much to test. Feel free to add a "clear" listener to Input's container and ensure the listener's callback is called.

## 📸 Images/Videos of Functionality

N/A
