### PR TITLE
Account for Dropdown within a shadow DOM when reacting to "focusout"

### DIFF
--- a/.changeset/soft-swans-occur.md
+++ b/.changeset/soft-swans-occur.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Dropdown no longer opens then closes immediately when used in another web component.

--- a/packages/components/src/dropdown.option.ts
+++ b/packages/components/src/dropdown.option.ts
@@ -73,6 +73,12 @@ export default class CsDropdownOption extends LitElement {
   // An option is considered active when it's interacted with via keyboard or hovered.
   privateActive = false;
 
+  // Used by Dropdown as an alternative to `document.activeElement`. When Dropdown is
+  // itself in a shadow DOM and an element in that shadow DOM receives focus, `document.activeElement`
+  // will be set to the outer host. Thus, without this, Dropdown has no way of knowing whether it's
+  // an Option that has focus or another element within it that host.
+  privateIsFocused = false;
+
   override click() {
     this.selected = true;
   }
@@ -103,6 +109,8 @@ export default class CsDropdownOption extends LitElement {
       tabindex=${this.privateActive ? '0' : '-1'}
       role="option"
       @click=${this.#onClick}
+      @focusin=${this.#onFocusin}
+      @focusout=${this.#onFocusout}
       @keydown=${this.#onKeydown}
       ${ref(this.#componentElementRef)}
     >
@@ -136,6 +144,14 @@ export default class CsDropdownOption extends LitElement {
   #onClick() {
     this.selected = true;
     this.dispatchEvent(new Event('private-change', { bubbles: true }));
+  }
+
+  #onFocusin() {
+    this.privateIsFocused = true;
+  }
+
+  #onFocusout() {
+    this.privateIsFocused = false;
   }
 
   #onKeydown(event: KeyboardEvent) {

--- a/packages/components/src/dropdown.styles.ts
+++ b/packages/components/src/dropdown.styles.ts
@@ -24,6 +24,13 @@ export default [
       position: absolute;
       visibility: hidden;
 
+      /*
+        ".button-and-options" is relative and many Dropdowns may be stacked in a column.
+        This ensures that the ".options" of Dropdowns earlier in the column aren't obscured
+        by the ".button-and-options" that come after.
+      */
+      z-index: 1;
+
       &.large {
         --gap: var(--cs-spacing-sm);
         --padding-inline: var(--cs-spacing-sm);

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -338,7 +338,11 @@ export default class CsDropdown extends LitElement {
     // `document.body` receives focus immediately after focus is moved. So we
     // wait a frame to see where focus ultimately landed.
     setTimeout(() => {
-      if (!this.contains(document.activeElement)) {
+      const isOptionFocused = this.#optionElements.some(
+        ({ privateIsFocused }) => privateIsFocused,
+      );
+
+      if (!isOptionFocused) {
         this.open = false;
       }
     });

--- a/packages/components/src/textarea.stories.ts
+++ b/packages/components/src/textarea.stories.ts
@@ -64,7 +64,6 @@ const meta: Meta = {
     placeholder: {
       control: 'text',
       table: {
-        defaultValue: { summary: 'Placeholder' },
         type: { summary: 'string' },
       },
     },


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Dropdown closes when it loses focus and focus changes within Dropdown as it's interacted with. Focus moves from the button to the options when Dropdown is opened. And focus moves to each Option when it's hovered or arrowed to. 

Each change of focus creates a `focusout` event. Dropdown's `focusout` handler has [a guard](https://github.com/CrowdStrike/glide-core/pull/154/files#diff-c92939e55b2584bc9a3c1c390255082d93a0cde336bb47e3ba1fc4a72028cc1cL341) that checks `document.activeElement` to determine whether the event was caused by focus moving within Dropdown or out of it. 

Checking `document.activeElement` works well until Dropdown itself is used within shadow DOM. Then `document.activeElement` is set to the host of that shadow DOM instead of the host (`<cs-dropdown>`) of Dropdown. 

This PR changes the logic of Dropdown's `focusout` handler and adds a `privateIsFocused` property to Option to account for this.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

The only way I know to reproduce this is to locally `link` this branch to an application that uses Dropdown within a shadow DOM. The ticket has an example.

## 📸 Images/Videos of Functionality

N/A
