### PR TITLE
Add lint rule that prevents a redundant property attribute

### DIFF
--- a/packages/components/eslint.config.js
+++ b/packages/components/eslint.config.js
@@ -41,6 +41,8 @@ export default [
         'error',
       '@crowdstrike/glide-core-eslint-plugin/no-nested-template-literals':
         'error',
+      '@crowdstrike/glide-core-eslint-plugin/no-redundant-property-attribute':
+        'error',
       '@crowdstrike/glide-core-eslint-plugin/no-redundant-property-string-type':
         'error',
       '@crowdstrike/glide-core-eslint-plugin/prefer-closed-shadow-root':

--- a/packages/components/src/icon-button.ts
+++ b/packages/components/src/icon-button.ts
@@ -36,7 +36,7 @@ export default class CsIconButton extends LitElement {
   @property()
   label = '';
 
-  @property({ attribute: 'variant', reflect: true })
+  @property({ reflect: true })
   variant: 'primary' | 'secondary' | 'tertiary' = 'primary';
 
   override firstUpdated() {

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,6 +1,7 @@
 import { consistentReferenceElementDeclarations } from './rules/consistent-reference-element-declarations.js';
 import { noNestedTemplateLiterals } from './rules/no-nested-template-literals.js';
 import { noPrefixedEventName } from './rules/no-cs-prefixed-event-name.js';
+import { noRedudantPropertyAttribute } from './rules/no-redundant-property-attribute.js';
 import { noRedudantPropertyStringType } from './rules/no-redundant-property-string-type.js';
 import { preferClosedShadowRoot } from './rules/prefer-closed-shadow-root.js';
 import { prefixedClassDeclaration } from './rules/prefixed-lit-element-class-declaration.js';
@@ -10,6 +11,7 @@ const rules = {
     consistentReferenceElementDeclarations,
   'no-cs-prefixed-event-name': noPrefixedEventName,
   'no-nested-template-literals': noNestedTemplateLiterals,
+  'no-redundant-property-attribute': noRedudantPropertyAttribute,
   'no-redundant-property-string-type': noRedudantPropertyStringType,
   'prefer-closed-shadow-root': preferClosedShadowRoot,
   'prefixed-lit-element-class-declaration': prefixedClassDeclaration,

--- a/packages/eslint-plugin/src/rules/no-redundant-property-attribute.spec.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-property-attribute.spec.ts
@@ -1,0 +1,44 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noRedudantPropertyAttribute } from './no-redundant-property-attribute.js';
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('no-redundant-property-attribute', noRedudantPropertyAttribute, {
+  valid: [
+    {
+      // We ignore classes that don't extend LitElement
+      code: 'class TestComponent { @property({ attribute: "name" }) name = "test" }',
+    },
+    {
+      code: 'class TestComponent extends LitElement { @property() name = "test" }',
+    },
+    {
+      code: 'class TestComponent extends LitElement { @property({ reflect: true }) name = "test" }',
+    },
+    {
+      code: 'class TestComponent extends LitElement { @property({ attribute: "name1" }) name2 = "test" }',
+    },
+  ],
+  invalid: [
+    {
+      code: 'class TestComponent extends LitElement { @property({ attribute: "name" }) name = "test" }',
+      output:
+        'class TestComponent extends LitElement { @property() name = "test" }',
+      errors: [{ messageId: 'noRedudantPropertyAttribute' }],
+    },
+    {
+      code: 'class TestComponent extends LitElement { @property({ attribute: "name", reflect: true }) name = "test" }',
+      output:
+        'class TestComponent extends LitElement { @property({ reflect: true }) name = "test" }',
+      errors: [{ messageId: 'noRedudantPropertyAttribute' }],
+    },
+    {
+      code: 'class TestComponent extends LitElement { @property({ attribute: "name", reflect: true, type: Boolean }) name = "test" }',
+      output:
+        'class TestComponent extends LitElement { @property({ reflect: true, type: Boolean }) name = "test" }',
+      errors: [{ messageId: 'noRedudantPropertyAttribute' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/no-redundant-property-attribute.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-property-attribute.ts
@@ -1,0 +1,129 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/CrowdStrike/glide-core/blob/main/packages/eslint-plugin/src/rules/${name}.ts`,
+);
+
+export const noRedudantPropertyAttribute = createRule({
+  name: 'no-redundant-property-attribute',
+  meta: {
+    docs: {
+      description:
+        'Ensures the Lit property decorator does not specify an attribute key that matches the property name.',
+      recommended: 'recommended',
+    },
+    type: 'suggestion',
+    messages: {
+      noRedudantPropertyAttribute:
+        'The "attribute" defined in the property decorator matches the property declaration name, making it redundant.  Please remove it.',
+    },
+    schema: [],
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create: (context) => {
+    let isLitElement = true;
+
+    return {
+      ClassDeclaration(node) {
+        if (
+          !node.superClass ||
+          (node.superClass?.type === 'Identifier' &&
+            node.superClass.name !== 'LitElement')
+        ) {
+          isLitElement = false;
+          return;
+        }
+      },
+      Decorator(node) {
+        if (!isLitElement) {
+          return;
+        }
+
+        let variableName = '';
+
+        if (
+          node.expression.type === 'CallExpression' &&
+          node.expression.callee?.type === 'Identifier' &&
+          node.expression.callee.name === 'property'
+        ) {
+          const nodeParent = node.parent;
+
+          if (!nodeParent) {
+            return;
+          }
+
+          if (
+            nodeParent.type === 'PropertyDefinition' &&
+            nodeParent.key.type === 'Identifier'
+          ) {
+            variableName = nodeParent.key.name;
+          }
+
+          const expressionArguments = node.expression.arguments;
+
+          for (const argument of expressionArguments) {
+            if (argument.type === 'ObjectExpression' && argument.properties) {
+              for (const property of argument.properties) {
+                if (
+                  property.type === 'Property' &&
+                  property.key?.type === 'Identifier' &&
+                  property.key.name === 'attribute' &&
+                  property.value &&
+                  property.value.type === 'Literal' &&
+                  property.value.value === variableName
+                ) {
+                  context.report({
+                    node: property,
+                    messageId: 'noRedudantPropertyAttribute',
+                    fix: function (fixer) {
+                      if (argument.properties?.length === 1) {
+                        const source = context.sourceCode;
+                        const tokenBefore = source.getTokenBefore(argument);
+                        const tokenAfter = source.getTokenAfter(argument);
+
+                        const rangeStart =
+                          tokenBefore?.value === ','
+                            ? tokenBefore.range[0]
+                            : argument.range[0];
+                        const rangeAfter =
+                          tokenAfter?.value === ','
+                            ? tokenAfter.range[1]
+                            : argument.range[1];
+
+                        if (argument.properties?.length > 0) {
+                          return fixer.removeRange([rangeStart, rangeAfter]);
+                        }
+                      }
+
+                      if (argument.properties?.length > 1) {
+                        const source = context.sourceCode;
+                        const tokenBefore = source.getTokenBefore(property);
+                        const tokenAfter = source.getTokenAfter(property);
+
+                        if (!tokenBefore || !tokenAfter) {
+                          console.error(
+                            `Error attempting to lint fix "no-redundant-property-attribute" at range: ${property.range}". Please report this error to @crowdstrike/glide-core.`,
+                          );
+                          return null;
+                        }
+
+                        return fixer.removeRange([
+                          tokenBefore.range[0] + 1,
+                          tokenAfter.range[1],
+                        ]);
+                      }
+
+                      return null;
+                    },
+                  });
+                }
+              }
+            }
+          }
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
## 🚀 Description

This PR is downstream of https://github.com/CrowdStrike/glide-core/pull/180.

Adds a lint rule preventing an `attribute` defined in `@property()` matching the name since it is redundant.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

```bash
➜  components git:(lint-rule-property-decorator-attribute) ✗ pnpm lint:production:eslint

> @crowdstrike/glide-core-components@0.4.3 lint:production:eslint oss/glide-core/packages/components
> eslint .


oss/glide-core/packages/components/src/icon-button.ts
  39:15  error  The "attribute" defined in the property decorator matches the property declaration name, making it redundant.  Please remove it  @crowdstrike/glide-core-eslint-plugin/no-redundant-property-attribute

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```
