### PR TITLE
Add no-nested-template-literals rule

### DIFF
--- a/packages/components/eslint.config.js
+++ b/packages/components/eslint.config.js
@@ -39,6 +39,8 @@ export default [
         'error',
       '@crowdstrike/glide-core-eslint-plugin/no-cs-prefixed-event-name':
         'error',
+      '@crowdstrike/glide-core-eslint-plugin/no-nested-template-literals':
+        'error',
       '@crowdstrike/glide-core-eslint-plugin/prefer-closed-shadow-root':
         'error',
       '@crowdstrike/glide-core-eslint-plugin/prefixed-lit-element-class-declaration':

--- a/packages/components/src/tag.ts
+++ b/packages/components/src/tag.ts
@@ -70,7 +70,7 @@ export default class CsTag extends LitElement {
               class=${classMap({
                 [this.size]: true,
               })}
-              aria-label=${`Remove ${this.removableLabel}`}
+              aria-label="Remove ${this.removableLabel}"
               @click=${this.#onClick}
             >
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none">

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,4 +1,5 @@
 import { consistentReferenceElementDeclarations } from './rules/consistent-reference-element-declarations.js';
+import { noNestedTemplateLiterals } from './rules/no-nested-template-literals.js';
 import { noPrefixedEventName } from './rules/no-cs-prefixed-event-name.js';
 import { preferClosedShadowRoot } from './rules/prefer-closed-shadow-root.js';
 import { prefixedClassDeclaration } from './rules/prefixed-lit-element-class-declaration.js';
@@ -6,6 +7,7 @@ import { prefixedClassDeclaration } from './rules/prefixed-lit-element-class-dec
 const rules = {
   'consistent-reference-element-declarations':
     consistentReferenceElementDeclarations,
+  'no-nested-template-literals': noNestedTemplateLiterals,
   'no-cs-prefixed-event-name': noPrefixedEventName,
   'prefer-closed-shadow-root': preferClosedShadowRoot,
   'prefixed-lit-element-class-declaration': prefixedClassDeclaration,

--- a/packages/eslint-plugin/src/rules/no-nested-template-literals.spec.ts
+++ b/packages/eslint-plugin/src/rules/no-nested-template-literals.spec.ts
@@ -1,0 +1,27 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noNestedTemplateLiterals } from './no-nested-template-literals.js';
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('no-nested-template-literals', noNestedTemplateLiterals, {
+  valid: [
+    {
+      code: 'console.log(`Hello, @${username}!`);',
+    },
+    {
+      code: 'class TestComponent extends LitElement { render() { return html`<svg width="${this.#triangleWidth}px">`; } }',
+    },
+  ],
+  invalid: [
+    {
+      code: 'console.log(`Hello, ${`@${username}`}!`);',
+      errors: [{ messageId: 'noNestedTemplateLiterals' }],
+    },
+    {
+      code: 'class TestComponent extends LitElement { render() { return html`<svg width=${`${this.#triangleWidth}px`}>`; } }',
+      errors: [{ messageId: 'noNestedTemplateLiterals' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/no-nested-template-literals.ts
+++ b/packages/eslint-plugin/src/rules/no-nested-template-literals.ts
@@ -1,0 +1,38 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/CrowdStrike/glide-core/blob/main/packages/eslint-plugin/src/rules/${name}.ts`,
+);
+
+export const noNestedTemplateLiterals = createRule({
+  name: 'no-nested-template-literals',
+  meta: {
+    docs: {
+      description:
+        'Forbids the use of a template literal inside of another template literal.',
+      recommended: 'recommended',
+    },
+    type: 'suggestion',
+    messages: {
+      noNestedTemplateLiterals: 'Nested template literals are not allowed.',
+    },
+    schema: [],
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create: (context) => {
+    return {
+      TemplateLiteral(node) {
+        for (const expression of node.expressions) {
+          if (expression.type === 'TemplateLiteral') {
+            context.report({
+              node: expression,
+              messageId: 'noNestedTemplateLiterals',
+            });
+          }
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
## 🚀 Description

Adds a lint rule forbidding nested template literals.  From [this comment on a prior PR](https://github.com/CrowdStrike/glide-core/pull/31#discussion_r1567656908)

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

spec has been added, which shows valid and invalid cases. Also see the violation that was caught and fixed. 

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
