### PR TITLE
Update tooltip to have a max-width and wrap.

### DIFF
--- a/.changeset/cold-snakes-drop.md
+++ b/.changeset/cold-snakes-drop.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Tooltips now have a max-width and overflow wrap the provided text rather than growing for eternity in length.

--- a/packages/components/src/tooltip.styles.ts
+++ b/packages/components/src/tooltip.styles.ts
@@ -43,6 +43,8 @@ export default [
       inset-block-start: 50%;
       inset-block-start: 0;
       inset-inline-start: 0;
+      max-inline-size: 11.25rem;
+      overflow-wrap: break-word;
       padding: var(--glide-core-spacing-xs) var(--glide-core-spacing-sm);
       position: fixed;
       z-index: 1;


### PR DESCRIPTION
## 🚀 Description

Updates Tooltip to have a `max-width` (logical property) as the designs call for.

I initially added `word-wrap`, but learned [from the docs](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap):

> The property was originally a nonstandard and unprefixed Microsoft extension called word-wrap, and was implemented by most browsers with the same name. It has since been renamed to overflow-wrap, with word-wrap being an alias.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A - small visual fix. See images below.

## 📸 Images/Videos of Functionality

| Before  | After |
| ------------- | ------------- |
| <img width="1522" alt="before" src="https://github.com/CrowdStrike/glide-core/assets/8069555/bb1fcf20-859e-4018-a5aa-b0c275a4e583"> | <img width="1516" alt="after" src="https://github.com/CrowdStrike/glide-core/assets/8069555/25a78e90-aa00-4d28-8d4b-7c831c4a0ee4">  |




