### PR TITLE
Updated ifDefined imports to be from lit, not lit-html

### DIFF
--- a/.changeset/hip-pigs-scream.md
+++ b/.changeset/hip-pigs-scream.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Update ifDefined, ref, and when imports to be from lit rather than lit-html

--- a/packages/components/src/button-group.ts
+++ b/packages/components/src/button-group.ts
@@ -7,7 +7,7 @@ import {
   queryAssignedElements,
 } from 'lit/decorators.js';
 import { owSlotType } from './library/ow.js';
-import { when } from 'lit-html/directives/when.js';
+import { when } from 'lit/directives/when.js';
 import CsButtonGroupButton from './button-group.button.js';
 import styles from './button-group.styles.js';
 

--- a/packages/components/src/checkbox.ts
+++ b/packages/components/src/checkbox.ts
@@ -4,7 +4,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { svg } from 'lit/static-html.js';
-import { when } from 'lit-html/directives/when.js';
+import { when } from 'lit/directives/when.js';
 import checkedIcon from './icons/checked.js';
 import styles from './checkbox.styles.js';
 

--- a/packages/components/src/modal.icon-button.ts
+++ b/packages/components/src/modal.icon-button.ts
@@ -2,7 +2,7 @@ import './icon-button.js';
 import { LitElement, html } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { owSlot } from './library/ow.js';
 import styles from './modal.icon-button.styles.js';
 

--- a/packages/components/src/modal.tertiary-icon.ts
+++ b/packages/components/src/modal.tertiary-icon.ts
@@ -2,7 +2,7 @@ import './tooltip.js';
 import { LitElement, html } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { owSlot } from './library/ow.js';
 
 /**

--- a/packages/components/src/tab.group.ts
+++ b/packages/components/src/tab.group.ts
@@ -1,7 +1,7 @@
 import './icon-button.js';
 import { LitElement, html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
-import { createRef, ref } from 'lit-html/directives/ref.js';
+import { createRef, ref } from 'lit/directives/ref.js';
 import {
   customElement,
   property,


### PR DESCRIPTION
## 🚀 Description

We had two spots importing this from `lit-html`, but everywhere else imports [from lit](https://lit.dev/docs/templates/directives/#ifdefined).  This updates usages to match.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Green build

## 📸 Images/Videos of Functionality

N/A