### PR TITLE
Handle external programmatic changes to Dropdown's `value`

### DIFF
--- a/.changeset/stupid-flowers-join.md
+++ b/.changeset/stupid-flowers-join.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown's `value` is no longer read-only.

--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -30,7 +30,3 @@ runs:
     - name: Install dependencies
       shell: bash
       run: pnpm install
-
-    - name: Install Playwright
-      shell: bash
-      run: pnpm dlx playwright@1.45.0 install --with-deps

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,8 @@
     "test:development:serve": "npx http-server dist/coverage/lcov-report --silent",
     "test:development:web-test-runner": "web-test-runner --watch",
     "test:production": "npm-run-all --parallel test:production:* start:production:stylesheets --aggregate-output --print-label",
-    "test:production:web-test-runner": "web-test-runner"
+    "test:production:web-test-runner": "web-test-runner",
+    "postinstall": "pnpm dlx playwright install --with-deps"
   },
   "engines": {
     "node": ">= 20",

--- a/packages/components/src/dropdown.stories.ts
+++ b/packages/components/src/dropdown.stories.ts
@@ -216,7 +216,7 @@ const meta: Meta = {
       table: {
         defaultValue: { summary: '[]' },
         type: {
-          summary: 'readonly string[]',
+          summary: 'string[]',
         },
       },
       type: { name: 'function' },

--- a/packages/components/src/dropdown.test.interactions.filterable.ts
+++ b/packages/components/src/dropdown.test.interactions.filterable.ts
@@ -316,7 +316,9 @@ it('uses the label of the selected option as a placeholder when not `multiple`',
     </glide-core-dropdown>`,
   );
 
-  component?.querySelector('glide-core-dropdown-option')?.click();
+  const option = component?.querySelector('glide-core-dropdown-option');
+
+  option?.click();
 
   await elementUpdated(component);
 
@@ -324,7 +326,7 @@ it('uses the label of the selected option as a placeholder when not `multiple`',
     '[data-test="input"]',
   );
 
-  expect(input?.placeholder).to.equal('One');
+  expect(input?.placeholder).to.equal(option?.label);
 });
 
 it('uses `placeholder` as a placeholder when `multiple` and an option is selected', async () => {

--- a/packages/components/src/dropdown.test.interactions.multiple.ts
+++ b/packages/components/src/dropdown.test.interactions.multiple.ts
@@ -415,6 +415,58 @@ it('does not activate the next option on ArrowDown when a tag is focused', async
   expect(options[0]?.privateActive).to.be.true;
 });
 
+it('selects and deselects options when `value` is changed programmatically', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" multiple>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.value = ['two', 'three'];
+
+  const options = component.querySelectorAll('glide-core-dropdown-option');
+
+  expect(options[0].selected).to.be.false;
+  expect(options[1].selected).to.be.true;
+  expect(options[2].selected).to.be.true;
+});
+
+it('selects no options when `value` is changed programmatically to an empty string and some options have no `value`', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" multiple>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.value = [''];
+
+  const options = component.querySelectorAll('glide-core-dropdown-option');
+
+  expect(options[0].selected).to.be.false;
+  expect(options[1].selected).to.be.false;
+  expect(options[2].selected).to.be.false;
+});
+
 it('updates `value` when an option is selected or deselected via click', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

`value` is currently read-only to mimic native. We try not to deviate from native except when it greatly reduces complexity or when native is silly or unintuitive.

We recently had a consumer trying to set `value` directly. He was surprised his change didn't affect Dropdown's placeholder and which options were selected. I would be too. So this seems like an obvious case to deviate from native.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

#### Single-select

1. Open [Dropdown](https://glide-core.crowdstrike-ux.workers.dev/dropdown-value-readonly?path=/story/dropdown--single-selection-horizontal) in Storybook.
1. Change `value` to `['one']` using DevTools.
1. Check that the correct option is selected and that Dropdown's placeholder has changed.

#### Multiselect

1. Open [Dropdown](https://glide-core.crowdstrike-ux.workers.dev/dropdown-value-readonly?path=/story/dropdown--single-selection-horizontal) in Storybook.
1. Change  `value` to `['one', 'two']` using DevTools.
1. Check that the correct options are selected and  there is a tag for each.

## 📸 Images/Videos of Functionality

N/A
