### PR TITLE
Account for Menu within a shadow DOM when reacting to "focusout"

### DIFF
--- a/.changeset/plenty-moose-walk.md
+++ b/.changeset/plenty-moose-walk.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Menu no longer opens then closes immediately when used in another web component.

--- a/packages/components/src/menu.button.ts
+++ b/packages/components/src/menu.button.ts
@@ -31,6 +31,13 @@ export default class CsMenuButton extends LitElement {
   // A button is considered active when it's interacted with via keyboard or hovered.
   privateActive = false;
 
+  // Used by Menu as an alternative to `document.activeElement`. When Menu is
+  // itself in a shadow DOM and an element in that shadow DOM receives focus,
+  // `document.activeElement` will be set to the outer host. Thus, without this,
+  // Menu has no way of knowing whether it's a Menu Button or Menu Link that has
+  // focus or another element within it that host.
+  privateIsFocused = false;
+
   // `shadowRoot.delegatesFocus` is preferred because it's more declarative.
   // But using it here triggers a focus-visible state whenever `this.focus` is
   // called. And we only want a focus outline when the `this.focus` is called
@@ -53,6 +60,8 @@ export default class CsMenuButton extends LitElement {
       role="menuitem"
       tabindex=${this.privateActive ? '0' : '-1'}
       type="button"
+      @focusin=${this.#onFocusin}
+      @focusout=${this.#onFocusout}
       ${ref(this.#componentElementRef)}
     >
       <slot name="icon"></slot>
@@ -61,4 +70,12 @@ export default class CsMenuButton extends LitElement {
   }
 
   #componentElementRef = createRef<HTMLElement>();
+
+  #onFocusin() {
+    this.privateIsFocused = true;
+  }
+
+  #onFocusout() {
+    this.privateIsFocused = false;
+  }
 }

--- a/packages/components/src/menu.link.ts
+++ b/packages/components/src/menu.link.ts
@@ -35,6 +35,13 @@ export default class CsMenuLink extends LitElement {
   // A link is considered active when it's interacted with via keyboard or hovered.
   privateActive = false;
 
+  // Used by Menu as an alternative to `document.activeElement`. When Menu is
+  // itself in a shadow DOM and an element in that shadow DOM receives focus,
+  // `document.activeElement` will be set to the outer host. Thus, without this,
+  // Menu has no way of knowing whether it's a Menu Button or Menu Link that has
+  // focus or another element within it that host.
+  privateIsFocused = false;
+
   // `shadowRoot.delegatesFocus` is preferred because it's more declarative.
   // But using here it triggers a focus-visible state whenever `this.focus` is
   // called. And we only want a focus outline when the `this.focus` is called
@@ -57,6 +64,8 @@ export default class CsMenuLink extends LitElement {
       href=${ifDefined(this.url)}
       role="menuitem"
       tabindex=${this.privateActive ? '0' : '-1'}
+      @focusin=${this.#onFocusin}
+      @focusout=${this.#onFocusout}
       ${ref(this.#componentElementRef)}
     >
       <slot name="icon"></slot>
@@ -65,4 +74,12 @@ export default class CsMenuLink extends LitElement {
   }
 
   #componentElementRef = createRef<HTMLElement>();
+
+  #onFocusin() {
+    this.privateIsFocused = true;
+  }
+
+  #onFocusout() {
+    this.privateIsFocused = false;
+  }
 }

--- a/packages/components/src/menu.ts
+++ b/packages/components/src/menu.ts
@@ -300,17 +300,13 @@ export default class CsMenu extends LitElement {
     // `document.body` receives focus immediately after focus is moved. So we
     // wait a frame to see where focus ultimately landed.
     setTimeout(() => {
-      const activeElement = document.activeElement;
+      const isOptionFocused = this.#optionElements.some(
+        ({ privateIsFocused }) => privateIsFocused,
+      );
 
-      const isMenuItem =
-        activeElement instanceof CsMenuLink ||
-        activeElement instanceof CsMenuButton;
-
-      if (isMenuItem && this.#optionElements.includes(activeElement)) {
-        return;
+      if (!isOptionFocused) {
+        this.open = false;
       }
-
-      this.open = false;
     });
   }
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Menu closes when it loses focus, and focus changes within Menu as it's interacted with. Focus moves from the target to the the first option when Menu is opened. And focus moves from one option to another when an option is hovered or arrowed to. 

Each change of focus creates a `focusout` event. Menu's `focusout` handler has [a guard](https://github.com/CrowdStrike/glide-core/blob/main/packages/components/src/menu.ts#L309) that checks `document.activeElement` to determine whether the event was caused by focus moving within Menu or out of it. 

Checking `document.activeElement` works well until Menu itself is used within shadow DOM. Then `document.activeElement` is set to the host of that shadow DOM instead of the host (`<cs-dropdown>`) of Dropdown. 

This PR changes the logic of Menu's `focusout` handler and adds a `privateIsFocused` property to Menu Button and Menu Link to account for this.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

The only way I know to reproduce this is to locally `link` this branch to an application that uses Menu within a shadow DOM. 

## 📸 Images/Videos of Functionality

N/A
