### PR TITLE
Add backdrop-filter blur to drawer

### DIFF
--- a/.changeset/light-donkeys-raise.md
+++ b/.changeset/light-donkeys-raise.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Adjusted Drawer to contain a blurred backdrop filter.

--- a/packages/components/src/drawer.styles.ts
+++ b/packages/components/src/drawer.styles.ts
@@ -4,6 +4,7 @@ export default [
   css`
     .component {
       all: unset;
+      backdrop-filter: blur(50px);
       background-color: var(--glide-core-surface-base-lighter);
       block-size: 0;
       border-end-start-radius: 0.625rem;


### PR DESCRIPTION
## 🚀 Description

This fixes a bug with Drawer, where we were missing the `backdrop-filter` CSS property.  Confirmed with Zheng this is what we want.

## 📋 Checklist


- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Could verify the CSS property exists, but it's very subtle.

## 📸 Images/Videos of Functionality

It's too subtle to make a difference on a white or dark background, but in a very _extreme_ case:

<img width="1600" alt="Screenshot 2024-06-21 at 9 43 36 AM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/b584beaf-2c9f-4d44-87a8-285fcfcad2fa">

