### PR TITLE
Add Form Controls Layout

### DIFF
--- a/.changeset/fifty-deers-reflect.md
+++ b/.changeset/fifty-deers-reflect.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Remove the left margin on Button when a prefix icon is present to improve visual balancing.

--- a/.changeset/five-peas-sort.md
+++ b/.changeset/five-peas-sort.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Form control labels now truncate with an ellipsis when too long, and they show a tooltip when the truncated label is hovered.

--- a/.changeset/pink-timers-yawn.md
+++ b/.changeset/pink-timers-yawn.md
@@ -1,0 +1,18 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Add a Form Controls Layout component.
+
+Form Controls Layout accepts any number of Glide Core form controls in its default slot.
+It supports a single attribute, `split`, whose value can be `"left"` or `"middle"`:
+
+- `"left"`, the default, puts the controls' labels into a one-third column and the controls themselves into a two-thirds column.
+- `"middle"` puts the controls' labels and controls into two equal-width columns.
+
+```html
+<glide-core-form-controls-layout split="left">
+  <glide-core-input label="Label" placeholder="Placeholder" />
+  <glide-core-checkbox label="Label" />
+</glide-core-form-controls-layout>
+```

--- a/.changeset/serious-actors-cry.md
+++ b/.changeset/serious-actors-cry.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Add a `disabled` attribute to Tooltip.

--- a/.changeset/sour-walls-serve.md
+++ b/.changeset/sour-walls-serve.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Prevent Checkbox's checkbox from shrinking when its summary wraps.

--- a/packages/components/src/button.styles.ts
+++ b/packages/components/src/button.styles.ts
@@ -42,7 +42,7 @@ export default [
       }
 
       /* We remove spacing using negative margin when an icon is present to help with empty space balancing */
-      &.has-prefx,
+      &.has-prefix,
       ::slotted([slot='prefix']) {
         margin-inline-start: -0.125rem;
       }

--- a/packages/components/src/checkbox-group.styles.ts
+++ b/packages/components/src/checkbox-group.styles.ts
@@ -10,7 +10,7 @@ export default [
       }
     }
 
-    glide-core-label::part(tooltip-and-label-container) {
+    glide-core-label::part(tooltips-and-label) {
       align-items: flex-start;
     }
 

--- a/packages/components/src/checkbox-group.ts
+++ b/packages/components/src/checkbox-group.ts
@@ -2,6 +2,7 @@ import './label.js';
 import { LitElement, html } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { owSlot, owSlotType } from './library/ow.js';
 import GlideCoreCheckbox from './checkbox.js';
 import styles from './checkbox-group.styles.js';
@@ -51,6 +52,9 @@ export default class GlideCoreCheckboxGroup extends LitElement {
 
   @property({ reflect: true })
   name?: string;
+
+  @property()
+  privateSplit?: 'left' | 'middle';
 
   @property({ reflect: true, type: Boolean })
   get required() {
@@ -170,6 +174,7 @@ export default class GlideCoreCheckboxGroup extends LitElement {
       ${ref(this.#componentElementRef)}
     >
       <glide-core-label
+        split=${ifDefined(this.privateSplit ?? undefined)}
         ?hide=${this.hideLabel}
         ?disabled=${this.disabled}
         ?error=${this.#isShowValidationFeedback}

--- a/packages/components/src/checkbox.styles.ts
+++ b/packages/components/src/checkbox.styles.ts
@@ -33,6 +33,9 @@ when browsers support them.
 
     .input-and-checkbox {
       block-size: 0.875rem;
+
+      /* Prevent shrinkage when the summary wraps. */
+      flex-shrink: 0;
       inline-size: 0.875rem;
       position: relative;
     }

--- a/packages/components/src/checkbox.ts
+++ b/packages/components/src/checkbox.ts
@@ -3,6 +3,7 @@ import { LitElement, html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { svg } from 'lit/static-html.js';
 import { when } from 'lit/directives/when.js';
 import checkedIcon from './icons/checked.js';
@@ -64,6 +65,9 @@ export default class GlideCoreCheckbox extends LitElement {
 
   @property({ reflect: true })
   name?: string;
+
+  @property()
+  privateSplit?: 'left' | 'middle';
 
   @property({ attribute: 'private-variant' })
   privateVariant?: 'minimal';
@@ -171,6 +175,7 @@ export default class GlideCoreCheckbox extends LitElement {
         () =>
           html`<glide-core-label
             orientation=${this.orientation}
+            split=${ifDefined(this.privateSplit ?? undefined)}
             ?disabled=${this.disabled}
             ?error=${this.#isShowValidationFeedback}
             ?hide=${this.hideLabel}

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -6,6 +6,7 @@ import { LocalizeController } from './library/localize.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { svg } from 'lit/static-html.js';
 import { when } from 'lit/directives/when.js';
@@ -62,6 +63,9 @@ export default class GlideCoreDropdown extends LitElement {
 
   @property({ reflect: true })
   placeholder?: string;
+
+  @property()
+  privateSplit?: 'left' | 'middle';
 
   @property({ type: Boolean })
   readonly = false;
@@ -333,6 +337,7 @@ export default class GlideCoreDropdown extends LitElement {
       })}
     >
       <glide-core-label
+        split=${ifDefined(this.privateSplit ?? undefined)}
         orientation=${this.orientation}
         ?disabled=${this.disabled}
         ?error=${this.#isShowValidationFeedback}

--- a/packages/components/src/form-controls-layout.stories.ts
+++ b/packages/components/src/form-controls-layout.stories.ts
@@ -1,0 +1,99 @@
+import './checkbox-group.js';
+import './dropdown';
+import './form-controls-layout.js';
+import './input.js';
+import './radio-group.js';
+import './radio.js';
+import { html } from 'lit';
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+const meta: Meta = {
+  title: 'Form Controls Layout',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Aligns form control labels and the controls themselves in two columns. Only horizontal controls are supported.',
+      },
+    },
+  },
+  args: {
+    'slot="default"': '',
+    split: 'left',
+  },
+  argTypes: {
+    'slot="default"': {
+      table: {
+        type: {
+          summary:
+            'GlideCoreCheckbox | GlideCoreCheckboxGroup | GlideCoreDropdown | GlideCoreInput | GlideCoreTextArea',
+        },
+      },
+      type: { name: 'function', required: true },
+    },
+    split: {
+      control: { type: 'radio' },
+      options: ['left', 'middle'],
+      table: {
+        defaultValue: { summary: '"left"' },
+        type: { summary: '"left" | "middle"' },
+      },
+    },
+  },
+  render(arguments_) {
+    return html`
+      <form style="height: 15rem;">
+        <glide-core-form-controls-layout split=${arguments_.split}>
+          <glide-core-checkbox-group label="Label">
+            <glide-core-checkbox label="One" value="one"></glide-core-checkbox>
+            <glide-core-checkbox label="Two" value="two"></glide-core-checkbox>
+
+            <glide-core-checkbox
+              label="Three"
+              value="three"
+            ></glide-core-checkbox>
+          </glide-core-checkbox-group>
+
+          <glide-core-dropdown
+            label="Label"
+            name="name"
+            placeholder="Placeholder"
+            size="large"
+          >
+            <glide-core-dropdown-option
+              label="One"
+              value="one"
+            ></glide-core-dropdown-option>
+
+            <glide-core-dropdown-option
+              label="Two"
+              value="two"
+            ></glide-core-dropdown-option>
+
+            <glide-core-dropdown-option
+              label="Three"
+              value="three"
+            ></glide-core-dropdown-option>
+          </glide-core-dropdown>
+
+          <glide-core-input
+            label="Label "
+            placeholder="Placeholder"
+          ></glide-core-input>
+
+          <glide-core-textarea
+            placeholder="Placeholder"
+            label="Label"
+          ></glide-core-textarea>
+        </glide-core-form-controls-layout>
+      </form>
+    `;
+  },
+};
+
+export default meta;
+
+export const SingleSelectionHorizontal: StoryObj = {
+  name: 'Default',
+};

--- a/packages/components/src/form-controls-layout.styles.ts
+++ b/packages/components/src/form-controls-layout.styles.ts
@@ -1,0 +1,11 @@
+import { css } from 'lit';
+
+export default [
+  css`
+    .component {
+      display: flex;
+      flex-direction: column;
+      row-gap: 0.625rem;
+    }
+  `,
+];

--- a/packages/components/src/form-controls-layout.test.basics.ts
+++ b/packages/components/src/form-controls-layout.test.basics.ts
@@ -1,0 +1,86 @@
+import './checkbox.js';
+import './input.js';
+import { ArgumentError } from 'ow';
+import { expect, fixture, html } from '@open-wc/testing';
+import GlideCoreFormControlsLayout from './form-controls-layout.js';
+import expectArgumentError from './library/expect-argument-error.js';
+import sinon from 'sinon';
+
+it('registers', async () => {
+  expect(window.customElements.get('glide-core-form-controls-layout')).to.equal(
+    GlideCoreFormControlsLayout,
+  );
+});
+
+it('has defaults', async () => {
+  const component = await fixture<GlideCoreFormControlsLayout>(html`
+    <glide-core-form-controls-layout>
+      <glide-core-input
+        label="Label"
+        placeholder="Placeholder"
+      ></glide-core-input>
+    </glide-core-form-controls-layout>
+  `);
+
+  expect(component.getAttribute('split')).to.equal('left');
+  expect(component.split).to.equal('left');
+});
+
+it('sets `privateActive` on each control', async () => {
+  const component = await fixture<GlideCoreFormControlsLayout>(html`
+    <glide-core-form-controls-layout>
+      <glide-core-input
+        label="Label"
+        placeholder="Placeholder"
+      ></glide-core-input>
+
+      <glide-core-checkbox label="Label"></glide-core-checkbox>
+    </glide-core-form-controls-layout>
+  `);
+
+  const input = component.querySelector('glide-core-input');
+  const checkbox = component.querySelector('glide-core-checkbox');
+
+  expect(input?.privateSplit).to.equal('left');
+  expect(checkbox?.privateSplit).to.equal('left');
+});
+
+it('throws if it does not have a default slot', async () => {
+  const spy = sinon.spy();
+
+  try {
+    await fixture(html`
+      <glide-core-form-controls-layout></glide-core-form-controls-layout>
+    `);
+  } catch (error) {
+    if (error instanceof ArgumentError) {
+      spy();
+    }
+  }
+
+  expect(spy.called).to.be.true;
+});
+
+it('throws if its default slot is the incorrect type', async () => {
+  await expectArgumentError(() => {
+    return fixture(html`
+      <glide-core-form-controls-layout>
+        <input />
+      </glide-core-form-controls-layout>
+    `);
+  });
+});
+
+it('throws if a vertical control is present', async () => {
+  await expectArgumentError(() => {
+    return fixture(html`
+      <glide-core-form-controls-layout>
+        <glide-core-input
+          label="Label"
+          placeholder="Placeholder"
+          orientation="vertical"
+        ></glide-core-input>
+      </glide-core-form-controls-layout>
+    `);
+  });
+});

--- a/packages/components/src/form-controls-layout.test.interactions.ts
+++ b/packages/components/src/form-controls-layout.test.interactions.ts
@@ -1,0 +1,31 @@
+import './checkbox.js';
+import './input.js';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import GlideCoreFormControlsLayout from './form-controls-layout.js';
+
+it('sets `privateActive` on each control when `split` is changed programmatically', async () => {
+  const component = await fixture<GlideCoreFormControlsLayout>(html`
+    <glide-core-form-controls-layout>
+      <glide-core-input
+        label="Label"
+        placeholder="Placeholder"
+      ></glide-core-input>
+
+      <glide-core-checkbox label="Label"></glide-core-checkbox>
+    </glide-core-form-controls-layout>
+  `);
+
+  // Why isn't it a `GlideCoreFormControlsLayout` instance yet? No idea!
+  // It should be fully rendered by this point. Nothing to do with the
+  // component itself, which is quite simple. And no other test behaves
+  // like this.
+  await waitUntil(() => component instanceof GlideCoreFormControlsLayout);
+
+  component.split = 'middle';
+
+  const input = component.querySelector('glide-core-input');
+  const checkbox = component.querySelector('glide-core-checkbox');
+
+  expect(input?.privateSplit).to.equal('middle');
+  expect(checkbox?.privateSplit).to.equal('middle');
+});

--- a/packages/components/src/form-controls-layout.ts
+++ b/packages/components/src/form-controls-layout.ts
@@ -1,0 +1,119 @@
+import './checkbox.js';
+import './dropdown.option.js';
+import './label.js';
+import { LitElement, html } from 'lit';
+import { createRef, ref } from 'lit/directives/ref.js';
+import { customElement, property } from 'lit/decorators.js';
+import GlideCoreCheckbox from './checkbox.js';
+import GlideCoreCheckboxGroup from './checkbox-group.js';
+import GlideCoreDropdown from './dropdown.js';
+import GlideCoreInput from './input.js';
+import GlideCoreTextArea from './textarea.js';
+import ow, { owSlot, owSlotType } from './library/ow.js';
+import styles from './form-controls-layout.styles.js';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'glide-core-form-controls-layout': GlideCoreFormControlsLayout;
+  }
+}
+
+/**
+ * @description Aligns form control labels and the controls themselves in two columns. Only horizontally oriented controls are supported.
+ *
+ * @slot - GlideCoreCheckbox | GlideCoreCheckboxGroup | GlideCoreDropdown | GlideCoreInput | GlideCoreTextArea.
+ */
+@customElement('glide-core-form-controls-layout')
+export default class GlideCoreFormControlsLayout extends LitElement {
+  static override shadowRootOptions: ShadowRootInit = {
+    ...LitElement.shadowRootOptions,
+    mode: 'closed',
+  };
+
+  static override styles = styles;
+
+  @property({ reflect: true })
+  get split() {
+    return this.#split;
+  }
+
+  set split(split: 'left' | 'middle') {
+    this.#split = split;
+
+    const assignedElements = this.#slotElementRef.value?.assignedElements();
+
+    if (assignedElements) {
+      for (const element of assignedElements) {
+        if ('privateSplit' in element) {
+          element.privateSplit = this.split;
+        }
+      }
+    }
+  }
+
+  override firstUpdated() {
+    owSlot(this.#slotElementRef.value);
+
+    owSlotType(this.#slotElementRef.value, [
+      GlideCoreCheckbox,
+      GlideCoreCheckboxGroup,
+      GlideCoreDropdown,
+      GlideCoreInput,
+      GlideCoreTextArea,
+    ]);
+
+    this.#assertHorizontalControls();
+  }
+
+  override render() {
+    return html`<div class="component">
+      <slot
+        @slotchange=${this.#onSlotChange}
+        ${ref(this.#slotElementRef)}
+      ></slot>
+    </div>`;
+  }
+
+  #slotElementRef = createRef<HTMLSlotElement>();
+
+  #split: 'left' | 'middle' = 'left';
+
+  #assertHorizontalControls() {
+    const assignedElements = this.#slotElementRef.value?.assignedElements();
+
+    if (assignedElements) {
+      for (const element of assignedElements) {
+        if ('orientation' in element) {
+          ow(
+            element.orientation === 'horizontal',
+            ow.boolean.true.message('Only horizontal controls are supported.'),
+          );
+        }
+      }
+    }
+  }
+
+  #onSlotChange() {
+    owSlot(this.#slotElementRef.value);
+
+    owSlotType(this.#slotElementRef.value, [
+      GlideCoreCheckbox,
+      GlideCoreCheckboxGroup,
+      GlideCoreDropdown,
+      GlideCoreInput,
+      GlideCoreTextArea,
+    ]);
+
+    this.#assertHorizontalControls();
+
+    const assignedElements = this.#slotElementRef.value?.assignedElements();
+
+    if (assignedElements) {
+      for (const element of assignedElements) {
+        if ('privateSplit' in element) {
+          element.privateSplit = this.split;
+        }
+      }
+    }
+  }
+}

--- a/packages/components/src/input.test.basics.ts
+++ b/packages/components/src/input.test.basics.ts
@@ -10,6 +10,14 @@ it('registers', async () => {
   );
 });
 
+it('is accessible', async () => {
+  const element = await fixture<GlideCoreInput>(html`
+    <glide-core-input label="Test" value="lorem"></glide-core-input>
+  `);
+
+  await expect(element).to.be.accessible();
+});
+
 it('accepts and contains "value" attribute', async () => {
   const element = await fixture<GlideCoreInput>(html`
     <glide-core-input label="Test" value="lorem"></glide-core-input>

--- a/packages/components/src/input.ts
+++ b/packages/components/src/input.ts
@@ -111,6 +111,9 @@ export default class GlideCoreInput extends LitElement {
   @property({ type: Boolean })
   disabled = false;
 
+  @property()
+  privateSplit?: 'left' | 'middle';
+
   @property({
     type: Number,
     converter(value) {
@@ -182,7 +185,12 @@ export default class GlideCoreInput extends LitElement {
   override render() {
     return html`
       <glide-core-label
+        class=${classMap({
+          left: this.privateSplit === 'left',
+          middle: this.privateSplit === 'middle',
+        })}
         orientation=${this.orientation}
+        split=${ifDefined(this.privateSplit ?? undefined)}
         ?disabled=${this.disabled}
         ?error=${this.#isShowValidationFeedback ||
         this.#isMaxCharacterCountExceeded}

--- a/packages/components/src/label.styles.ts
+++ b/packages/components/src/label.styles.ts
@@ -22,23 +22,35 @@ export default [
         flex-direction: column;
       }
 
+      &.left {
+        grid-template-columns: calc(100% / 3) 1fr;
+      }
+
+      &.middle {
+        grid-template-columns: 1fr 1fr;
+      }
+
       &.hidden-label {
         display: flex;
         flex-direction: column;
       }
     }
 
-    .tooltip-and-label {
+    .tooltips-and-label {
       align-items: center;
       column-gap: var(--glide-core-spacing-xs);
       display: flex;
+      justify-content: flex-end;
+
+      /* Prevent it from growing larger than its column percentage when a child of Form Controls Layout. */
+      min-inline-size: 0;
 
       &.hidden {
         ${visuallyHidden};
       }
     }
 
-    glide-core-tooltip {
+    .optional-tooltip {
       display: none;
 
       &.vertical {
@@ -54,7 +66,7 @@ export default [
       }
     }
 
-    .tooltip-target {
+    .optional-tooltip-target {
       background-color: transparent;
       border: none;
       border-radius: 0.0625rem;
@@ -83,7 +95,12 @@ export default [
       font-variant: var(--glide-core-heading-xxxs-font-variant);
       font-weight: var(--glide-core-heading-xxxs-font-weight);
       line-height: 100%;
+      margin-inline-start: auto;
+      overflow: hidden;
+      text-align: end;
+      text-overflow: ellipsis;
       user-select: none;
+      white-space: nowrap;
 
       &.disabled ::slotted(*) {
         cursor: not-allowed;
@@ -96,6 +113,10 @@ export default [
       &.vertical {
         margin-block-end: var(--glide-core-spacing-xxs);
       }
+    }
+
+    .label-overflow-tooltip {
+      inline-size: 100%;
     }
 
     .required-symbol {

--- a/packages/components/src/label.test.basics.ts
+++ b/packages/components/src/label.test.basics.ts
@@ -1,5 +1,5 @@
 import { ArgumentError } from 'ow';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
 import GlideCoreLabel from './label.js';
 import sinon from 'sinon';
 
@@ -155,10 +155,8 @@ it('throws if it does not have a default slot', async () => {
   const spy = sinon.spy();
 
   try {
-    await fixture<GlideCoreLabel>(
-      html`<glide-core-label orientation="vertical"
-        ><input slot="control"
-      /></glide-core-label>`,
+    await fixture(
+      html`<glide-core-label><input slot="control" /></glide-core-label>`,
     );
   } catch (error) {
     if (error instanceof ArgumentError) {
@@ -171,10 +169,11 @@ it('throws if it does not have a default slot', async () => {
 
 it('throws if it does not have a "control" slot', async () => {
   const spy = sinon.spy();
+  const stub = sinon.stub(console, 'error');
 
   try {
-    await fixture<GlideCoreLabel>(
-      html`<glide-core-label orientation="vertical">
+    await fixture(
+      html`<glide-core-label>
         <label>Label</label>
       </glide-core-label>`,
     );
@@ -185,4 +184,10 @@ it('throws if it does not have a "control" slot', async () => {
   }
 
   expect(spy.called).to.be.true;
+
+  // It's not clear to me why the error logged by Ow shows up in the console
+  // here and not in the above test or elsewhere. A bug in Web Test Runner?
+  // Something I don't understand about Lit's lifecycle?
+  await waitUntil(() => stub.called);
+  stub.restore();
 });

--- a/packages/components/src/menu.stories.ts
+++ b/packages/components/src/menu.stories.ts
@@ -15,7 +15,7 @@ const meta: Meta = {
   parameters: {
     docs: {
       description: {
-        component: 'A basic menu.',
+        component: 'A menu with optional icons.',
       },
       story: {
         autoplay: true,

--- a/packages/components/src/radio-group.styles.ts
+++ b/packages/components/src/radio-group.styles.ts
@@ -33,7 +33,7 @@ export default [
       }
     }
 
-    glide-core-label::part(tooltip-and-label-container) {
+    glide-core-label::part(tooltips-and-label) {
       align-items: flex-start;
     }
   `,

--- a/packages/components/src/radio-group.ts
+++ b/packages/components/src/radio-group.ts
@@ -4,6 +4,7 @@ import { LitElement, type PropertyValueMap, html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { owSlot, owSlotType } from './library/ow.js';
 import GlideCoreRadio from './radio.js';
 import styles from './radio-group.styles.js';
@@ -49,6 +50,9 @@ export default class GlideCoreRadioGroup extends LitElement {
 
   @property()
   name = '';
+
+  @property()
+  privateSplit?: 'left' | 'middle';
 
   @property({ type: Boolean, reflect: true })
   required = false;
@@ -128,6 +132,7 @@ export default class GlideCoreRadioGroup extends LitElement {
       >
         <glide-core-label
           orientation="horizontal"
+          split=${ifDefined(this.privateSplit ?? undefined)}
           ?disabled=${this.disabled}
           ?error=${this.#isShowValidationFeedback}
           ?hide=${this.hideLabel}

--- a/packages/components/src/tabs.stories.ts
+++ b/packages/components/src/tabs.stories.ts
@@ -34,13 +34,19 @@ const meta: Meta = {
       <glide-core-tab slot="nav" panel="3" disabled>Disabled</glide-core-tab>
 
       <glide-core-tab-panel name="1"
-        ><div style="margin:10px">Content for tab 1</div></glide-core-tab-panel
+        ><div style="margin: 0.625rem">
+          Content for tab 1
+        </div></glide-core-tab-panel
       >
       <glide-core-tab-panel name="2"
-        ><div style="margin:10px">Content for tab 2</div></glide-core-tab-panel
+        ><div style="margin: 0.625rem">
+          Content for tab 2
+        </div></glide-core-tab-panel
       >
       <glide-core-tab-panel name="3"
-        ><div style="margin:10px">Content for tab 3</div></glide-core-tab-panel
+        ><div style="margin: 0.625rem">
+          Content for tab 3
+        </div></glide-core-tab-panel
       >
     </glide-core-tab-group>
   `,

--- a/packages/components/src/textarea.styles.ts
+++ b/packages/components/src/textarea.styles.ts
@@ -1,7 +1,7 @@
 import { css } from 'lit';
 
 export default css`
-  glide-core-label::part(tooltip-and-label-container) {
+  glide-core-label::part(tooltips-and-label) {
     align-items: flex-start;
     margin-block-start: var(--glide-core-spacing-sm);
   }

--- a/packages/components/src/textarea.ts
+++ b/packages/components/src/textarea.ts
@@ -85,6 +85,9 @@ export default class GlideCoreTextarea extends LitElement {
     | 'words'
     | 'characters' = 'on';
 
+  @property()
+  privateSplit?: 'left' | 'middle';
+
   override blur() {
     this.#textareaElementRef.value?.blur();
   }
@@ -123,6 +126,7 @@ export default class GlideCoreTextarea extends LitElement {
 
   override render() {
     return html`<glide-core-label
+      split=${ifDefined(this.privateSplit ?? undefined)}
       orientation=${this.orientation}
       ?disabled=${this.disabled}
       ?error=${this.#isShowValidationFeedback || this.#isInvalidCharacterLength}

--- a/packages/components/src/toggle.ts
+++ b/packages/components/src/toggle.ts
@@ -2,6 +2,7 @@ import './label.js';
 import { LitElement, html } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './toggle.styles.js';
 
 declare global {
@@ -46,6 +47,9 @@ export default class GlideCoreToggle extends LitElement {
   @property({ reflect: true })
   name?: string;
 
+  @property()
+  privateSplit?: 'left' | 'middle';
+
   @property({ reflect: true })
   summary?: string;
 
@@ -61,6 +65,7 @@ export default class GlideCoreToggle extends LitElement {
     return html`<div data-test="component">
       <glide-core-label
         orientation=${this.orientation}
+        split=${ifDefined(this.privateSplit ?? undefined)}
         ?disabled=${this.disabled}
         ?hide=${this.hideLabel}
       >

--- a/packages/components/src/tooltip.stories.ts
+++ b/packages/components/src/tooltip.stories.ts
@@ -20,6 +20,7 @@ const meta: Meta = {
     'slot="default"': 'Tooltip <kbd>CMD + K</kbd>',
     'slot="target"': '',
     placement: 'bottom',
+    disabled: false,
   },
   argTypes: {
     'slot="default"': {
@@ -30,9 +31,16 @@ const meta: Meta = {
     },
     'slot="target"': {
       table: {
-        type: { summary: 'Element', detail: 'Any focusable element.' },
+        type: { summary: 'Element' },
       },
       type: { name: 'function', required: true },
+    },
+    disabled: {
+      control: 'boolean',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
     },
     placement: {
       control: { type: 'radio' },
@@ -53,7 +61,10 @@ const meta: Meta = {
       <div
         style="align-items: center; display: flex; height: 8rem; justify-content: center;"
       >
-        <glide-core-tooltip placement=${arguments_.placement}>
+        <glide-core-tooltip
+          placement=${arguments_.placement}
+          ?disabled=${arguments_.disabled}
+        >
           ${unsafeHTML(arguments_['slot="default"'])}
           <span slot="target" class="icon" tabindex="0">
             <glide-core-example-icon name="info"></glide-core-example-icon>

--- a/packages/components/src/tooltip.styles.ts
+++ b/packages/components/src/tooltip.styles.ts
@@ -15,6 +15,9 @@ export default [
 
       /* Additional whitespace from line height and the tooltip won't be vertically centered. */
       display: flex;
+
+      /* Allows the consumer to style the target using "text-overflow: ellipsis". */
+      inline-size: 100%;
       padding: 0;
       position: relative;
 

--- a/packages/components/src/tooltip.test.interactions.ts
+++ b/packages/components/src/tooltip.test.interactions.ts
@@ -25,6 +25,25 @@ it('is visible on "focusin"', async () => {
   ).to.be.true;
 });
 
+it('is hidden on "focusin" when disabled', async () => {
+  const component = await fixture<GlideCoreTooltip>(
+    html`<glide-core-tooltip disabled>
+      Tooltip
+      <span slot="target" tabindex="0">Target</span>
+    </glide-core-tooltip>`,
+  );
+
+  component.shadowRoot
+    ?.querySelector('[aria-labelledby="tooltip"]')
+    ?.dispatchEvent(new FocusEvent('focusin'));
+
+  await elementUpdated(component);
+
+  expect(
+    component.shadowRoot?.querySelector('[role="tooltip"]')?.checkVisibility(),
+  ).to.not.be.ok;
+});
+
 it('is hidden on "blur"', async () => {
   const component = await fixture<GlideCoreTooltip>(
     html`<glide-core-tooltip>
@@ -94,6 +113,25 @@ it('is visible on "mouseover"', async () => {
   expect(
     component.shadowRoot?.querySelector('[role="tooltip"]')?.checkVisibility(),
   ).to.be.true;
+});
+
+it('is hidden on "mouseover" when disabled', async () => {
+  const component = await fixture<GlideCoreTooltip>(
+    html`<glide-core-tooltip disabled>
+      Tooltip
+      <span slot="target" tabindex="0">Target</span>
+    </glide-core-tooltip>`,
+  );
+
+  component.shadowRoot
+    ?.querySelector('.component')
+    ?.dispatchEvent(new MouseEvent('mouseover'));
+
+  await elementUpdated(component);
+
+  expect(
+    component.shadowRoot?.querySelector('[role="tooltip"]')?.checkVisibility(),
+  ).to.not.be.ok;
 });
 
 it('is hidden on "mouseout"', async () => {

--- a/packages/components/src/tooltip.ts
+++ b/packages/components/src/tooltip.ts
@@ -11,6 +11,7 @@ import {
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { offsetParent } from 'composed-offset-position';
 import { owSlot } from './library/ow.js';
 import styles from './tooltip.styles.js';
@@ -34,6 +35,9 @@ export default class GlideCoreTooltip extends LitElement {
   };
 
   static override styles = styles;
+
+  @property({ reflect: true, type: Boolean })
+  disabled = false;
 
   /* The placement of the tooltip relative to its target. Automatic placement will take over if the tooltip is cut off by the viewport. */
   @property()
@@ -82,7 +86,7 @@ export default class GlideCoreTooltip extends LitElement {
         @mouseout=${this.#onMouseout}
       >
         <div
-          aria-labelledby="tooltip"
+          aria-labelledby=${ifDefined(this.disabled ? undefined : 'tooltip')}
           class="target"
           slot="target"
           @focusin=${this.#onFocusin}
@@ -100,13 +104,15 @@ export default class GlideCoreTooltip extends LitElement {
         <div
           class=${classMap({
             tooltip: true,
-            visible: this.isVisible,
+            visible: this.isVisible && !this.disabled,
           })}
           id="tooltip"
-          role="tooltip"
+          role=${ifDefined(this.disabled ? undefined : 'tooltip')}
           ${ref(this.#tooltipElementRef)}
         >
-          <span aria-label="Tooltip: "></span>
+          <span
+            aria-label=${ifDefined(this.disabled ? undefined : 'Tooltip: ')}
+          ></span>
 
           <slot
             @slotchange=${this.#onDefaultSlotChange}
@@ -122,9 +128,6 @@ export default class GlideCoreTooltip extends LitElement {
   setContainingBlock(containingBlock: Element) {
     this.containingBlock = containingBlock;
   }
-
-  @state()
-  private effectivePlacement?: string;
 
   #arrowElementRef = createRef<HTMLDivElement>();
 
@@ -246,8 +249,6 @@ export default class GlideCoreTooltip extends LitElement {
                 bottom: '',
                 [staticSide]: '-3px',
               });
-
-              this.effectivePlacement = placement;
             }
           })();
         },

--- a/packages/components/web-test-runner.config.js
+++ b/packages/components/web-test-runner.config.js
@@ -9,7 +9,7 @@ import rollupPluginCommonjs from '@rollup/plugin-commonjs';
 export default {
   filterBrowserLogs(log) {
     // Uncaught Ow errors are expected from "slotchange" handlers and shouldn't muddy the logs.
-    return log.type === 'error' && log.args.at(0)?.includes('ow.ts')
+    return log.type === 'error' && log.args.at(0)?.includes('node_modules/ow')
       ? false
       : true;
   },


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- Adds Form Controls Layout with a `split` attribute.
- Adds a `privateSplit` attribute to every form control and to Label to support Form Controls Layout.
- Adds an ellipsis and tooltip to form controls on overflow.
- Fixes a Button visual bug.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to Storybook.
2. Check that Form Controls Layout matches the mockups.
3. Replace a control's label with a bunch of dummy text, causing it to overflow.
4. Check that an ellipsis is shown.
5. Check that tooltip with the full text is shown when the label is hovered.
6. Make the viewport larger so the label with dummy text doesn't overflow.
7.  Check that the ellipsis and tooltip are dynamically removed.

## 📸 Images/Videos of Functionality

### `split="left"`

<img width="1016" alt="image" src="https://github.com/user-attachments/assets/89eb5c00-70e6-48cf-8f64-bfee75e15244">

### `split="middle"`
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/586b09e2-2359-48a0-a7f4-53eb6d87e32a">

