### PR TITLE
Rename package to simply "glide-core"

### DIFF
--- a/.changeset/beige-hornets-hide.md
+++ b/.changeset/beige-hornets-hide.md
@@ -1,5 +1,5 @@
 ---
-'@crowdstrike/glide-core-components': patch
+'@crowdstrike/glide-core': patch
 ---
 
-Add `@crowdstrike/glide-core-components/styles/fonts.css` containing a `@font-face` rule and inlined Nunito for easier inclusion.
+Add `@crowdstrike/glide-core/styles/fonts.css` containing a `@font-face` rule and inlined Nunito for easier inclusion.

--- a/.changeset/hip-chairs-burn.md
+++ b/.changeset/hip-chairs-burn.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+The package has been renamed to `@crowdstrike/glide-core` for simplicity. Components and styles are now contained in a single package.

--- a/.changeset/two-kings-dream.md
+++ b/.changeset/two-kings-dream.md
@@ -1,5 +1,5 @@
 ---
-'@crowdstrike/glide-core-components': minor
+'@crowdstrike/glide-core': minor
 ---
 
-Replace `@crowdstrike/glide-core-styles` with `@crowdstrike/glide-core-components/styles/variables.css`.
+Replace `@crowdstrike/glide-core-styles` with `@crowdstrike/glide-core/styles/variables.css`.

--- a/.github/workflows/on-merge-branch-changeset-release-main.yml
+++ b/.github/workflows/on-merge-branch-changeset-release-main.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm
-      - run: NODE_ENV=production pnpm --filter "@crowdstrike/glide-core-components" start
+      - run: NODE_ENV=production pnpm --filter "@crowdstrike/glide-core" start
       - name: Publish to NPM
         id: changesets
         uses: changesets/action@v1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@crowdstrike/glide-core",
+  "name": "@crowdstrike/glide-core-root",
   "description": "CrowdStrike's Glide Design System monorepo root. Should not be published/consumed directly.",
   "version": "0.0.0",
   "author": "CrowdStrike UX Team",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @crowdstrike/glide-core-components
+# @crowdstrike/glide-core
 
 ## 0.4.6
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -7,20 +7,20 @@ This package contains Web Components built with [Lit](https://lit.dev/).
 ### 1. Add Lit as a dependency
 
 ```bash
-pnpm i @crowdstrike/glide-core-components lit
+pnpm i @crowdstrike/glide-core lit
 ```
 
 ### 2. Import the fonts and variables
 
 ```css
-@import '@crowdstrike/glide-core-components/styles/fonts.css';
-@import '@crowdstrike/glide-core-components/styles/variables.css';
+@import '@crowdstrike/glide-core/styles/fonts.css';
+@import '@crowdstrike/glide-core/styles/variables.css';
 ```
 
 ### 3. Import the component you want to use
 
 ```js
-import '@crowdstrike/glide-core-components/button.js';
+import '@crowdstrike/glide-core/button.js';
 ```
 
 ### 4. Render your component

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@crowdstrike/glide-core-components",
+  "name": "@crowdstrike/glide-core",
   "version": "0.4.6",
   "description": "CrowdStrike's Glide Design System components package for providing web components",
   "author": "CrowdStrike UX Team",


### PR DESCRIPTION
## 🚀 Description

This PR builds on https://github.com/CrowdStrike/glide-core/pull/133.

Having `glide-core-components` as the name of our package is a bit confusing when folks could import only our styles via our package.  Instead, renaming the package to simply `glide-core` would clear up any confusion.  This PR does just that!

This brings up another discussion point that was discussed in the PR linked above: we now have `packages/components` in our directory structure.  The goal in a downstream, eventual PR would be to get rid of the multi-package setup we have now in favor of a single repo for a single package.  The ESLint plugin code could live alongside our component code - there's no real need to have it as a separate package either. This work is more of an "implementation detail" on our end, and a slight inconvenience to our group, so I don't believe it needs to be addressed as part of this PR. This work essentially makes DX better for our customers - the consumers, but won't change anything on their end when we axe the monorepo. 

## 📋 Checklist

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- A green build

## 📸 Images/Videos of Functionality

No visual changes
