### PR TITLE
[DESIGN REVIEW ONLY] Remove button balancing altogether in favor of static padding

### DIFF
--- a/packages/components/src/button.styles.ts
+++ b/packages/components/src/button.styles.ts
@@ -41,15 +41,6 @@ export default [
         opacity: 1;
       }
 
-      /* We make the spacing slightly smaller when an icon is present to help with empty space balancing */
-      &.has-prefix {
-        padding-inline-start: var(--cs-spacing-sm);
-      }
-
-      &.has-suffix {
-        padding-inline-end: var(--cs-spacing-sm);
-      }
-
       &.primary {
         background-color: var(--cs-surface-primary);
         border-color: transparent;

--- a/packages/components/src/button.test.basics.ts
+++ b/packages/components/src/button.test.basics.ts
@@ -153,7 +153,7 @@ it('renders with a prefix slot', async () => {
 
   expect([
     ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal(['component', 'primary', 'large', 'has-prefix']);
+  ]).to.deep.equal(['component', 'primary', 'large']);
 
   expect(document.querySelector('[data-prefix]')).to.be.ok;
 });
@@ -168,7 +168,7 @@ it('renders with a suffix slot', async () => {
 
   expect([
     ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal(['component', 'primary', 'large', 'has-suffix']);
+  ]).to.deep.equal(['component', 'primary', 'large']);
 
   expect(document.querySelector('[data-suffix]')).to.be.ok;
 });
@@ -184,13 +184,7 @@ it('renders with a prefix and suffix slot when both are present initially', asyn
 
   expect([
     ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal([
-    'component',
-    'primary',
-    'large',
-    'has-prefix',
-    'has-suffix',
-  ]);
+  ]).to.deep.equal(['component', 'primary', 'large']);
 
   expect(document.querySelector('[data-prefix]')).to.be.ok;
   expect(document.querySelector('[data-suffix]')).to.be.ok;
@@ -217,13 +211,7 @@ it('renders with prefix and suffix classes when both are dynamically added', asy
 
   expect([
     ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal([
-    'component',
-    'primary',
-    'large',
-    'has-prefix',
-    'has-suffix',
-  ]);
+  ]).to.deep.equal(['component', 'primary', 'large']);
 
   expect(document.querySelector('[data-prefix]')).to.be.ok;
   expect(document.querySelector('[data-suffix]')).to.be.ok;

--- a/packages/components/src/button.ts
+++ b/packages/components/src/button.ts
@@ -1,7 +1,7 @@
 import { LitElement, html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { owSlot } from './library/ow.js';
 import styles from './button.styles.js';
 
@@ -61,30 +61,20 @@ export default class CsButton extends LitElement {
         tertiary: this.variant === 'tertiary',
         large: this.size === 'large',
         small: this.size === 'small',
-        'has-prefix': this.hasPrefixSlot,
-        'has-suffix': this.hasSuffixSlot,
       })}
       type=${this.type}
       ?disabled=${this.disabled}
       @click=${this.#handleClick}
       @keydown=${this.#onKeydown}
     >
-      <slot
-        name="prefix"
-        @slotchange=${this.#onPrefixSlotChange}
-        ${ref(this.#prefixSlotElementRef)}
-      ></slot>
+      <slot name="prefix"></slot>
 
       <slot
         @slotchange=${this.#onDefaultSlotChange}
         ${ref(this.#defaultSlotElementRef)}
       ></slot>
 
-      <slot
-        name="suffix"
-        @slotchange=${this.#onSuffixSlotChange}
-        ${ref(this.#suffixSlotElementRef)}
-      ></slot>
+      <slot name="suffix"></slot>
     </button>`;
   }
 
@@ -93,19 +83,9 @@ export default class CsButton extends LitElement {
     this.#internals = this.attachInternals();
   }
 
-  @state()
-  private hasPrefixSlot = false;
-
-  @state()
-  private hasSuffixSlot = false;
-
   #defaultSlotElementRef = createRef<HTMLSlotElement>();
 
   #internals: ElementInternals;
-
-  #prefixSlotElementRef = createRef<HTMLSlotElement>();
-
-  #suffixSlotElementRef = createRef<HTMLSlotElement>();
 
   #handleClick() {
     if (this.type === 'button') {
@@ -131,19 +111,5 @@ export default class CsButton extends LitElement {
 
       this.#handleClick();
     }
-  }
-
-  #onPrefixSlotChange() {
-    const assignedNodes = this.#prefixSlotElementRef.value?.assignedNodes();
-
-    this.hasPrefixSlot =
-      assignedNodes && assignedNodes.length > 0 ? true : false;
-  }
-
-  #onSuffixSlotChange() {
-    const assignedNodes = this.#suffixSlotElementRef.value?.assignedNodes();
-
-    this.hasSuffixSlot =
-      assignedNodes && assignedNodes.length > 0 ? true : false;
   }
 }


### PR DESCRIPTION
⚠️ Don't review this! It's a test for design only at this point.

## 🚀 Description

Remove all button balancing in favor of always having 16px of padding.

## 📋 Checklist

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A
