### PR TITLE
Add backdrop-filter to Modal

### DIFF
--- a/.changeset/tidy-papayas-perform.md
+++ b/.changeset/tidy-papayas-perform.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Add `backdrop-filter` to the Modal component as the designs call for to fix the background from bleeding into the Modal content.

--- a/packages/components/src/modal.styles.ts
+++ b/packages/components/src/modal.styles.ts
@@ -27,6 +27,7 @@ export default [
     }
 
     .component {
+      backdrop-filter: blur(100px);
       background-color: var(--glide-core-surface-base-lighter);
       border: none;
       border-radius: 0.5rem;


### PR DESCRIPTION
## 🚀 Description

The designs call for `backdrop-filter` to go along with `shadow-lg`, so here it is.

## 📋 Checklist

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Go to https://glide-core.crowdstrike-ux.workers.dev/fix-modal-backdrop?path=/docs/modal--overview
- Open the Modal

## 📸 Images/Videos of Functionality

| Before  | After |
| ------------- | ------------- |
| <img width="1970" alt="Screenshot 2024-06-26 at 1 40 00 PM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/54bb8b15-c2dd-4d78-9289-10d8d50f8424">  |  <img width="1970" alt="Screenshot 2024-06-26 at 1 40 16 PM" src="https://github.com/CrowdStrike/glide-core/assets/8069555/46464073-4994-47da-aefc-d15afb4cc69f">  |
| Without backdrop filter | With backdrop filter  |




