### PR TITLE
Fix Tooltip not being announced by VoiceOver

### DIFF
--- a/.changeset/short-dragons-vanish.md
+++ b/.changeset/short-dragons-vanish.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Fix Tooltip not being announced by VoiceOver.

--- a/packages/components/src/tooltip.test.interactions.ts
+++ b/packages/components/src/tooltip.test.interactions.ts
@@ -14,7 +14,7 @@ it('is visible on "focusin"', async () => {
   );
 
   component.shadowRoot
-    ?.querySelector('[aria-describedby="tooltip"]')
+    ?.querySelector('[aria-labelledby="tooltip"]')
     ?.dispatchEvent(new FocusEvent('focusin'));
 
   await elementUpdated(component);
@@ -33,13 +33,13 @@ it('is hidden on "blur"', async () => {
   );
 
   component.shadowRoot
-    ?.querySelector('[aria-describedby="tooltip"]')
+    ?.querySelector('[aria-labelledby="tooltip"]')
     ?.dispatchEvent(new FocusEvent('focusin'));
 
   await elementUpdated(component);
 
   component.shadowRoot
-    ?.querySelector('[aria-describedby="tooltip"]')
+    ?.querySelector('[aria-labelledby="tooltip"]')
     ?.dispatchEvent(new FocusEvent('focusout'));
 
   await elementUpdated(component);
@@ -58,7 +58,7 @@ it('is hidden on Escape', async () => {
   );
 
   component.shadowRoot
-    ?.querySelector('[aria-describedby="tooltip"]')
+    ?.querySelector('[aria-labelledby="tooltip"]')
     ?.dispatchEvent(new FocusEvent('focusin'));
 
   await elementUpdated(component);
@@ -85,7 +85,7 @@ it('is visible on "mouseover"', async () => {
   );
 
   component.shadowRoot
-    ?.querySelector('[aria-describedby="tooltip"]')
+    ?.querySelector('[aria-labelledby="tooltip"]')
     ?.dispatchEvent(new MouseEvent('mouseover'));
 
   await elementUpdated(component);
@@ -104,13 +104,13 @@ it('is hidden on "mouseout"', async () => {
   );
 
   component.shadowRoot
-    ?.querySelector('[aria-describedby="tooltip"]')
+    ?.querySelector('[aria-labelledby="tooltip"]')
     ?.dispatchEvent(new MouseEvent('mouseover'));
 
   await elementUpdated(component);
 
   component.shadowRoot
-    ?.querySelector('[aria-describedby="tooltip"]')
+    ?.querySelector('[aria-labelledby="tooltip"]')
     ?.dispatchEvent(new MouseEvent('mouseout'));
 
   await elementUpdated(component);

--- a/packages/components/src/tooltip.ts
+++ b/packages/components/src/tooltip.ts
@@ -70,7 +70,7 @@ export default class CsTooltip extends LitElement {
     return html`
       <div class="component">
         <div
-          aria-describedby="tooltip"
+          aria-labelledby="tooltip"
           class="target"
           slot="target"
           @focusin=${this.#onFocusin}


### PR DESCRIPTION
## <!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Tooltip can't contain a `<button>` because consumers may need need to use Tooltip with various buttons. For example, Icon Button, which contains a `<button>`, can have a Tooltip. So can a disabled [Button](http://localhost:6006/?path=/docs/button--overview). If not for this, a `<button>` inside Tooltip plus `aria-describedby` would be the way to go.

What we can do instead is use `aria-labelledby`, which unlike `aria-describedby`, VoiceOver reads even if the thing being labeled isn't a form control. `aria-labelledby` isn't ideal because the tooltip of Tooltip is really a description—not a label. But `aria-labelledby` gives us the desired result and presents to screenreaders the same as would `aria-describedby`.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

Go to the Tooltip story and tab to the information icon with VoiceOver turned on. The tooltip should be read aloud. 

You'll note that "Tooltip: Tooltip CMD + K" is what is read. This is slightly awkward. But it's only because  "Tooltip" is in the default slot for the benefit of non-VoiceOver Storybook users. Consumers will use something other than "Tooltip" in the default slot.

## 📸 Images/Videos of Functionality

N/A