### PR TITLE
Update paths for CSS in package.json exports

### DIFF
--- a/.changeset/fair-sheep-do.md
+++ b/.changeset/fair-sheep-do.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Updated the CSS import paths in the package.json exports field so the CSS files can be imported properly by applications.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,8 +29,8 @@
     "./styles/*": null,
     "./label.js": null,
     "./toasts.toast.js": null,
-    "./styles/fonts.js": "./dist/styles/fonts.js",
-    "./styles/variables.js": "./dist/styles/variables.js"
+    "./styles/fonts.css": "./dist/styles/fonts.css",
+    "./styles/variables.css": "./dist/styles/variables.css"
   },
   "scripts": {
     "start": "per-env",


### PR DESCRIPTION
## 🚀 Description

Fixes the `package.json#exports` so that apps can properly import the CSS files.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A