### PR TITLE
Don't throw when Dropdown's default slot is empty

### DIFF
--- a/.changeset/large-walls-prove.md
+++ b/.changeset/large-walls-prove.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Don't throw when Dropdown's default slot is empty so options can be provided asynchronously.

--- a/packages/components/src/dropdown.test.basics.ts
+++ b/packages/components/src/dropdown.test.basics.ts
@@ -1,9 +1,7 @@
 import './dropdown.option.js';
-import { ArgumentError } from 'ow';
 import { assert, expect, fixture, html } from '@open-wc/testing';
 import CsDropdown from './dropdown.js';
 import expectArgumentError from './library/expect-argument-error.js';
-import sinon from 'sinon';
 
 CsDropdown.shadowRootOptions.mode = 'open';
 
@@ -150,22 +148,6 @@ it('updates `value` dynamically', async () => {
   option.value = 'two';
 
   expect(component.value).to.deep.equal(['two']);
-});
-
-it('throws if it does not have a default slot', async () => {
-  const spy = sinon.spy();
-
-  try {
-    await fixture<CsDropdown>(
-      html`<cs-dropdown label="Label" placeholder="Placeholder"></cs-dropdown>`,
-    );
-  } catch (error) {
-    if (error instanceof ArgumentError) {
-      spy();
-    }
-  }
-
-  expect(spy.called).to.be.true;
 });
 
 it('throws if the default slot is the incorrect type', async () => {

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -3,7 +3,7 @@ import { LitElement, html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
-import { owSlot, owSlotType } from './library/ow.js';
+import { owSlotType } from './library/ow.js';
 import CsDropdownOption from './dropdown.option.js';
 import styles from './dropdown.styles.js';
 
@@ -98,7 +98,6 @@ export default class CsDropdown extends LitElement {
   }
 
   override firstUpdated() {
-    owSlot(this.#defaultSlotElementRef.value);
     owSlotType(this.#defaultSlotElementRef.value, [CsDropdownOption]);
 
     const firstOption = this.#optionElements.at(0);
@@ -381,7 +380,6 @@ export default class CsDropdown extends LitElement {
   }
 
   #onDefaultSlotChange() {
-    owSlot(this.#defaultSlotElementRef.value);
     owSlotType(this.#defaultSlotElementRef.value, [CsDropdownOption]);
   }
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

We got a bug report about Dropdown throwing when it's default slot is empty. The reporter was rendering Dropdown's options asynchronously. We'll probably see cases like this with other components. I figure we can cross that bridge when we get to it given the usefulness of the assertion. For now, I've removed the assertion only from Dropdown.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

If you're bored or feeling diligent, feel free to pull the branch and adjust the story so Dropdown doesn't have any options. Then check for an error.

## 📸 Images/Videos of Functionality

N/A
