### PR TITLE
Reorder story arguments

### DIFF
--- a/packages/components/src/accordion.stories.ts
+++ b/packages/components/src/accordion.stories.ts
@@ -53,8 +53,8 @@ const meta: Meta = {
   },
   args: {
     label: 'Accordion',
-    open: false,
     'slot="default"': 'Inner content',
+    open: false,
   },
   argTypes: {
     label: {

--- a/packages/components/src/button-group.stories.ts
+++ b/packages/components/src/button-group.stories.ts
@@ -28,11 +28,12 @@ const meta: Meta = {
   `,
   args: {
     label: 'Group label',
+    'slot="default"': '',
     variant: '',
     orientation: 'horizontal',
   },
   argTypes: {
-    ['slot="default"']: {
+    'slot="default"': {
       table: {
         type: { summary: '<cs-button-group-button>' },
       },

--- a/packages/components/src/button.stories.ts
+++ b/packages/components/src/button.stories.ts
@@ -22,10 +22,10 @@ const meta: Meta = {
     >
   `,
   args: {
+    'slot="default"': 'Button',
     disabled: false,
     variant: 'primary',
     size: 'large',
-    'slot="default"': 'Button',
   },
   argTypes: {
     variant: {

--- a/packages/components/src/checkbox-group.stories.ts
+++ b/packages/components/src/checkbox-group.stories.ts
@@ -18,9 +18,9 @@ const meta: Meta = {
     },
   },
   args: {
-    ['slot="description"']: 'Description',
-    disabled: false,
     label: 'Label',
+    'slot="description"': 'Description',
+    disabled: false,
     name: 'name',
     required: false,
     value: '',
@@ -128,7 +128,7 @@ export const Vertical: StoryObj = {};
 
 export const VerticalWithToolip: StoryObj = {
   args: {
-    ['slot="tooltip"']: 'Tooltip',
+    'slot="tooltip"': 'Tooltip',
     orientation: 'vertical',
   },
   name: 'Vertical (With Tooltip)',

--- a/packages/components/src/checkbox.stories.ts
+++ b/packages/components/src/checkbox.stories.ts
@@ -19,12 +19,12 @@ const meta: Meta = {
     },
   },
   args: {
-    ['slot="tooltip"']: '',
-    ['slot="description"']: 'Description',
+    label: 'Label',
+    'slot="tooltip"': '',
+    'slot="description"': 'Description',
     checked: false,
     disabled: false,
     indeterminate: false,
-    label: 'Label',
     name: 'name',
     orientation: 'horizontal',
     summary: 'Summary',
@@ -193,7 +193,7 @@ export const Horizontal: StoryObj = {};
 
 export const HorizontalWithTooltip: StoryObj = {
   args: {
-    ['slot="tooltip"']: 'Tooltip',
+    'slot="tooltip"': 'Tooltip',
   },
   name: 'Horizontal (With Tooltip)',
 };
@@ -213,7 +213,7 @@ export const Vertical: StoryObj = {
 
 export const VerticalWithToolip: StoryObj = {
   args: {
-    ['slot="tooltip"']: 'Tooltip',
+    'slot="tooltip"': 'Tooltip',
     orientation: 'vertical',
   },
   name: 'Vertical (With Tooltip)',

--- a/packages/components/src/dropdown.stories.ts
+++ b/packages/components/src/dropdown.stories.ts
@@ -23,7 +23,7 @@ const meta: Meta = {
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
-    ['slot="default"']: '',
+    'slot="default"': '',
     'hide-label': false,
     disabled: false,
     open: false,
@@ -32,11 +32,11 @@ const meta: Meta = {
     required: false,
     size: 'large',
     value: '',
-    ['slot="tooltip"']: '',
-    ['slot="description"']: 'Description',
+    'slot="tooltip"': '',
+    'slot="description"': 'Description',
   },
   argTypes: {
-    ['slot="default"']: {
+    'slot="default"': {
       table: {
         type: { summary: 'CsDropdownOption' },
       },
@@ -290,7 +290,7 @@ export const SingleSelectionHorizontalWithIcon: StoryObj = {
 
 export const SingleSelectionHorizontalWithTooltip: StoryObj = {
   args: {
-    ['slot="tooltip"']: 'Tooltip',
+    'slot="tooltip"': 'Tooltip',
   },
   name: 'Single Selection (Horizontal With Tooltip)',
 };
@@ -362,7 +362,7 @@ export const SingleSelectionVerticalWithIcon: StoryObj = {
 
 export const SingleSelectionVerticalWithTooltip: StoryObj = {
   args: {
-    ['slot="tooltip"']: 'Tooltip',
+    'slot="tooltip"': 'Tooltip',
     orientation: 'vertical',
   },
   name: 'Single Selection (Vertical With Tooltip)',

--- a/packages/components/src/icon-button.stories.ts
+++ b/packages/components/src/icon-button.stories.ts
@@ -23,8 +23,9 @@ const meta: Meta = {
     </cs-icon-button>
   `,
   args: {
-    disabled: false,
     label: 'For screenreaders',
+    'slot="default"': '',
+    disabled: false,
   },
   argTypes: {
     'slot="default"': {

--- a/packages/components/src/input.stories.ts
+++ b/packages/components/src/input.stories.ts
@@ -16,18 +16,19 @@ const meta: Meta = {
     },
   },
   args: {
+    label: 'Label',
     type: 'text',
     value: 'Value',
     placeholder: 'Placeholder...',
     clearable: false,
-    label: 'Label',
     'hide-label': false,
     'label-position': 'left',
     required: false,
-    ['slot="tooltip"']: '',
-    ['slot="description"']: 'Description',
+    'slot="tooltip"': '',
+    'slot="description"': 'Description',
     readonly: false,
     disabled: false,
+    name: 'name',
   },
   play(context) {
     const input = context.canvasElement.querySelector('cs-input');
@@ -89,16 +90,15 @@ const meta: Meta = {
     value: {
       control: 'text',
       table: {
-        defaultValue: { summary: '' },
         type: { summary: 'string' },
       },
     },
     label: {
       control: 'text',
       table: {
-        defaultValue: { summary: 'Label' },
         type: { summary: 'string' },
       },
+      type: { name: 'string', required: true },
     },
     'hide-label': {
       control: 'boolean',
@@ -144,13 +144,13 @@ const meta: Meta = {
         type: { summary: 'boolean' },
       },
     },
-    ['slot="tooltip"']: {
+    'slot="tooltip"': {
       control: { type: 'text' },
       table: {
         type: { summary: 'string' },
       },
     },
-    ['slot="description"']: {
+    'slot="description"': {
       control: { type: 'text' },
       table: {
         type: { summary: 'string | html' },
@@ -313,7 +313,7 @@ export const SearchType: StoryObj = {
 export const MaxCharacterCount: StoryObj = {
   args: {
     maxCharacterCount: 20,
-    ['slot="description"']: undefined,
+    'slot="description"': undefined,
   },
 };
 
@@ -321,13 +321,13 @@ export const MaxCharacterCountAndDescription: StoryObj = {
   name: 'Max Character Count (With Description)',
   args: {
     maxCharacterCount: 20,
-    ['slot="description"']:
+    'slot="description"':
       'Description here lives alongside max character count',
   },
 };
 
 export const Tooltip: StoryObj = {
   args: {
-    ['slot="tooltip"']: 'Tooltip',
+    'slot="tooltip"': 'Tooltip',
   },
 };

--- a/packages/components/src/menu.stories.ts
+++ b/packages/components/src/menu.stories.ts
@@ -22,18 +22,20 @@ const meta: Meta = {
     },
   },
   args: {
+    'slot="default"': '',
+    'slot="target"': '',
     open: false,
     placement: 'bottom-start',
     size: 'large',
   },
   argTypes: {
-    ['slot="default"']: {
+    'slot="default"': {
       table: {
         type: { summary: 'CsMenuLink | CsMenuButton' },
       },
       type: { name: 'function', required: true },
     },
-    ['slot="target"']: {
+    'slot="target"': {
       table: {
         type: { summary: 'Element', detail: 'Any focusable element.' },
       },

--- a/packages/components/src/modal.stories.ts
+++ b/packages/components/src/modal.stories.ts
@@ -43,8 +43,8 @@ const meta: Meta = {
   `,
   args: {
     label: 'Basic Modal',
-    'show-back-button': false,
     'slot="default"': 'Modal content area',
+    'show-back-button': false,
   },
   argTypes: {
     label: {

--- a/packages/components/src/textarea.stories.ts
+++ b/packages/components/src/textarea.stories.ts
@@ -24,8 +24,8 @@ const meta: Meta = {
     }
   },
   args: {
-    value: 'Value',
     label: 'Label',
+    value: 'Value',
     placeholder: 'Placeholder...',
     'hide-label': false,
     'label-position': 'left',
@@ -36,13 +36,19 @@ const meta: Meta = {
     'max-character-count': '',
     'slot="description"': 'Description',
     name: 'name',
-    ['slot="tooltip"']: '',
+    'slot="tooltip"': '',
   },
   argTypes: {
+    label: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+      },
+      type: { name: 'string', required: true },
+    },
     value: {
       control: 'text',
       table: {
-        defaultValue: { summary: '' },
         type: { summary: 'string' },
       },
     },
@@ -103,13 +109,13 @@ const meta: Meta = {
         type: { summary: 'number' },
       },
     },
-    ['slot="tooltip"']: {
+    'slot="tooltip"': {
       control: { type: 'text' },
       table: {
         type: { summary: 'string' },
       },
     },
-    ['slot="description"']: {
+    'slot="description"': {
       control: { type: 'text' },
       table: {
         type: { summary: 'string | html' },
@@ -118,7 +124,6 @@ const meta: Meta = {
     name: {
       control: 'text',
       table: {
-        defaultValue: { summary: '' },
         type: { summary: 'string' },
       },
     },
@@ -230,6 +235,6 @@ export const WithError: StoryObj = {
 
 export const Tooltip: StoryObj = {
   args: {
-    ['slot="tooltip"']: 'Tooltip',
+    'slot="tooltip"': 'Tooltip',
   },
 };

--- a/packages/components/src/toggle.stories.ts
+++ b/packages/components/src/toggle.stories.ts
@@ -16,11 +16,11 @@ const meta: Meta = {
     },
   },
   args: {
-    ['slot="description"']: 'Description',
-    ['slot="tooltip"']: '',
+    label: 'Label',
+    'slot="description"': 'Description',
+    'slot="tooltip"': '',
     checked: false,
     disabled: false,
-    label: 'Label',
     orientation: 'horizontal',
     summary: 'Summary',
   },
@@ -110,7 +110,7 @@ export const Horizontal: StoryObj = {};
 
 export const HorizontalWithTooltip: StoryObj = {
   args: {
-    ['slot="tooltip"']: 'Tooltip',
+    'slot="tooltip"': 'Tooltip',
   },
   name: 'Horizontal (With Tooltip)',
 };
@@ -123,7 +123,7 @@ export const Vertical: StoryObj = {
 
 export const VerticalWithToolip: StoryObj = {
   args: {
-    ['slot="tooltip"']: 'Tooltip',
+    'slot="tooltip"': 'Tooltip',
     orientation: 'vertical',
   },
   name: 'Vertical (With Tooltip)',

--- a/packages/components/src/tooltip.stories.ts
+++ b/packages/components/src/tooltip.stories.ts
@@ -38,7 +38,11 @@ const meta: Meta = {
       options: ['bottom', 'left', 'right', 'top'],
       table: {
         defaultValue: { summary: '"bottom"' },
-        type: { summary: '"bottom" | "left" | "right" | "top"' },
+        type: {
+          summary: '"bottom" | "left" | "right" | "top"',
+          detail:
+            '// Tooltip will try to move itself to the opposite of this value if it results in an overflow.\n// For example, if "bottom" results in an overflow Tooltip will try "top" but not "right" or "left".',
+        },
       },
     },
   },

--- a/packages/components/src/tree.stories.ts
+++ b/packages/components/src/tree.stories.ts
@@ -22,8 +22,9 @@ const meta: Meta = {
     },
   },
   args: {
-    '<cs-tree-item>.selected': false,
+    'slot="default"': '',
     '<cs-tree-item>.label': 'Branch',
+    '<cs-tree-item>.selected': false,
   },
   play(context) {
     const links = context.canvasElement.querySelectorAll('cs-menu-link');
@@ -56,7 +57,7 @@ const meta: Meta = {
     </div>
   `,
   argTypes: {
-    ['slot="default"']: {
+    'slot="default"': {
       table: {
         type: { summary: 'CsTreeItem' },
       },


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

I learned while working on [#139](https://github.com/CrowdStrike/glide-core/pull/139#discussion_r1607315901) that the order of `args` not `argTypes` is what determines the order the controls are rendered. There's probably some discussion to be had offline about how we should order our controls. But I figure that's out of scope for now. This PR simply moves required arguments to the top.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

A quick poke around Storybook should do. Make sure required attributes come first in each component's controls table.

## 📸 Images/Videos of Functionality

### Before

<img width="1036" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/3d6bf696-f2da-41b3-aae6-9280ff9a9185">

### After

<img width="1026" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/7e7aaee1-649b-4ab7-833f-58c4bf2b33c9">

