### PR TITLE
Add logo URL to the README logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://glide-core.crowdstrike-ux.workers.dev" target="_blank">
+  <a href="https://glide-core.crowdstrike-ux.workers.dev">
     <img src="https://github.com/CrowdStrike/glide-core/blob/main/.github/glide-core.png?raw=true" alt="Glide Core logo" width="300" />
   </a>
 </p>


### PR DESCRIPTION
## 🚀 Description

Clicking the logo goes straight to the image URL, but we can override it like this.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- View https://github.com/CrowdStrike/glide-core/blob/7924883b18523ff11b172ebcb5a3d10a79c88e5e/README.md as the rendered markdown
- Click the logo
- Verify it opens storybook, not the image

## 📸 Images/Videos of Functionality

N/A