### PR TITLE
Bring global Modal and Drawer styles inside Modal and Drawer

### DIFF
--- a/.changeset/tall-flies-explode.md
+++ b/.changeset/tall-flies-explode.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Removed `.glide-lock-scroll` from `variables.css` and marked it as private.

--- a/packages/components/src/drawer.ts
+++ b/packages/components/src/drawer.ts
@@ -10,6 +10,26 @@ declare global {
   }
 }
 
+const globalStylesheet = new CSSStyleSheet();
+
+globalStylesheet.insertRule(`
+  @supports (scrollbar-gutter: stable) {
+    .private-glide-core-drawer-lock-scroll {
+      scrollbar-gutter: stable !important;
+      overflow: hidden !important;
+    }
+  }
+`);
+
+globalStylesheet.insertRule(`
+  @supports not (scrollbar-gutter: stable) {
+    .private-glide-core-drawer-lock-scroll {
+      padding-right: var(--glide-scroll-size, 0.9375rem) !important;
+      overflow: hidden !important;
+    }
+  }
+`);
+
 /**
  * @cssprop [--width] - Sets the width of the Drawer when open.
  *
@@ -47,23 +67,50 @@ export default class GlideCoreDrawer extends LitElement {
 
         this.dispatchEvent(new Event('close'));
 
-        document.documentElement.classList.remove('glide-lock-scroll');
+        document.documentElement.classList.remove(
+          'private-glide-core-drawer-lock-scroll',
+        );
       },
       { once: true },
     );
 
     this.#dialogElementRef?.value?.classList?.add('closing');
-    document.documentElement.classList.add('glide-lock-scroll');
+
+    document.documentElement.classList.add(
+      'private-glide-core-drawer-lock-scroll',
+    );
 
     this.currentState = 'closing';
   }
 
-  override disconnectedCallback(): void {
+  override connectedCallback() {
+    super.connectedCallback();
+
+    const isAdopted = document.adoptedStyleSheets.includes(globalStylesheet);
+
+    if (!isAdopted) {
+      document.adoptedStyleSheets.push(globalStylesheet);
+    }
+  }
+
+  override disconnectedCallback() {
     super.disconnectedCallback();
 
-    if (document.documentElement.classList.contains('glide-lock-scroll')) {
-      document.documentElement.classList.remove('glide-lock-scroll');
+    if (
+      document.documentElement.classList.contains(
+        'private-glide-core-drawer-lock-scroll',
+      )
+    ) {
+      document.documentElement.classList.remove(
+        'private-glide-core-drawer-lock-scroll',
+      );
     }
+
+    document.adoptedStyleSheets = document.adoptedStyleSheets.filter(
+      (stylesheet) => {
+        return stylesheet !== globalStylesheet;
+      },
+    );
   }
 
   override firstUpdated() {
@@ -88,13 +135,19 @@ export default class GlideCoreDrawer extends LitElement {
 
         this.dispatchEvent(new Event('open'));
 
-        document.documentElement.classList.remove('glide-lock-scroll');
+        document.documentElement.classList.remove(
+          'private-glide-core-drawer-lock-scroll',
+        );
       },
       { once: true },
     );
 
     this.#dialogElementRef?.value?.classList?.add('open');
-    document.documentElement.classList.add('glide-lock-scroll');
+
+    document.documentElement.classList.add(
+      'private-glide-core-drawer-lock-scroll',
+    );
+
     this.currentState = 'opening';
 
     this.isOpen = true;

--- a/packages/components/src/modal.test.lock-scroll.ts
+++ b/packages/components/src/modal.test.lock-scroll.ts
@@ -18,7 +18,7 @@ after(() => {
   removeSpy.restore();
 });
 
-it('adds the "glide-lock-scroll" class to the documentElement when opened and removes it when closed', async () => {
+it('adds the "private-glide-core-modal-lock-scroll" class to the documentElement when opened and removes it when closed', async () => {
   const element = await fixture<GlideCoreModal>(
     html`<glide-core-modal label="Modal title"
       >Modal Content</glide-core-modal
@@ -28,20 +28,20 @@ it('adds the "glide-lock-scroll" class to the documentElement when opened and re
   element.showModal();
 
   expect(addSpy.callCount).to.equal(1);
-  expect(addSpy.calledWith('glide-lock-scroll')).to.be.ok;
+  expect(addSpy.calledWith('private-glide-core-modal-lock-scroll')).to.be.ok;
 
   expect(removeSpy.callCount).to.equal(0);
 
   element.close();
 
   expect(removeSpy.callCount).to.equal(1);
-  expect(removeSpy.calledWith('glide-lock-scroll')).to.be.ok;
+  expect(removeSpy.calledWith('private-glide-core-modal-lock-scroll')).to.be.ok;
 
   // Verify `add` was not called again for some reason
   expect(addSpy.callCount).to.equal(1);
 });
 
-it('removes the "glide-lock-scroll" class when the close button is clicked', async () => {
+it('removes the "private-glide-core-modal-lock-scroll" class when the close button is clicked', async () => {
   const element = await fixture<GlideCoreModal>(
     html`<glide-core-modal label="Modal title"
       >Modal Content</glide-core-modal
@@ -63,7 +63,7 @@ it('removes the "glide-lock-scroll" class when the close button is clicked', asy
   expect(removeSpy.callCount).to.equal(1);
 });
 
-it('removes the "glide-lock-scroll" class when the "close" method is called', async () => {
+it('removes the "private-glide-core-modal-lock-scroll" class when the "close" method is called', async () => {
   const element = await fixture<GlideCoreModal>(
     html`<glide-core-modal label="Modal title"
       >Modal Content</glide-core-modal
@@ -84,7 +84,7 @@ it('removes the "glide-lock-scroll" class when the "close" method is called', as
   expect(removeSpy.callCount).to.equal(1);
 });
 
-it('removes the "glide-lock-scroll" class when the escape key is pressed', async () => {
+it('removes the "private-glide-core-modal-lock-scroll" class when the escape key is pressed', async () => {
   const element = await fixture<GlideCoreModal>(
     html`<glide-core-modal label="Modal title"
       >Modal Content</glide-core-modal
@@ -100,7 +100,7 @@ it('removes the "glide-lock-scroll" class when the escape key is pressed', async
   expect(removeSpy.callCount).to.equal(1);
 });
 
-it('removes class "glide-lock-scroll" from document when click is outside dialog', async () => {
+it('removes class "private-glide-core-modal-lock-scroll" from document when click is outside dialog', async () => {
   const element = await fixture<GlideCoreModal>(
     html`<glide-core-modal label="Modal title"
       >Modal Content</glide-core-modal
@@ -113,8 +113,11 @@ it('removes class "glide-lock-scroll" from document when click is outside dialog
 
   expect(boundingRectangle).is.not.null;
 
-  expect(document.documentElement.classList.contains('glide-lock-scroll')).to.be
-    .true;
+  expect(
+    document.documentElement.classList.contains(
+      'private-glide-core-modal-lock-scroll',
+    ),
+  ).to.be.true;
 
   const { top, left } = boundingRectangle!;
 
@@ -123,6 +126,9 @@ it('removes class "glide-lock-scroll" from document when click is outside dialog
     position: [Math.floor(left - 1), Math.floor(top - 1)],
   });
 
-  expect(document.documentElement.classList.contains('glide-lock-scroll')).to.be
-    .false;
+  expect(
+    document.documentElement.classList.contains(
+      'private-glide-core-modal-lock-scroll',
+    ),
+  ).to.be.false;
 });

--- a/packages/components/src/styles/variables.css
+++ b/packages/components/src/styles/variables.css
@@ -2,37 +2,3 @@
 @import 'variables/light.css';
 @import 'variables/dark.css';
 @import 'variables/not-in-figma.css';
-
-/*
-  Modal component specific styles.
-
-  A few notes on these styles:
-  - Modal's need a way to lock the body from scrolling.
-    !important ensures we don't hit specificity issues.
-  - For Modal, we need to take into account the fact that
-    users may have scrollbars enabled via their OS. When
-    scrollbars are enabled, we need to account for the
-    offset that occurs with the <dialog element. When
-    a <dialog is opened, the background content shifts if
-    the main content area has scrollbars enabled because
-    they get *removed* when the <dialog is opened.
-    To combat this, we use `scrollbar-gutter` with a fallback.
-    For browsers that don't support it yet, we use padding
-    and a runtime calculation to ensure the content doesn't shift.
-
-  Safari appears to be the only browser without this enabeld at
-  the moment https://caniuse.com/mdn-css_properties_scrollbar-gutter
-*/
-@supports (scrollbar-gutter: stable) {
-  .glide-lock-scroll {
-    scrollbar-gutter: stable !important;
-    overflow: hidden !important;
-  }
-}
-
-@supports not (scrollbar-gutter: stable) {
-  .glide-lock-scroll {
-    padding-right: var(--glide-scroll-size, 0.9375rem) !important;
-    overflow: hidden !important;
-  }
-}


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- Moves Modal and Drawer's global styles from `variables.css` to `modal.ts` and `drawer.ts`. Modal and Drawer now lock scroll in a more encapsulated (though still global) way and independent of whether `variables.css` is imported.
- Renames `.glide-lock-scroll` to `.private-glide-core-modal-lock-scroll` and `.private-glide-core-drawer-lock-scroll`.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to the [Modal](https://glide-core.crowdstrike-ux.workers.dev/bring-modal-styles-inside-modal?path=/docs/modal--overview) story. 
2. Open Modal
3. Make sure Modal's backdrop doesn't scroll.
4. Make sure the constructed stylesheet is only applied once to `<html>`.

## 📸 Images/Videos of Functionality

N/A
