### PR TITLE
Use "not-allowed" cursor consistently with form controls when disabled

### DIFF
--- a/.changeset/perfect-falcons-warn.md
+++ b/.changeset/perfect-falcons-warn.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Use "not-allowed" cursor consistently with form controls when disabled.

--- a/packages/components/src/checkbox.styles.ts
+++ b/packages/components/src/checkbox.styles.ts
@@ -19,10 +19,6 @@ when browsers support them.
         .checkbox {
           border-color: var(--cs-status-error);
         }
-
-        .summary {
-          color: var(--cs-status-error);
-        }
       }
     }
 
@@ -68,6 +64,7 @@ when browsers support them.
 
     input {
       block-size: 100%;
+      cursor: inherit;
       inline-size: 100%;
       inset-block-start: 0;
       inset-inline-start: 0;
@@ -123,14 +120,6 @@ when browsers support them.
 
     .indeterminate-icon {
       display: none;
-    }
-
-    .summary {
-      font-family: var(--cs-body-sm-font-family);
-      font-size: var(--cs-body-sm-font-size);
-      font-style: var(--cs-body-sm-font-style);
-      font-weight: var(--cs-body-sm-font-weight);
-      line-height: 100%;
     }
   `,
 ];

--- a/packages/components/src/checkbox.ts
+++ b/packages/components/src/checkbox.ts
@@ -173,6 +173,7 @@ export default class CsCheckbox extends LitElement {
         () =>
           html`<cs-label
             orientation=${this.orientation}
+            ?disabled=${this.disabled}
             ?error=${this.#isShowValidationFeedback}
             ?required=${this.required}
           >
@@ -203,33 +204,27 @@ export default class CsCheckbox extends LitElement {
               inconsistent with how other form controls behave as their validity isn’t announced
               on screen readers by default before validation.
             -->
-            <div class="input-and-checkbox-and-summary" slot="control">
-              <div class="input-and-checkbox">
-                <input
-                  aria-describedby="summary description"
-                  aria-invalid=${this.#isShowValidationFeedback}
-                  data-test="input"
-                  id="input"
-                  type="checkbox"
-                  ?checked=${this.checked}
-                  ?disabled=${this.disabled}
-                  ?required=${this.required}
-                  @change=${this.#onInputChange}
-                  ${ref(this.#inputElementRef)}
-                />
+            <div class="input-and-checkbox" slot="control">
+              <input
+                aria-describedby="summary description"
+                aria-invalid=${this.#isShowValidationFeedback}
+                data-test="input"
+                id="input"
+                type="checkbox"
+                ?checked=${this.checked}
+                ?disabled=${this.disabled}
+                ?required=${this.required}
+                @change=${this.#onInputChange}
+                ${ref(this.#inputElementRef)}
+              />
 
-                <div class="checkbox">
-                  <div class="checked-icon">${checkedIcon}</div>
-                  ${indeterminateIcon}
-                </div>
+              <div class="checkbox">
+                <div class="checked-icon">${checkedIcon}</div>
+                ${indeterminateIcon}
               </div>
-
-              ${when(
-                this.summary,
-                () =>
-                  html`<div class="summary" id="summary">${this.summary}</div>`,
-              )}
             </div>
+
+            <div id="summary" slot="summary">${this.summary}</div>
 
             <slot id="description" name="description" slot="description"></slot>
           </cs-label>`,

--- a/packages/components/src/dropdown.styles.ts
+++ b/packages/components/src/dropdown.styles.ts
@@ -66,6 +66,7 @@ export default [
       border: 1px solid var(--cs-border-base-lighter);
       border-radius: var(--cs-spacing-xs);
       color: var(--cs-text-body-1);
+      cursor: inherit;
       display: flex;
       font-family: var(--cs-body-sm-font-family);
       font-size: var(--cs-body-sm-font-size);

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -172,6 +172,7 @@ export default class CsDropdown extends LitElement {
     >
       <cs-label
         orientation=${this.orientation}
+        ?disabled=${this.disabled}
         ?error=${this.#isShowValidationFeedback}
         ?hide=${this.hideLabel}
         ?required=${this.required}

--- a/packages/components/src/input.styles.ts
+++ b/packages/components/src/input.styles.ts
@@ -31,6 +31,7 @@ export default css`
     border: 1px solid var(--cs-border-base-light);
     border-radius: var(--cs-spacing-xs);
     box-sizing: border-box;
+    color: var(--cs-text-body-1);
     display: flex;
     gap: var(--cs-spacing-xxs);
     line-height: var(--cs-body-xs-line-height);
@@ -44,9 +45,24 @@ export default css`
       border-color: var(--cs-border-focus);
     }
 
+    /* we had to resort to an attribute selector because there may be a bug in chrome and safari
+    * with ':read-only'
+    * https://bugs.chromium.org/p/chromium/issues/detail?id=1519649
+    */
+    &.readonly {
+      border: 1px solid transparent;
+      padding-inline-start: 0;
+    }
+
+    &.disabled {
+      background-color: var(--cs-surface-base-gray-light);
+      color: var(--cs-text-tertiary-disabled);
+    }
+
     input {
       border: none;
-      color: var(--cs-text-body-1);
+      color: inherit;
+      cursor: inherit;
       font-family: var(--cs-font-sans);
       font-size: var(--cs-body-sm-font-size);
       font-weight: var(--cs-body-xs-font-weight);
@@ -66,24 +82,6 @@ export default css`
     .suffix {
       align-items: center;
       display: flex;
-    }
-
-    /* we had to resort to an attribute selector because there may be a bug in chrome and safari
-    * with ':read-only'
-    * https://bugs.chromium.org/p/chromium/issues/detail?id=1519649
-    */
-    &.readonly {
-      border: 1px solid transparent;
-      padding-inline-start: 0;
-    }
-
-    &.disabled {
-      background-color: var(--cs-surface-base-gray-light);
-      color: var(--cs-text-tertiary-disabled);
-    }
-
-    input:disabled {
-      cursor: not-allowed;
     }
   }
 

--- a/packages/components/src/input.ts
+++ b/packages/components/src/input.ts
@@ -176,6 +176,7 @@ export default class CsInput extends LitElement {
     return html`
       <cs-label
         orientation=${this.orientation}
+        ?disabled=${this.disabled}
         ?error=${this.#isShowValidationFeedback ||
         this.#isMaxCharacterCountExceeded}
         ?hide=${this.hideLabel}

--- a/packages/components/src/label.styles.ts
+++ b/packages/components/src/label.styles.ts
@@ -86,6 +86,10 @@ make it difficult to center vertically with the label.
       line-height: 100%;
       user-select: none;
 
+      &.disabled ::slotted(*) {
+        cursor: not-allowed;
+      }
+
       &.horizontal {
         line-height: 100%;
       }
@@ -99,11 +103,32 @@ make it difficult to center vertically with the label.
       color: var(--cs-status-error);
     }
 
+    .control-and-summary {
+      align-items: center;
+      display: flex;
+      gap: var(--cs-spacing-sm);
+    }
+
     .control {
       display: block;
 
+      &.disabled::slotted(*) {
+        cursor: not-allowed;
+      }
+
       &.vertical:not(.hidden-label) {
         margin-block-start: var(--cs-spacing-xxs);
+      }
+    }
+
+    .summary {
+      font-family: var(--cs-body-sm-font-family);
+      font-size: var(--cs-body-sm-font-size);
+      font-style: var(--cs-body-sm-font-style);
+      font-weight: var(--cs-body-sm-font-weight);
+
+      &.error {
+        color: var(--cs-status-error);
       }
     }
 

--- a/packages/components/src/label.ts
+++ b/packages/components/src/label.ts
@@ -20,6 +20,7 @@ declare global {
  *
  * @slot - The label.
  * @slot control - The control with which the label is associated.
+ * @slot summary - Additional information or context.
  * @slot description - Additional information or context.
  * @slot tooltip - Content for the tooltip.
  */
@@ -31,6 +32,9 @@ export default class CsLabel extends LitElement {
   };
 
   static override styles = styles;
+
+  @property({ reflect: true, type: Boolean })
+  disabled = false;
 
   @property({ reflect: true, type: Boolean })
   error = false;
@@ -89,7 +93,13 @@ export default class CsLabel extends LitElement {
             ></slot>
           </cs-tooltip>
 
-          <div class="label" data-test="label">
+          <div
+            class=${classMap({
+              label: true,
+              disabled: this.disabled,
+            })}
+            data-test="label"
+          >
             <slot
               @slotchange=${this.#onLabelSlotChange}
               ${ref(this.#labelSlotElementRef)}
@@ -102,17 +112,30 @@ export default class CsLabel extends LitElement {
         </div>
       </div>
 
-      <slot
-        class=${classMap({
-          control: true,
-          error: this.error,
-          vertical: this.orientation === 'vertical',
-          'hidden-label': this.hide,
-        })}
-        name="control"
-        @slotchange=${this.#onControlSlotChange}
-        ${ref(this.#controlSlotElementRef)}
-      ></slot>
+      <div class="control-and-summary">
+        <slot
+          class=${classMap({
+            control: true,
+            error: this.error,
+            disabled: this.disabled,
+            vertical: this.orientation === 'vertical',
+            'hidden-label': this.hide,
+          })}
+          name="control"
+          @slotchange=${this.#onControlSlotChange}
+          ${ref(this.#controlSlotElementRef)}
+        ></slot>
+
+        <slot
+          class=${classMap({
+            summary: true,
+            error: this.error,
+          })}
+          name="summary"
+          @slotchange=${this.#onSummarySlotChange}
+          ${ref(this.#summarySlotElementRef)}
+        ></slot>
+      </div>
 
       <slot
         class=${classMap({
@@ -133,6 +156,9 @@ export default class CsLabel extends LitElement {
   private hasDescriptionSlot = false;
 
   @state()
+  private hasSummarySlot = false;
+
+  @state()
   private hasTooltipSlot = false;
 
   #controlSlotElementRef = createRef<HTMLSlotElement>();
@@ -140,6 +166,8 @@ export default class CsLabel extends LitElement {
   #descriptionSlotElementRef = createRef<HTMLSlotElement>();
 
   #labelSlotElementRef = createRef<HTMLSlotElement>();
+
+  #summarySlotElementRef = createRef<HTMLSlotElement>();
 
   #tooltipSlotElementRef = createRef<HTMLSlotElement>();
 
@@ -159,6 +187,14 @@ export default class CsLabel extends LitElement {
 
   #onLabelSlotChange() {
     owSlot(this.#labelSlotElementRef.value);
+  }
+
+  #onSummarySlotChange() {
+    const assignedNodes = this.#summarySlotElementRef.value?.assignedNodes({
+      flatten: true,
+    });
+
+    this.hasSummarySlot = Boolean(assignedNodes && assignedNodes.length > 0);
   }
 
   #onTooltipSlotChange() {

--- a/packages/components/src/textarea.styles.ts
+++ b/packages/components/src/textarea.styles.ts
@@ -16,6 +16,7 @@ export default css`
     border: 1px solid var(--cs-border-base-light);
     border-radius: 0.5rem;
     color: var(--cs-text-body-1);
+    cursor: inherit;
     display: block;
     flex-grow: 1;
     font-family: var(--cs-body-xs-font-family);
@@ -52,7 +53,6 @@ export default css`
       background-color: var(--cs-surface-base-gray-light);
       border: 0.0625rem solid var(--cs-border-base-light);
       color: var(--cs-text-tertiary-disabled);
-      cursor: not-allowed;
     }
   }
 

--- a/packages/components/src/textarea.ts
+++ b/packages/components/src/textarea.ts
@@ -119,6 +119,7 @@ export default class CsTextarea extends LitElement {
   override render() {
     return html`<cs-label
       orientation=${this.orientation}
+      ?disabled=${this.disabled}
       ?error=${this.#isShowValidationFeedback || this.#isInvalidCharacterLength}
       ?hide=${this.hideLabel}
       ?required=${this.required}

--- a/packages/components/src/toggle.styles.ts
+++ b/packages/components/src/toggle.styles.ts
@@ -74,18 +74,13 @@ Use the ":checked" pseudo class on the host and throughout when browsers support
 
     input {
       block-size: 100%;
+      cursor: inherit;
       inline-size: 100%;
       inset-block-start: 0;
       inset-inline-start: 0;
+      margin: 0;
       opacity: 0;
       position: absolute;
-    }
-
-    .summary {
-      font-family: var(--cs-body-sm-font-family);
-      font-size: var(--cs-body-sm-font-size);
-      font-style: var(--cs-body-sm-font-style);
-      font-weight: var(--cs-body-sm-font-weight);
     }
   `,
 ];

--- a/packages/components/src/toggle.ts
+++ b/packages/components/src/toggle.ts
@@ -2,7 +2,6 @@ import './label.js';
 import { LitElement, html } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
-import { when } from 'lit-html/directives/when.js';
 import styles from './toggle.styles.js';
 
 declare global {
@@ -57,56 +56,49 @@ export default class CsToggle extends LitElement {
 
   override render() {
     return html`<div data-test="component">
-      <cs-label orientation=${this.orientation}>
+      <cs-label orientation=${this.orientation} ?disabled=${this.disabled}>
         <slot name="tooltip" slot="tooltip"></slot>
         <label for="input"> ${this.label} </label>
 
-        <div class="toggle-and-input-and-summary" slot="control">
-          <div class="toggle-and-input">
-            <!--
-              The input is described by the summary and description but not the tooltip.
-              Screenreaders will come across the tooltip naturally as they move focus
-              through Toggle.
+        <div class="toggle-and-input" slot="control">
+          <!--
+            The input is described by the summary and description but not the tooltip.
+            Screenreaders will come across the tooltip naturally as they move focus
+            through Toggle.
 
-              Describing the input additionally by the tooltip is possible. We'd have to:
+            Describing the input additionally by the tooltip is possible. We'd have to:
 
-              1. Get the content of the tooltip slot.
-              2. Dump the content into a DIV.
-              3. Visually hide the DIV.
-              4. Describe the input using the DIV.
-              5. Hide the tooltip using "aria-hidden" so its content isn't doubly read.
+            1. Get the content of the tooltip slot.
+            2. Dump the content into a DIV.
+            3. Visually hide the DIV.
+            4. Describe the input using the DIV.
+            5. Hide the tooltip using "aria-hidden" so its content isn't doubly read.
 
-              Even then, the tooltip would still receive focus to support sighted keyboard
-              users. Screenreaders would likewise focus the tooltip. But its contents would
-              not be read aloud because they would be hidden. This would be pretty confusing.
+            Even then, the tooltip would still receive focus to support sighted keyboard
+            users. Screenreaders would likewise focus the tooltip. But its contents would
+            not be read aloud because they would be hidden. This would be pretty confusing.
 
-              —
+            —
 
-              An input gives us a few things that together make using one worthwhile:
+            An input gives us a few things that together make using one worthwhile:
 
-              - "change" and "input" events.
-              - Toggling checked using the spacebar.
-              - The ":checked" pseudo class.
-            -->
-            <input
-              aria-describedby="summary description"
-              data-test="input"
-              id="input"
-              type="checkbox"
-              ?checked=${this.checked}
-              ?disabled=${this.disabled}
-              @change=${this.#onInputChange}
-              ${ref(this.#inputElementRef)}
-            />
-          </div>
-
-          ${when(
-            this.summary,
-            () => html`
-              <div class="summary" id="summary">${this.summary}</div>
-            `,
-          )}
+            - "change" and "input" events.
+            - Toggling checked using the spacebar.
+            - The ":checked" pseudo class.
+          -->
+          <input
+            aria-describedby="summary description"
+            data-test="input"
+            id="input"
+            type="checkbox"
+            ?checked=${this.checked}
+            ?disabled=${this.disabled}
+            @change=${this.#onInputChange}
+            ${ref(this.#inputElementRef)}
+          />
         </div>
+
+        <div slot="summary" id="summary">${this.summary}</div>
 
         <slot
           class="description"


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- Adds a "not-allowed" cursor to Label when disabled. Design wants to use this cursor across the board whenever a form control is disabled. We currently use it in some cases but not others.
- Adds a "summary" slot to Label so the cursor can be applied to the control itself and not the control and summary. As a bonus, the summary is deduplicated.
- Removes the margin from Toggle's input for a more accurate click target.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- [ ] Checkbox and Toggle should have a summary and it should be announced by VoiceOver. 
- [ ] Every form control should have a "not-allowed" cursor on both its label and control when disabled. The exception is Checkbox Group, which I forgot to migrate to Label. Working on that now.

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A
