### PR TITLE
Add Dropdown `readonly` attribute

### DIFF
--- a/.changeset/perfect-suns-search.md
+++ b/.changeset/perfect-suns-search.md
@@ -1,0 +1,8 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Dropdown now has a `readonly` attribute.
+- Dropdown is no longer tabbable when disabled.
+- Dropdown no longer opens on ArrowDown, ArrowUp, and Space when disabled.
+- The background color of the filtering field now matches the rest of Dropdown when disabled.

--- a/packages/components/src/dropdown.stories.ts
+++ b/packages/components/src/dropdown.stories.ts
@@ -34,6 +34,7 @@ const meta: Meta = {
     orientation: 'horizontal',
     multiple: false,
     name: 'name',
+    readonly: false,
     required: false,
     'select-all': false,
     size: 'large',
@@ -182,6 +183,13 @@ const meta: Meta = {
       },
       type: { name: 'string', required: true },
     },
+    readonly: {
+      control: 'boolean',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
     required: {
       control: 'boolean',
       table: {
@@ -270,6 +278,7 @@ const meta: Meta = {
         ?hide-label=${arguments_['hide-label'] || nothing}
         ?multiple=${arguments_.multiple}
         ?open=${arguments_.open}
+        ?readonly=${arguments_.readonly}
         ?required=${arguments_.required}
         ?select-all=${arguments_['select-all']}
       >
@@ -335,6 +344,7 @@ export const SingleSelectionHorizontalWithIcon: StoryObj = {
         ?multiple=${arguments_.multiple}
         ?open=${arguments_.open}
         ?disabled=${arguments_.disabled}
+        ?readonly=${arguments_.readonly}
         ?required=${arguments_.required}
         ?select-all=${arguments_['select-all']}
       >
@@ -415,6 +425,7 @@ export const SingleSelectionVerticalWithIcon: StoryObj = {
         ?multiple=${arguments_.multiple}
         ?open=${arguments_.open}
         ?disabled=${arguments_.disabled}
+        ?readonly=${arguments_.readonly}
         ?required=${arguments_.required}
         ?select-all=${arguments_['select-all']}
       >
@@ -492,6 +503,7 @@ export const SingleSelectionHorizontalWithFiltering: StoryObj = {
         ?multiple=${arguments_.multiple}
         ?open=${arguments_.open}
         ?disabled=${arguments_.disabled}
+        ?readonly=${arguments_.readonly}
         ?required=${arguments_.required}
         ?select-all=${arguments_['select-all']}
       >
@@ -589,6 +601,7 @@ export const MultipleSelectionHorizontalWithFiltering: StoryObj = {
         ?multiple=${arguments_.multiple}
         ?open=${arguments_.open}
         ?disabled=${arguments_.disabled}
+        ?readonly=${arguments_.readonly}
         ?required=${arguments_.required}
         ?select-all=${arguments_['select-all']}
       >

--- a/packages/components/src/dropdown.styles.ts
+++ b/packages/components/src/dropdown.styles.ts
@@ -64,15 +64,20 @@ export default [
         color: var(--glide-core-status-error);
       }
 
+      &.readonly {
+        border-color: transparent;
+        padding-inline-start: 0;
+      }
+
       &:has(.button:focus-visible, .input:focus-visible) {
         ${focusOutline};
       }
 
-      &:hover:not(&.error, &.disabled) {
+      &:hover:not(&.error, &.disabled, &.readonly) {
         border-color: var(--glide-core-border-base);
       }
 
-      &.quiet:hover:not(&.error, &.disabled, &.multiple) {
+      &.quiet:hover:not(&.error, &.disabled, &.multiple, &.readonly) {
         background-color: var(--glide-core-surface-hover);
       }
     }
@@ -139,6 +144,7 @@ export default [
       background: none;
       block-size: var(--button-and-input-height);
       border: none;
+      cursor: inherit;
       display: flex;
       padding: 0;
 
@@ -148,8 +154,10 @@ export default [
     }
 
     .input {
+      background-color: transparent;
       block-size: var(--button-and-input-height);
       border: none;
+      cursor: inherit;
       font-size: inherit;
       min-inline-size: var(--min-inline-size);
       padding: 0;
@@ -166,6 +174,13 @@ export default [
 
       &::placeholder {
         font-family: var(--glide-core-font-sans);
+      }
+    }
+
+    .caret-icon {
+      &.disabled,
+      &.readonly {
+        color: var(--glide-core-surface-selected-disabled);
       }
     }
   `,

--- a/packages/components/src/dropdown.test.interactions.filterable.ts
+++ b/packages/components/src/dropdown.test.interactions.filterable.ts
@@ -580,3 +580,19 @@ it('sets `aria-activedescendant` on Meta + ArrowDown', async () => {
     options.at(-1)?.id,
   );
 });
+
+it('cannot be tabbed to when `disabled`', async () => {
+  await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      multiple
+      disabled
+    >
+      ${defaultSlot}
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ down: 'Tab' });
+  expect(document.activeElement).to.equal(document.body);
+});

--- a/packages/components/src/dropdown.test.interactions.multiple.ts
+++ b/packages/components/src/dropdown.test.interactions.multiple.ts
@@ -1126,3 +1126,27 @@ it('does not select an option on Enter when the option is not focused', async ()
 
   expect(option?.selected).to.be.false;
 });
+
+it('cannot be tabbed to when `disabled`', async () => {
+  await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      disabled
+      multiple
+    >
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ down: 'Tab' });
+  expect(document.activeElement).to.equal(document.body);
+});

--- a/packages/components/src/dropdown.test.interactions.single.ts
+++ b/packages/components/src/dropdown.test.interactions.single.ts
@@ -559,3 +559,22 @@ it('does not select an option on Enter when the option is not focused', async ()
 
   expect(option?.selected).to.be.false;
 });
+
+it('cannot be tabbed to when `disabled`', async () => {
+  await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" disabled>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ down: 'Tab' });
+  expect(document.activeElement).to.equal(document.body);
+});

--- a/packages/components/src/dropdown.test.interactions.ts
+++ b/packages/components/src/dropdown.test.interactions.ts
@@ -25,6 +25,38 @@ it('opens on ArrowUp', async () => {
   expect(option?.privateActive).to.be.true;
 });
 
+it('does not open on ArrowUp when `disabled`', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" disabled>
+      <glide-core-dropdown-option
+        label="Label"
+        value="value"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.focus();
+  await sendKeys({ press: 'ArrowUp' });
+
+  expect(component.open).to.be.false;
+});
+
+it('does not open on ArrowUp when `readonly`', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" readonly>
+      <glide-core-dropdown-option
+        label="Label"
+        value="value"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.focus();
+  await sendKeys({ press: 'ArrowUp' });
+
+  expect(component.open).to.be.false;
+});
+
 it('opens on ArrowDown', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder">
@@ -49,6 +81,48 @@ it('opens on ArrowDown', async () => {
   expect(option?.privateActive).to.be.true;
 });
 
+it('does not open on ArrowDown when `disabled`', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" disabled>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.focus();
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(component.open).to.be.false;
+});
+
+it('does not open on ArrowDown when `readonly`', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" readonly>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.focus();
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(component.open).to.be.false;
+});
+
 it('opens on Space', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder">
@@ -63,6 +137,38 @@ it('opens on Space', async () => {
   await sendKeys({ press: ' ' });
 
   expect(component.open).to.be.true;
+});
+
+it('does not open on Space when `disabled`', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" disabled>
+      <glide-core-dropdown-option
+        label="Label"
+        value="value"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.focus();
+  await sendKeys({ press: ' ' });
+
+  expect(component.open).to.be.false;
+});
+
+it('does not open on Space when `readonly`', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" readonly>
+      <glide-core-dropdown-option
+        label="Label"
+        value="value"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.focus();
+  await sendKeys({ press: ' ' });
+
+  expect(component.open).to.be.false;
 });
 
 // See the `document` click listener comment in `dropdown.ts` for an explanation.

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -62,6 +62,9 @@ export default class GlideCoreDropdown extends LitElement {
   @property({ reflect: true })
   placeholder?: string;
 
+  @property({ type: Boolean })
+  readonly = false;
+
   @property({ attribute: 'select-all', reflect: true, type: Boolean })
   selectAll = false;
 
@@ -321,6 +324,7 @@ export default class GlideCoreDropdown extends LitElement {
               quiet: this.variant === 'quiet',
               disabled: this.disabled,
               error: this.#isShowValidationFeedback,
+              readonly: this.readonly,
               multiple: this.multiple,
             })}
             @click=${this.#onDropdownClick}
@@ -393,6 +397,9 @@ export default class GlideCoreDropdown extends LitElement {
                   : this.selectedOptions.at(-1)?.label ?? ''}
                 role="combobox"
                 spellcheck="false"
+                tabindex=${this.disabled ? '-1' : '0'}
+                ?disabled=${this.disabled}
+                ?readonly=${this.readonly}
                 @input=${this.#onInputInput}
                 @keydown=${this.#onInputKeydown}
                 ${ref(this.#inputElementRef)}
@@ -428,7 +435,7 @@ export default class GlideCoreDropdown extends LitElement {
               class="button"
               data-test="button"
               id="button"
-              tabindex=${this.isFilterable ? '-1' : '0'}
+              tabindex=${this.isFilterable || this.disabled ? '-1' : '0'}
               type="button"
               ${ref(this.#buttonElementRef)}
             >
@@ -442,6 +449,11 @@ export default class GlideCoreDropdown extends LitElement {
                 () => {
                   return svg`<svg
                     aria-label="Open"
+                    class=${classMap({
+                      'caret-icon': true,
+                      disabled: this.disabled,
+                      readonly: this.readonly,
+                    })}
                     width="16"
                     height="16"
                     viewBox="0 0 24 24"
@@ -730,6 +742,10 @@ export default class GlideCoreDropdown extends LitElement {
   // options can receive focus via VoiceOver, and `.dropdown` won't emit a "keydown"
   // if an option is focused.
   #onDropdownAndOptionsKeydown(event: KeyboardEvent) {
+    if (this.disabled || this.readonly) {
+      return;
+    }
+
     if (event.key === 'Escape') {
       this.open = false;
       this.focus();
@@ -890,6 +906,10 @@ export default class GlideCoreDropdown extends LitElement {
   }
 
   #onDropdownClick(event: MouseEvent) {
+    if (this.disabled || this.readonly) {
+      return;
+    }
+
     if (this.#isRemovingTag) {
       this.#isRemovingTag = false;
       return;


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- Adds a `readonly` attribute.
- Fills in some test gaps when `disabled`.
- Gives `.input` a transparent background so it matches `.dropdown`'s background when disabled.
- `.input` and `.button` can no longer be tabbed to when Dropdown is disabled. Tests for this as well.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Open Storybook.
1. Set `readonly` to `false`.
1. Make sure the left padding, border are gone and the color of the caret icon has changed.

## 📸 Images/Videos of Functionality

<img width="236" alt="image" src="https://github.com/CrowdStrike/glide-core/assets/114178960/e19614fc-306f-4447-bd87-2b7d14b52d71">
