### PR TITLE
Let Dropdown expand to fill its container

### DIFF
--- a/.changeset/twenty-parrots-vanish.md
+++ b/.changeset/twenty-parrots-vanish.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown now expands to fill its container.

--- a/packages/components/src/dropdown.styles.ts
+++ b/packages/components/src/dropdown.styles.ts
@@ -10,6 +10,7 @@ export default [
     }
 
     .dropdown-and-options {
+      display: flex;
       position: relative;
     }
 
@@ -24,6 +25,7 @@ export default [
       color: var(--glide-core-text-body-1);
       cursor: inherit;
       display: inline-flex;
+      flex-grow: 1;
       font-size: var(--glide-core-body-sm-font-size);
       font-style: var(--glide-core-body-sm-font-style);
       font-weight: var(--glide-core-body-sm-font-weight);


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

So Dropdown behaves like other form controls. Also because a consumer needs Dropdown to behave this way.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

Open Storybook, then DevTools. Remove the `inline-block` from the `<form>` that wraps Dropdown. Dropdown should expand.

## 📸 Images/Videos of Functionality

### Before

<img width="645" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/33a517fd-8fe1-454d-b4e1-9bddd7d63a19">

### After

<img width="638" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/f3c9f1c4-dad8-43ed-8658-385bbf53a2c5">


<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
