### PR TITLE
Allow Dropdown to consist of only text nodes when asserting against its

### DIFF
--- a/.changeset/healthy-singers-sell.md
+++ b/.changeset/healthy-singers-sell.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Allow Dropdown and Menu's default slots to contain only whitespace to accommodate asychronously rendered options.

--- a/packages/components/src/dropdown.test.basics.ts
+++ b/packages/components/src/dropdown.test.basics.ts
@@ -1,7 +1,10 @@
 import './dropdown.option.js';
+import { ArgumentError } from 'ow';
 import { assert, expect, fixture, html } from '@open-wc/testing';
+import { repeat } from 'lit/directives/repeat.js';
 import CsDropdown from './dropdown.js';
 import expectArgumentError from './library/expect-argument-error.js';
+import sinon from 'sinon';
 
 CsDropdown.shadowRootOptions.mode = 'open';
 
@@ -158,4 +161,29 @@ it('throws if the default slot is the incorrect type', async () => {
       </cs-dropdown>`,
     );
   });
+});
+
+it('does not throw if the default slot only contains whitespace', async () => {
+  const spy = sinon.spy();
+
+  try {
+    await fixture(
+      html`<cs-dropdown label="Label" placeholder="Placeholder">
+        ${repeat(
+          [],
+          () =>
+            html`<cs-dropdown-option
+              label="Option"
+              value="option"
+            ></cs-dropdown-option>`,
+        )}
+      </cs-dropdown>`,
+    );
+  } catch (error) {
+    if (error instanceof ArgumentError) {
+      spy();
+    }
+  }
+
+  expect(spy.notCalled).to.be.true;
 });

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -98,7 +98,10 @@ export default class CsDropdown extends LitElement {
   }
 
   override firstUpdated() {
-    owSlotType(this.#defaultSlotElementRef.value, [CsDropdownOption]);
+    // `Text` is allowed so slotted content can be rendered asychronously. Think of
+    // a case where the only slotted content is a `repeat` whose array is empty
+    // at first then populated after a fetch.
+    owSlotType(this.#defaultSlotElementRef.value, [CsDropdownOption, Text]);
 
     const firstOption = this.#optionElements.at(0);
 
@@ -380,7 +383,7 @@ export default class CsDropdown extends LitElement {
   }
 
   #onDefaultSlotChange() {
-    owSlotType(this.#defaultSlotElementRef.value, [CsDropdownOption]);
+    owSlotType(this.#defaultSlotElementRef.value, [CsDropdownOption, Text]);
   }
 
   get #optionElements() {

--- a/packages/components/src/menu.test.basics.ts
+++ b/packages/components/src/menu.test.basics.ts
@@ -1,6 +1,7 @@
 import './menu.button.js';
 import { ArgumentError } from 'ow';
 import { expect, fixture, html } from '@open-wc/testing';
+import { repeat } from 'lit/directives/repeat.js';
 import CsMenu from './menu.js';
 import CsMenuLink from './menu.link.js';
 import expectArgumentError from './library/expect-argument-error.js';
@@ -111,6 +112,25 @@ it('throws if it does not have a "target" slot', async () => {
   }
 
   expect(spy.called).to.be.true;
+});
+
+it('does not throw if the default slot only contains whitespace', async () => {
+  const spy = sinon.spy();
+
+  try {
+    await fixture<CsMenu>(
+      html`<cs-menu>
+        <button slot="target">Target</button>
+        ${repeat([], () => html`<cs-menu-link label="Link"></cs-menu-link>`)}
+      </cs-menu>`,
+    );
+  } catch (error) {
+    if (error instanceof ArgumentError) {
+      spy();
+    }
+  }
+
+  expect(spy.notCalled).to.be.true;
 });
 
 it('sets accessibility attributes on the target', async () => {

--- a/packages/components/src/menu.ts
+++ b/packages/components/src/menu.ts
@@ -86,8 +86,16 @@ export default class CsMenu extends LitElement {
 
   override firstUpdated() {
     owSlot(this.#defaultSlotElementRef.value);
-    owSlotType(this.#defaultSlotElementRef.value, [CsMenuButton, CsMenuLink]);
     owSlot(this.#targetSlotElementRef.value);
+
+    // `Text` is allowed so slotted content can be rendered asychronously. Think of
+    // a case where the only slotted content is a `repeat` whose array is empty
+    // at first then populated after a fetch.
+    owSlotType(this.#defaultSlotElementRef.value, [
+      CsMenuButton,
+      CsMenuLink,
+      Text,
+    ]);
 
     // For when Menu is open initially via the `open` attribute.
     this.#setUpFloatingUi();
@@ -197,7 +205,12 @@ export default class CsMenu extends LitElement {
 
   #onDefaultSlotChange() {
     owSlot(this.#defaultSlotElementRef.value);
-    owSlotType(this.#defaultSlotElementRef.value, [CsMenuButton, CsMenuLink]);
+
+    owSlotType(this.#defaultSlotElementRef.value, [
+      CsMenuButton,
+      CsMenuLink,
+      Text,
+    ]);
   }
 
   #onOptionsClick() {

--- a/packages/components/src/tree.item.menu.test.basics.ts
+++ b/packages/components/src/tree.item.menu.test.basics.ts
@@ -13,13 +13,6 @@ it('throws if it does not have a default slot', async () => {
       <cs-tree-item-menu></cs-tree-item-menu>
     `);
   });
-
-  // Menu is rendered asynchronously outside of Tree Menu Item's lifecycle
-  // and asserts against its default slot. That assertion, which is expected
-  // to fail, results in an unhandled rejection that gets logged.
-  const stub = sinon.stub(console, 'error');
-  await waitUntil(() => stub.called);
-  stub.restore();
 });
 
 it('throws if the default slot is the incorrect type', async () => {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

A user had a bug where he was rendering Dropdown's options asynchronously and its slot assertion was failing because the slot only contained whitespace. The fix is to add `Text` as an allowed node type. I've accounted for this in Menu as well. 

Something to be aware of with slots whose content might reasonably be rendered asynchronously. As far as I can tell, these would only be slots that are made visible after a user interaction. All other slots would need to have their content rendered synchronously so the page doesn't change or shift after the initial render.

Accordion is another example but, unlike Dropdown and Menu, it allows for arbitrary slotted content. So text nodes are already allowed.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

Open Dropdown's story in your editor. Remove every `<cs-dropdown-option>` from the default slot of the default story. Leave some whitespace. Then check the console and make sure Dropdown does't throw.

## 📸 Images/Videos of Functionality

N/A