### PR TITLE
Switch to corepack instead of volta

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pnpm dlx playwright install
 > [!NOTE]
 >
 > - If you have `ignore-scripts=true` in your `~/.npmrc`, you'll also need to run `pnpm prepare`, which will install some Git hooks for linting, formatting, typechecking, and testing.
-> - If you use [Volta](https://volta.sh), add `export VOLTA_FEATURE_PNPM=1` to your shell configuration to enable PNPM support.
+> - We recommend using [Corepack](https://pnpm.io/installation#using-corepack) to help manage the version of `pnpm` installed in this repository; however, it is not a requirement.
 
 ### Running Storybook
 

--- a/package.json
+++ b/package.json
@@ -38,8 +38,5 @@
     "node": ">= 20",
     "pnpm": ">= 8"
   },
-  "volta": {
-    "node": "20.12.2",
-    "pnpm": "9.0.6"
-  }
+  "packageManager": "pnpm@9.0.6+sha512.f6d863130973207cb7a336d6b439a242a26ac8068077df530d6a86069419853dc1ffe64029ec594a9c505a3a410d19643c870aba6776330f5cfddcf10a9c1617"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -61,10 +61,7 @@
     "node": ">= 20",
     "pnpm": ">= 8"
   },
-  "volta": {
-    "node": "20.12.2",
-    "pnpm": "9.0.6"
-  },
+  "packageManager": "pnpm@9.0.6+sha512.f6d863130973207cb7a336d6b439a242a26ac8068077df530d6a86069419853dc1ffe64029ec594a9c505a3a410d19643c870aba6776330f5cfddcf10a9c1617",
   "dependencies": {
     "@floating-ui/dom": "^1.5.4",
     "ow": "^1.1.1"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -49,8 +49,5 @@
     "node": ">= 20",
     "pnpm": ">= 8"
   },
-  "volta": {
-    "node": "20.12.2",
-    "pnpm": "9.0.6"
-  }
+  "packageManager": "pnpm@9.0.6+sha512.f6d863130973207cb7a336d6b439a242a26ac8068077df530d6a86069419853dc1ffe64029ec594a9c505a3a410d19643c870aba6776330f5cfddcf10a9c1617"
 }


### PR DESCRIPTION
## 🚀 Description

This move aligns this repository with other repositories we have.  It will take some work for each contributor here to migrate though.  Here were my steps:

- [Uninstall volta](https://docs.volta.sh/advanced/uninstall)
- Had to install the xcode command line tools again (not sure why)
  - `xcode-select --install`
- Install node
   - `brew install node@20`
- Double-checked node installed correctly
  - `node -v`
- Added node to PATH
  - `echo 'export PATH="/opt/homebrew/opt/node@20/bin:$PATH"' >> ~/.zshrc`
- Sourced the zshrc
  - `source ~/.zshrc`
- Enable corepack
  - `corepack enable pnpm`
- Went to glide-core
  - `cd oss/glide-core`
  - `corepack use pnpm@9.0.6`
    - To match the version we currently specify via `volta`
- Install dependencies
  - `pnpm i`
- Back to normal

After these steps, we get a new `packageManager` field in our `package.json`.  After his PR merges, that shouldn't show up for you.

## 📋 Checklist

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A