### PR TITLE
Remove outline-offset for tertiary icon buttons. Fixes modal back button focus outline

### DIFF
--- a/.changeset/warm-toes-hide.md
+++ b/.changeset/warm-toes-hide.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Remove outline-offset for tertiary icon buttons

--- a/packages/components/src/icon-button.styles.ts
+++ b/packages/components/src/icon-button.styles.ts
@@ -93,6 +93,10 @@ export default [
         border-color: transparent;
         color: var(--icon-color, var(--cs-icon-default));
 
+        &:focus-visible {
+          outline-offset: 0;
+        }
+
         &:disabled {
           color: var(--cs-icon-tertiary-disabled);
         }


### PR DESCRIPTION
## 🚀 Description

Since there's no border, we don't need to offset the focus outline. This prevents the outline from getting cut off from overflow

### Before

![image](https://github.com/CrowdStrike/glide-core/assets/11724146/5b29a521-7bb1-4ea6-bebf-d1db06fa1e19)

![image](https://github.com/CrowdStrike/glide-core/assets/11724146/dcc9dbbd-1d8c-414f-ace9-4fc5bd15352b)

### After 

![image](https://github.com/CrowdStrike/glide-core/assets/11724146/dafe5f1e-c476-44c6-963e-dd6e1a2f4552)

![image](https://github.com/CrowdStrike/glide-core/assets/11724146/b0e83f16-a72d-436b-82ad-52791149b6c1)

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
