### PR TITLE
Set autoplay to true where missing in stories

### DIFF
--- a/packages/components/src/input.stories.ts
+++ b/packages/components/src/input.stories.ts
@@ -13,6 +13,9 @@ const meta: Meta = {
         component:
           'An input with a label and optional description. Participates in forms and validation via `FormData` and various methods.',
       },
+      story: {
+        autoplay: true,
+      },
     },
   },
   args: {

--- a/packages/components/src/textarea.stories.ts
+++ b/packages/components/src/textarea.stories.ts
@@ -11,6 +11,9 @@ const meta: Meta = {
         component:
           'A textarea with a label and optional description. Participates in forms and validation via `FormData` and various methods.',
       },
+      story: {
+        autoplay: true,
+      },
     },
   },
   play(context) {


### PR DESCRIPTION
## 🚀 Description

We are now using Storybook's `play` [everywhere](https://github.com/CrowdStrike/glide-core/pull/161); however, I noticed we weren't telling the story to autoplay everywhere.  This lead to Input and Textarea to be styled (seemingly) improperly due to `reportValidity()` not being called.

Reproduction steps for this bug:

- Go to https://glide-core.crowdstrike-ux.workers.dev/main?path=/docs/input--overview#with%20error and notice there is no error border
- Now go to the story directly and see that there is: https://glide-core.crowdstrike-ux.workers.dev/main?path=/story/input--with-error
- Do the same steps with Textarea

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Go to https://glide-core.crowdstrike-ux.workers.dev/fix-error-stories-storybook?path=/docs/input--overview#with%20error
- Verify in the overview page that the the border exists (since `reportValidity()` is called in the `play` function)
- Go to https://glide-core.crowdstrike-ux.workers.dev/fix-error-stories-storybook?path=/story/input--with-error
- Verify the border exists
- Do the same steps for Textarea

## 📸 Images/Videos of Functionality

N/A