### PR TITLE
Fix up layout of tree item menu

### DIFF
--- a/.changeset/beige-colts-applaud.md
+++ b/.changeset/beige-colts-applaud.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Fix up layout of tree item menu

--- a/packages/components/src/menu.styles.ts
+++ b/packages/components/src/menu.styles.ts
@@ -9,10 +9,11 @@ export default [
 
     .component {
       color: var(--cs-text-body-1);
-      display: inline-block;
+      display: flex;
     }
 
     .target-container {
+      display: flex;
       position: relative;
     }
 

--- a/packages/components/src/menu.ts
+++ b/packages/components/src/menu.ts
@@ -126,11 +126,12 @@ export default class GlideCoreMenu extends LitElement {
     // slot, but there's nothing to be done with one in this case.
 
     /*  eslint-disable lit-a11y/list, lit-a11y/mouse-events-have-key-events */
-    return html`<div class="component">
+    return html`
       <div
         @focusout=${this.#onTargetAndOptionsFocusout}
         @keydown=${this.#onTargetAndOptionsKeydown}
         ${ref(this.#componentElementRef)}
+        class="component"
       >
         <div
           class="target-container"
@@ -165,7 +166,7 @@ export default class GlideCoreMenu extends LitElement {
           ></slot>
         </div>
       </div>
-    </div>`;
+    `;
   }
 
   #cleanUpFloatingUi?: ReturnType<typeof autoUpdate>;

--- a/packages/components/src/tree.item.menu.styles.ts
+++ b/packages/components/src/tree.item.menu.styles.ts
@@ -2,14 +2,16 @@ import { css } from 'lit';
 
 export default [
   css`
-    /* Allows the target icon to properly align */
+    :host {
+      display: contents;
+    }
+
     .component {
       display: flex;
-      margin-block-end: -0.25rem;
     }
 
     glide-core-icon-button {
-      display: inline-flex;
+      display: flex;
 
       --icon-color: var(--icon-button-color);
       --hovered-icon-color: var(--hovered-icon-button-color);


### PR DESCRIPTION
The cs-menu inside cs-tree's menu slot was having unpredictable height issues.
Fixed by switching to a flex layout, instead of inline-block

<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

Visit the Tree component: https://glide-core.crowdstrike-ux.workers.dev/fix-tree-item-menu-icon?path=/docs/tree--overview, and confirm that the 3-dot menu is properly aligned.
<img width="417" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/11724146/9a5d0ea7-4ee0-4b24-b722-805c223de999">

Also check out the Menu component, and validate nothing looks broken (I had to change a few elements within that component as well)



## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
