### PR TITLE
Fix Checkbox, Checkbox Group, and Dropdown not resetting with their form

### DIFF
--- a/.changeset/eighty-waves-try.md
+++ b/.changeset/eighty-waves-try.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core-components': patch
+---
+
+Fix Checkbox, Checkbox Group, and Dropdown not resetting with their form.

--- a/packages/components/src/checkbox-group.ts
+++ b/packages/components/src/checkbox-group.ts
@@ -155,7 +155,7 @@ export default class CsCheckboxGroup extends LitElement {
 
   formResetCallback() {
     for (const checkbox of this.#checkboxes) {
-      checkbox.checked = checkbox.getAttribute('checked') === '';
+      checkbox.formResetCallback();
     }
   }
 

--- a/packages/components/src/checkbox.ts
+++ b/packages/components/src/checkbox.ts
@@ -151,7 +151,7 @@ export default class CsCheckbox extends LitElement {
                 data-test="input"
                 id="input"
                 type="checkbox"
-                ?checked=${this.checked}
+                .checked=${this.checked}
                 ?disabled=${this.disabled}
                 ?required=${this.required}
                 @change=${this.#onInputChange}
@@ -215,7 +215,7 @@ export default class CsCheckbox extends LitElement {
                 data-test="input"
                 id="input"
                 type="checkbox"
-                ?checked=${this.checked}
+                .checked=${this.checked}
                 ?disabled=${this.disabled}
                 ?required=${this.required}
                 @change=${this.#onInputChange}

--- a/packages/components/src/dropdown.test.form.ts
+++ b/packages/components/src/dropdown.test.form.ts
@@ -1,5 +1,5 @@
 import './dropdown.option.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import CsDropdown from './dropdown.js';
 import CsDropdownOption from './dropdown.option.js';
 
@@ -26,7 +26,15 @@ it('can be reset', async () => {
 
   form.reset();
 
+  await elementUpdated(component);
+
   expect(component.value).to.deep.equal([]);
+
+  expect(
+    component.shadowRoot
+      ?.querySelector('[data-test="placeholder-or-selected-option-label"]')
+      ?.textContent?.trim(),
+  ).to.equal('Placeholder');
 });
 
 it('can be reset to the initially selected option', async () => {

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -143,11 +143,20 @@ export default class CsDropdown extends LitElement {
   }
 
   formResetCallback() {
-    const lastSelectedOption = this.#optionElements.findLast((option) =>
-      option.hasAttribute('selected'),
-    );
+    for (const option of this.#optionElements) {
+      const isInitiallySelected = option.hasAttribute('selected');
 
-    this.value = lastSelectedOption?.value ? [lastSelectedOption.value] : [];
+      if (!isInitiallySelected) {
+        option.selected = false;
+      }
+    }
+
+    const { value } =
+      this.#optionElements.findLast((option) => {
+        return option.hasAttribute('selected');
+      }) ?? {};
+
+    this.value = value ? [value] : [];
   }
 
   override render() {
@@ -203,7 +212,9 @@ export default class CsDropdown extends LitElement {
             @keydown=${this.#onButtonKeydown}
             ${ref(this.#buttonElementRef)}
           >
-            ${this.selectedOption?.label ?? this.placeholder}
+            <span data-test="placeholder-or-selected-option-label">
+              ${this.selectedOption?.label ?? this.placeholder}
+            </span>
 
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
               <path


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

### Checkbox and Checkbox Group

1. Check a checkbox. 
2. Call `reset()` on the form.
3. Ensure that the checkbox is unchecked.


### Dropdown

1. Select an option.
2. Call `reset()` on the form.
3. Ensure that the text inside Dropdown's button reverts to "Placeholder".

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A
