### PR TITLE
Use negative margin with button slots

### DIFF
--- a/.changeset/gold-toes-double.md
+++ b/.changeset/gold-toes-double.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Adjusted padding of cs-button

--- a/packages/components/src/button.styles.ts
+++ b/packages/components/src/button.styles.ts
@@ -41,13 +41,15 @@ export default [
         opacity: 1;
       }
 
-      /* We make the spacing slightly smaller when an icon is present to help with empty space balancing */
-      &.has-prefix {
-        padding-inline-start: var(--cs-spacing-sm);
+      /* We remove spacing using negative margin when an icon is present to help with empty space balancing */
+      &.has-prefx,
+      ::slotted([slot='prefix']) {
+        margin-inline-start: -0.125rem;
       }
 
-      &.has-suffix {
-        padding-inline-end: var(--cs-spacing-sm);
+      &.has-suffix,
+      ::slotted([slot='suffix']) {
+        margin-inline-end: -0.125rem;
       }
 
       &.primary {


### PR DESCRIPTION
## 🚀 Description

Design wants 16px/1rem of padding on the horizontal axis; however, we were previously doing some balancing by removing some padding on the side with a filled slot.  Design noticed this and **always** wants 16px/1rem of spacing, even if the slot is filled.

Removing our padding offset makes the button a bit longer, due to 4 added pixels on whichever side has slotted content.

They noticed adding icons in the slots made the button feel unbalanced.  Due to that, I offered up this suggestion that I've done in the past.  I'm not a fan of negative margins most of the time, but this is a case that I think makes a bit of a sense.  It essentially maintains the padding specified by design by removing 2px/0.125rem from the total width of the element, making the button feel more balanced.

## 📋 Checklist

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

Check out Button at https://glide-core.crowdstrike-ux.workers.dev/button-balancing-tweaks and see what you think.

## 📸 Images/Videos of Functionality

In these next three videos I'm comparing this PR to what the changes would look like if we removed the "balancing" and always kept 16px/1rem of padding.  You can see that the button gets longer in both examples, but in the "1rem padding only" examples, the icons make the button feel _way_ off balance. It feels like there's more spacing on whichever side has the icon.  And that's because that is exactly what's happening - 4px are being added on the side with the icon. No good!

https://github.com/CrowdStrike/glide-core/assets/8069555/f1f7a5aa-88e5-417f-9acf-d197febc9db5


https://github.com/CrowdStrike/glide-core/assets/8069555/decc40de-2a2a-4d82-b78c-1adfc16a6a5b


https://github.com/CrowdStrike/glide-core/assets/8069555/c43a0977-9e4a-4141-9853-07ec8e65a3d8


Here are examples comparing this PR to what is on `main`.  The length of the button grows, due to always having 16px/1rem on the horizontal axis, but the buttons should feel a bit more balanced when being used with icons.

https://github.com/CrowdStrike/glide-core/assets/8069555/ff54872e-8aac-4a49-b456-09452326fd21

https://github.com/CrowdStrike/glide-core/assets/8069555/06ed3e42-451f-4271-8f06-13015aa7bab8

https://github.com/CrowdStrike/glide-core/assets/8069555/bbc31c87-1934-4ce4-8e5f-f78674fc0e8c




