### PR TITLE
Activate the last initially selected Dropdown option on first open

### DIFF
--- a/.changeset/two-toes-suffer.md
+++ b/.changeset/two-toes-suffer.md
@@ -1,0 +1,7 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown.
+Activate the last initially selected option on first open instead of the first option.
+Activate the first option only if no options are selected.

--- a/packages/components/src/dropdown.test.basics.multiple.ts
+++ b/packages/components/src/dropdown.test.basics.multiple.ts
@@ -24,6 +24,31 @@ it('is accessible', async () => {
   await expect(component).to.be.accessible();
 });
 
+it('sets `value` to that of the initially selected options', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown open multiple>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  expect(component.value).to.deep.equal(['two', 'three']);
+});
+
 it('has selected option labels when options are initially selected', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" multiple>

--- a/packages/components/src/dropdown.test.basics.single.ts
+++ b/packages/components/src/dropdown.test.basics.single.ts
@@ -60,6 +60,31 @@ it('sets its internal label to the last initially selected option', async () => 
   expect(label?.textContent?.trim()).to.equal('Two');
 });
 
+it('sets `value` to that of the last initially selected option', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown open>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  expect(component.value).to.deep.equal(['three']);
+});
+
 it('hides Select All', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder">

--- a/packages/components/src/dropdown.test.basics.ts
+++ b/packages/components/src/dropdown.test.basics.ts
@@ -224,6 +224,56 @@ it('can be `select-all`', async () => {
   expect(component.selectAll).to.equal(true);
 });
 
+it('activates the first option when no options are initially selected', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown open>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = component.querySelectorAll('glide-core-dropdown-option');
+
+  expect(options[0]?.privateActive).to.be.true;
+  expect(options[1]?.privateActive).to.be.false;
+});
+
+it('activates the last selected option when options are initially selected', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown open>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = component.querySelectorAll('glide-core-dropdown-option');
+
+  expect(options[0]?.privateActive).to.be.false;
+  expect(options[1]?.privateActive).to.be.false;
+  expect(options[2]?.privateActive).to.be.true;
+});
+
 it('throws if the default slot is the incorrect type', async () => {
   await expectArgumentError(() => {
     return fixture<GlideCoreDropdown>(

--- a/packages/components/src/dropdown.test.focus.ts
+++ b/packages/components/src/dropdown.test.focus.ts
@@ -1,0 +1,25 @@
+import './dropdown.option.js';
+import { expect, fixture, html } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
+import GlideCoreDropdown from './dropdown.js';
+import GlideCoreDropdownOption from './dropdown.option.js';
+
+GlideCoreDropdown.shadowRootOptions.mode = 'open';
+GlideCoreDropdownOption.shadowRootOptions.mode = 'open';
+
+it('closes when it loses focus', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
+      <glide-core-dropdown-option
+        label="Label"
+        value="value"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.focus();
+
+  await sendKeys({ press: 'Tab' });
+
+  expect(component.open).to.be.false;
+});

--- a/packages/components/src/dropdown.test.interactions.ts
+++ b/packages/components/src/dropdown.test.interactions.ts
@@ -160,27 +160,6 @@ it('activates an option on "mouseover"', async () => {
   expect(options[1]?.privateActive).to.be.true;
 });
 
-it('activates the first option by default', async () => {
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown open>
-      <glide-core-dropdown-option
-        label="One"
-        value="one"
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option
-        label="Two"
-        value="two"
-      ></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  const options = component.querySelectorAll('glide-core-dropdown-option');
-
-  expect(options[0]?.privateActive).to.be.true;
-  expect(options[1]?.privateActive).to.be.false;
-});
-
 it('activates the next option on ArrowDown', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -96,15 +96,15 @@ export default class GlideCoreDropdown extends LitElement {
 
       // A single-select can only have one option selected. All but the last one
       // are deselected.
-      if (wasMultiple && option !== this.lastSelectedOptionWithValue) {
+      if (wasMultiple && option !== this.lastSelectedOption) {
         option.selected = false;
       }
     }
 
-    if (wasMultiple && this.lastSelectedOptionWithValue) {
-      this.value = [this.lastSelectedOptionWithValue.value];
-    } else if (wasSingle && this.lastSelectedOptionWithValue) {
-      this.lastSelectedOptionWithValue.privateUpdateCheckbox();
+    if (wasMultiple && this.lastSelectedOption?.value) {
+      this.value = [this.lastSelectedOption.value];
+    } else if (wasSingle && this.lastSelectedOption) {
+      this.lastSelectedOption.privateUpdateCheckbox();
     }
   }
 
@@ -129,10 +129,8 @@ export default class GlideCoreDropdown extends LitElement {
     );
   }
 
-  private get lastSelectedOptionWithValue() {
-    return this.#optionElements.findLast(
-      (option) => option.selected && option.value,
-    );
+  private get lastSelectedOption() {
+    return this.#optionElements.findLast((option) => option.selected);
   }
 
   private get isAllSelected() {
@@ -681,19 +679,25 @@ export default class GlideCoreDropdown extends LitElement {
       }
     }
 
+    const firstOption = this.#optionElementsNotHiddenIncludingSelectAll?.at(0);
+
     // Even with single-select, there's nothing to stop developers from adding
     // a `selected` attribute to more than one option. How native handles this
     // when setting `value` is to choose the last selected option.
     //
     // We're not setting `value` here. But we follow native's behavior elsewhere
     // when setting `value`. So we do the same here when setting `privateActive`.
-    if (this.lastSelectedOptionWithValue?.value) {
+    if (this.lastSelectedOption) {
       this.#deactivateAllOptions();
-      this.lastSelectedOptionWithValue.privateActive = true;
-      this.ariaActivedescendant = this.lastSelectedOptionWithValue.id;
+      this.lastSelectedOption.privateActive = true;
+      this.ariaActivedescendant = this.lastSelectedOption.id;
+    } else if (firstOption) {
+      this.#deactivateAllOptions();
+      firstOption.privateActive = true;
+      this.ariaActivedescendant = firstOption.id;
     }
 
-    // Update Select All to reflect the latest selection change.
+    // Update Select All to reflect the selected options.
     if (this.#selectAllElementRef.value) {
       this.#isInternalSelectAllChange = true;
       this.#selectAllElementRef.value.selected = this.isAllSelected;
@@ -702,22 +706,13 @@ export default class GlideCoreDropdown extends LitElement {
         this.isSomeSelected && !this.isAllSelected;
     }
 
-    const firstOption = this.#optionElementsNotHiddenIncludingSelectAll?.at(0);
-
-    // Activate the first option.
-    if (firstOption) {
-      this.#deactivateAllOptions();
-      firstOption.privateActive = true;
-      this.ariaActivedescendant = firstOption.id;
-    }
-
     // Set `value`.
     if (this.multiple) {
       this.value = this.selectedOptions
         .filter((option) => Boolean(option.value))
         .map(({ value }) => value);
-    } else if (this.lastSelectedOptionWithValue?.value) {
-      this.value = [this.lastSelectedOptionWithValue.value];
+    } else if (this.lastSelectedOption?.value) {
+      this.value = [this.lastSelectedOption.value];
     }
   }
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Dropdown should activate the last initially selected option on first open instead of always activating the first option. This fixes that. The first option is activated only when no options are selected.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Check out this branch.
2. Open `packages/components/src/dropdown.stories.ts` and add a `selected` attribute to the [second option](https://github.com/CrowdStrike/glide-core/blob/main/packages/components/src/dropdown.stories.ts#L284).
3. Open [the first](http://localhost:6006/?path=/story/dropdown--single-selection-horizontal) Dropdown story.
4. Open Dropdown.
5. Make sure the second option is active. 

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A