### PR TITLE
Fill the empty space with Label's control when there's no summary

### DIFF
--- a/.changeset/tender-ants-flow.md
+++ b/.changeset/tender-ants-flow.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Input and Textarea now expand to the full width of their container.

--- a/packages/components/src/label.styles.ts
+++ b/packages/components/src/label.styles.ts
@@ -112,6 +112,10 @@ make it difficult to center vertically with the label.
     .control {
       display: block;
 
+      &.summaryless {
+        flex-grow: 1;
+      }
+
       &.disabled::slotted(*) {
         cursor: not-allowed;
       }

--- a/packages/components/src/label.ts
+++ b/packages/components/src/label.ts
@@ -119,6 +119,7 @@ export default class CsLabel extends LitElement {
             error: this.error,
             disabled: this.disabled,
             vertical: this.orientation === 'vertical',
+            summaryless: !this.hasSummarySlot,
             'hidden-label': this.hide,
           })}
           name="control"


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Input and Textarea used to expand to fill their container. I broke that when I added a "summary" slot to Label.

(We need visual regression tests.)

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

Open Storybook. Check that Input and Textarea expand to fill their container.

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->

## Before

<img width="2254" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/6b77177e-ed1c-4102-bac4-a447f7e7ad97">


## After

<img width="2258" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/2fba43a1-b305-43d4-8f3b-24493b92ee18">

