### PR TITLE
Ensure tooltip remains open when hovered

### DIFF
--- a/.changeset/lucky-bobcats-brush.md
+++ b/.changeset/lucky-bobcats-brush.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Ensure tooltip remains open when hovered

--- a/packages/components/src/tooltip.test.interactions.ts
+++ b/packages/components/src/tooltip.test.interactions.ts
@@ -2,6 +2,7 @@ import './tooltip.js';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import CsTooltip from './tooltip.js';
+import sinon from 'sinon';
 
 CsTooltip.shadowRootOptions.mode = 'open';
 
@@ -85,7 +86,7 @@ it('is visible on "mouseover"', async () => {
   );
 
   component.shadowRoot
-    ?.querySelector('[aria-labelledby="tooltip"]')
+    ?.querySelector('.component')
     ?.dispatchEvent(new MouseEvent('mouseover'));
 
   await elementUpdated(component);
@@ -96,6 +97,8 @@ it('is visible on "mouseover"', async () => {
 });
 
 it('is hidden on "mouseout"', async () => {
+  const clock = sinon.useFakeTimers();
+
   const component = await fixture<CsTooltip>(
     html`<cs-tooltip>
       Tooltip
@@ -104,18 +107,22 @@ it('is hidden on "mouseout"', async () => {
   );
 
   component.shadowRoot
-    ?.querySelector('[aria-labelledby="tooltip"]')
+    ?.querySelector('.component')
     ?.dispatchEvent(new MouseEvent('mouseover'));
 
   await elementUpdated(component);
 
   component.shadowRoot
-    ?.querySelector('[aria-labelledby="tooltip"]')
+    ?.querySelector('.component')
     ?.dispatchEvent(new MouseEvent('mouseout'));
+
+  clock.tick(300);
 
   await elementUpdated(component);
 
   expect(
     component.shadowRoot?.querySelector('[role="tooltip"]')?.checkVisibility(),
   ).to.be.false;
+
+  clock.restore();
 });

--- a/packages/components/src/tooltip.ts
+++ b/packages/components/src/tooltip.ts
@@ -71,7 +71,11 @@ export default class CsTooltip extends LitElement {
 
     /* eslint-disable lit-a11y/mouse-events-have-key-events, lit-a11y/accessible-name */
     return html`
-      <div class="component">
+      <div
+        class="component"
+        @mouseover=${this.#onMouseover}
+        @mouseout=${this.#onMouseout}
+      >
         <div
           aria-labelledby="tooltip"
           class="target"
@@ -79,8 +83,6 @@ export default class CsTooltip extends LitElement {
           @focusin=${this.#onFocusin}
           @focusout=${this.#onFocusout}
           @keydown=${this.#onKeydown}
-          @mouseover=${this.#onMouseover}
-          @mouseout=${this.#onMouseout}
           ${ref(this.#targetElementRef)}
         >
           <slot
@@ -119,6 +121,8 @@ export default class CsTooltip extends LitElement {
 
   #cleanUpFloatingUi?: ReturnType<typeof autoUpdate>;
 
+  #closeTimeoutId?: ReturnType<typeof setTimeout>;
+
   #defaultSlotElementRef = createRef<HTMLSlotElement>();
 
   #isVisible = false;
@@ -128,6 +132,10 @@ export default class CsTooltip extends LitElement {
   #targetSlotElementRef = createRef<HTMLSlotElement>();
 
   #tooltipElementRef = createRef<HTMLSpanElement>();
+
+  #cancelClose() {
+    clearTimeout(this.#closeTimeoutId);
+  }
 
   #onDefaultSlotChange() {
     owSlot(this.#defaultSlotElementRef.value);
@@ -148,15 +156,22 @@ export default class CsTooltip extends LitElement {
   }
 
   #onMouseout() {
-    this.isVisible = false;
+    this.#scheduleClose();
   }
 
   #onMouseover() {
+    this.#cancelClose();
     this.isVisible = true;
   }
 
   #onTargetSlotChange() {
     owSlot(this.#targetSlotElementRef.value);
+  }
+
+  #scheduleClose() {
+    this.#closeTimeoutId = setTimeout(() => {
+      this.isVisible = false;
+    }, 200);
   }
 
   #setUpFloatingUi() {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

According to [accessibility guidelines](https://www.w3.org/TR/WCAG22/#content-on-hover-or-focus), a tooltip should remain visible when the user has moved the cursor over the tooltip content itself.

To make this smooth for the user, I added a 200ms delay for closing the tooltip. Otherwise, it would be too easy to accidentally move the mouse slightly off the tooltip icon before it goes over the tooltip itself

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

Go to https://glide-core.crowdstrike-ux.workers.dev/tooltip-stay-open-when-cursor-over-it?path=/docs/tooltip--overview, and confirm the tooltip stays visible when you hover over it.  You can do things like highlight and copy the text.

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
