### PR TITLE
Update modal body class to default to display block

### DIFF
--- a/.changeset/rude-llamas-hide.md
+++ b/.changeset/rude-llamas-hide.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Remove `display: flex;` from the Modal body content to default to `display: block;` instead.

--- a/packages/components/src/modal.styles.ts
+++ b/packages/components/src/modal.styles.ts
@@ -124,7 +124,6 @@ export default [
     }
 
     .body {
-      display: flex;
       line-height: 1;
       overflow: auto;
       padding-block: 1rem;


### PR DESCRIPTION
## 🚀 Description

`<dialog>` defaults the body to `display: block` but we set ours to `flex`. Instead let's go with the defaults and allow consumers to control their layout.

## 📋 Checklist

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Green build

## 📸 Images/Videos of Functionality

N/A - no visual changes for us.
