### PR TITLE
Add the --ci flag to storybook

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "start": "per-env",
     "start:development": "storybook dev --config-dir .storybook --disable-telemetry --port 6006 --ci",
+    "start:development:comment": "Upon running this script, a new tab will **not** automatically open due to the `--ci` flag. This may be a bit unexpected as it is not the default behavior. One must manually navigate to the Storybook URL provided in the terminal.",
     "start:production": "rimraf ./dist && npm-run-all --parallel start:production:components start:production:storybook start:production:stylesheets --aggregate-output --print-label",
     "start:production:components": "tsc --outDir ./dist && node ./terser.js",
     "start:production:figma": "pnpm dt export-variables && pnpm dt build-tokens && pnpm dt build-styles",


### PR DESCRIPTION
## 🚀 Description

Up to the team to agree upon this, so I'll wait until everyone is back before merging.  This PR doesn't open Storybook by default on a `pnpm start`, which means you need to click the URL provided in the CLI.

One advantage of this is that if you already have a Storybook tab open, it will automatically refresh rather than creating another new tab in your browser.

## 📋 Checklist

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A
