### PR TITLE
Stop Dropdown from closing when a tag is removed

### DIFF
--- a/.changeset/khaki-gifts-collect.md
+++ b/.changeset/khaki-gifts-collect.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown no longer closes when a tag is removed.

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -726,8 +726,11 @@ export default class GlideCoreDropdown extends LitElement {
   }
 
   #onDropdownAndOptionsFocusout(event: FocusEvent) {
-    // If `event.relatedTarget` is `null`, focus has returned to `document.body`.
-    if (event.relatedTarget === null) {
+    // If `event.relatedTarget` is `null`, focus has moved outside this component's
+    // shadow DOM, which means the user is done interacting with Dropodown. So we
+    // close it except when focus has moved to a tag, which tells us Dropdown is
+    // still in use.
+    if (event.relatedTarget === null && !this.#isRemovingTag) {
       this.open = false;
     }
   }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Make a selection when multiselect.
2. Click the "X" on the tag.
3. Dropdown should remain open.

## 📸 Images/Videos of Functionality

N/A
