### PR TITLE
Use `owSlot` and `owSlotType` consistently

### DIFF
--- a/packages/components/src/checkbox-group.test.basics.ts
+++ b/packages/components/src/checkbox-group.test.basics.ts
@@ -1,6 +1,7 @@
 import './checkbox.js';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import CsCheckboxGroup from './checkbox-group.js';
+import sinon from 'sinon';
 
 CsCheckboxGroup.shadowRootOptions.mode = 'open';
 
@@ -157,4 +158,18 @@ it('exposes standard form control properties and methods', async () => {
   expect(component.willValidate).to.be.true;
   expect(component.checkValidity).to.be.a('function');
   expect(component.reportValidity).to.be.a('function');
+});
+
+it('throws if it does not have a default slot', async () => {
+  const spy = sinon.spy();
+
+  try {
+    await fixture<CsCheckboxGroup>(
+      html`<cs-checkbox-group label="Checkbox Group"></cs-checkbox-group> `,
+    );
+  } catch {
+    spy();
+  }
+
+  expect(spy.called).to.be.true;
 });

--- a/packages/components/src/checkbox-group.ts
+++ b/packages/components/src/checkbox-group.ts
@@ -305,6 +305,9 @@ export default class CsCheckboxGroup extends LitElement {
   }
 
   #onDefaultSlotChange() {
+    owSlot(this.#defaultSlotElementRef.value);
+    owSlotType(this.#defaultSlotElementRef.value, [CsCheckbox]);
+
     this.value = this.#checkboxes
       .filter(({ checked, disabled }) => checked && !disabled)
       .map(({ value }) => value)

--- a/packages/components/src/dropdown.test.basics.ts
+++ b/packages/components/src/dropdown.test.basics.ts
@@ -155,11 +155,7 @@ it('throws if it does not have a default slot', async () => {
 
   try {
     await fixture<CsDropdown>(
-      html`<cs-dropdown
-        label="Label"
-        placeholder="Placeholder"
-        name="name"
-      ></cs-dropdown>`,
+      html`<cs-dropdown label="Label" placeholder="Placeholder"></cs-dropdown>`,
     );
   } catch {
     spy();

--- a/packages/components/src/menu.test.basics.ts
+++ b/packages/components/src/menu.test.basics.ts
@@ -71,9 +71,7 @@ it('throws if it does not have a default slot', async () => {
 
   try {
     await fixture<CsMenu>(
-      html`<cs-menu>
-        <button slot="target">Target</button>
-      </cs-menu>`,
+      html`<cs-menu><button slot="target">Target</button></cs-menu>`,
     );
   } catch {
     spy();

--- a/packages/components/src/menu.ts
+++ b/packages/components/src/menu.ts
@@ -135,7 +135,11 @@ export default class CsMenu extends LitElement {
           @keydown=${this.#onTargetContainerKeydown}
           id="target-container"
         >
-          <slot name="target" ${ref(this.#targetSlotElementRef)}></slot>
+          <slot
+            name="target"
+            @slotchange=${this.#onTargetSlotChange}
+            ${ref(this.#targetSlotElementRef)}
+          ></slot>
         </div>
 
         <div
@@ -153,6 +157,7 @@ export default class CsMenu extends LitElement {
             @click=${this.#onOptionsClick}
             @keydown=${this.#onOptionsKeydown}
             @mouseover=${this.#onOptionsMouseover}
+            @slotchange=${this.#onDefaultSlotChange}
             ${ref(this.#defaultSlotElementRef)}
           ></slot>
         </div>
@@ -195,13 +200,14 @@ export default class CsMenu extends LitElement {
     }
   }
 
-  get #optionElements() {
-    return (
-      this.#defaultSlotElementRef.value?.assignedElements({ flatten: true }) ??
-      []
-    ).filter((element): element is CsMenuLink | CsMenuButton => {
-      return element instanceof CsMenuLink || element instanceof CsMenuButton;
-    });
+  #onDefaultSlotChange() {
+    owSlot(this.#defaultSlotElementRef.value);
+
+    owSlotType(this.#defaultSlotElementRef.value, [
+      CsMenuButton,
+      CsMenuLink,
+      HTMLSlotElement,
+    ]);
   }
 
   #onOptionsClick() {
@@ -346,6 +352,19 @@ export default class CsMenu extends LitElement {
       this.open = true;
       this.#focusActiveOption();
     }
+  }
+
+  #onTargetSlotChange() {
+    owSlot(this.#targetSlotElementRef.value);
+  }
+
+  get #optionElements() {
+    return (
+      this.#defaultSlotElementRef.value?.assignedElements({ flatten: true }) ??
+      []
+    ).filter((element): element is CsMenuLink | CsMenuButton => {
+      return element instanceof CsMenuLink || element instanceof CsMenuButton;
+    });
   }
 
   #setUpFloatingUi() {

--- a/packages/components/src/tag.ts
+++ b/packages/components/src/tag.ts
@@ -51,8 +51,17 @@ export default class CsTag extends LitElement {
         })}
         ${ref(this.#containerElementRef)}
       >
-        <slot name="prefix" ${ref(this.#prefixSlotElementRef)}></slot>
-        <slot ${ref(this.#defaultSlotElementRef)}></slot>
+        <slot
+          name="prefix"
+          @slotchange=${this.#onPrefixSlotChange}
+          ${ref(this.#prefixSlotElementRef)}
+        ></slot>
+
+        <slot
+          @slotchange=${this.#onDefaultSlotChange}
+          ${ref(this.#defaultSlotElementRef)}
+        ></slot>
+
         ${when(
           this.removableLabel,
           () =>
@@ -90,9 +99,9 @@ export default class CsTag extends LitElement {
 
   #defaultSlotElementRef = createRef<HTMLSlotElement>();
 
-  #delayToRemove = 200;
-
   #prefixSlotElementRef = createRef<HTMLSlotElement>();
+
+  #removalDelay = 200;
 
   #onClick = () => {
     // The promise delays removing the tag's content from the DOM so that
@@ -100,11 +109,19 @@ export default class CsTag extends LitElement {
     new Promise(() =>
       setTimeout(() => {
         this.remove();
-      }, this.#delayToRemove),
+      }, this.#removalDelay),
     );
 
     this.#containerElementRef.value?.classList.toggle('activate');
     this.#containerElementRef.value?.classList.toggle('deactivate');
-    this.dispatchEvent(new CustomEvent('remove', { composed: true }));
+    this.dispatchEvent(new CustomEvent('remove'));
   };
+
+  #onDefaultSlotChange() {
+    owSlot(this.#defaultSlotElementRef.value);
+  }
+
+  #onPrefixSlotChange() {
+    Boolean(this.removableLabel) && owSlot(this.#prefixSlotElementRef.value);
+  }
 }

--- a/packages/components/src/tree.item.menu.test.basics.ts
+++ b/packages/components/src/tree.item.menu.test.basics.ts
@@ -1,0 +1,21 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import TreeItemMenu from './tree.item.menu.js';
+import sinon from 'sinon';
+
+it('registers', async () => {
+  expect(window.customElements.get('cs-tree-item-menu')).to.equal(TreeItemMenu);
+});
+
+it('throws if it does not have a default slot', async () => {
+  const spy = sinon.spy();
+
+  try {
+    await fixture<TreeItemMenu>(html`
+      <cs-tree-item-menu slot="menu"></cs-tree-item-menu>
+    `);
+  } catch {
+    spy();
+  }
+
+  expect(spy.called).to.be.true;
+});

--- a/packages/components/src/tree.item.menu.ts
+++ b/packages/components/src/tree.item.menu.ts
@@ -37,7 +37,10 @@ export default class CsTreeItemMenu extends LitElement {
   override render() {
     return html`
       <cs-menu class="component">
-        <slot ${ref(this.#defaultSlotElementRef)}></slot>
+        <slot
+          @slotchange=${this.#onDefaultSlotChange}
+          ${ref(this.#defaultSlotElementRef)}
+        ></slot>
 
         <cs-icon-button slot="target" variant="tertiary">
           <!-- 3-dot -->
@@ -65,4 +68,9 @@ export default class CsTreeItemMenu extends LitElement {
   }
 
   #defaultSlotElementRef = createRef<HTMLSlotElement>();
+
+  #onDefaultSlotChange() {
+    owSlot(this.#defaultSlotElementRef.value);
+    owSlotType(this.#defaultSlotElementRef.value, [CsMenuButton, CsMenuLink]);
+  }
 }

--- a/packages/components/src/tree.item.ts
+++ b/packages/components/src/tree.item.ts
@@ -9,7 +9,6 @@ import {
   state,
 } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-
 import { when } from 'lit/directives/when.js';
 import styles from './tree.item.styles.js';
 

--- a/packages/components/src/tree.test.basics.ts
+++ b/packages/components/src/tree.test.basics.ts
@@ -1,4 +1,5 @@
 import './tree.item.js';
+import './tree.item.menu.js';
 import './tree.js';
 import { assert, expect, fixture, html } from '@open-wc/testing';
 import CsMenu from './menu.js';
@@ -11,7 +12,11 @@ it('registers', async () => {
 });
 
 it('renders and sets default attributes', async () => {
-  const tree = await fixture<Tree>(html` <cs-tree></cs-tree> `);
+  const tree = await fixture<Tree>(html`
+    <cs-tree>
+      <cs-tree-item label="Child Item"></cs-tree-item>
+    </cs-tree>
+  `);
 
   expect(tree.selectedItem).to.equal(undefined);
 });

--- a/packages/components/src/tree.ts
+++ b/packages/components/src/tree.ts
@@ -1,5 +1,7 @@
 import { LitElement, html } from 'lit';
+import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, queryAssignedElements, state } from 'lit/decorators.js';
+import { owSlot, owSlotType } from './library/ow.js';
 import CsTreeItem from './tree.item.js';
 import styles from './tree.styles.js';
 
@@ -39,6 +41,11 @@ export default class CsTree extends LitElement {
     this.removeEventListener('focusout', this.#handleFocusOut);
   }
 
+  override firstUpdated() {
+    owSlot(this.#defaultSlotElementRef.value);
+    owSlotType(this.#defaultSlotElementRef.value, [CsTreeItem]);
+  }
+
   override render() {
     return html`<div
       class="component"
@@ -47,7 +54,10 @@ export default class CsTree extends LitElement {
       @click=${this.#handleClick}
       @keydown=${this.#handleKeydown}
     >
-      <slot></slot>
+      <slot
+        @slotchange=${this.#onDefaultSlotChange}
+        ${ref(this.#defaultSlotElementRef)}
+      ></slot>
     </div>`;
   }
 
@@ -79,6 +89,8 @@ export default class CsTree extends LitElement {
     this.addEventListener('focusin', this.#handleFocusIn);
     this.addEventListener('focusout', this.#handleFocusOut);
   }
+
+  #defaultSlotElementRef = createRef<HTMLSlotElement>();
 
   #focusItem(item: CsTreeItem | undefined | null) {
     item?.focus();
@@ -137,8 +149,8 @@ export default class CsTree extends LitElement {
   #handleFocusOut(event: FocusEvent) {
     const relatedTarget = event.relatedTarget as HTMLElement;
 
-    // If they've focused out of the tree,
-    // restore this tree's tabindex 0, so they can focus back in
+    // If they've focused out of the tree, restore this tree's tabindex 0,
+    // so they can focus back in.
     if (!relatedTarget || !this.contains(relatedTarget)) {
       this.privateTabIndex = 0;
       this.focusedItem = undefined;
@@ -214,5 +226,10 @@ export default class CsTree extends LitElement {
         this.selectItem(focusedItem);
       }
     }
+  }
+
+  #onDefaultSlotChange() {
+    owSlot(this.#defaultSlotElementRef.value);
+    owSlotType(this.#defaultSlotElementRef.value, [CsTreeItem]);
   }
 }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

We do a pretty good job of calling `owSlot` and `owSlotType` on `firstUpdated`. But we don't do it across the board. Additionally, slots can change and we want call `owSlot` and `owSlotType` when they do.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A