### PR TITLE
Add Japanese and French translations

### DIFF
--- a/.changeset/great-waves-explain.md
+++ b/.changeset/great-waves-explain.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Add Japanese and French translations

--- a/packages/components/src/library/localize.ts
+++ b/packages/components/src/library/localize.ts
@@ -3,12 +3,14 @@ import {
   registerTranslation,
 } from '@shoelace-style/localize';
 import en from '../translations/en.js'; // Register English as the default/fallback language
+import fr from '../translations/fr.js';
+import ja from '../translations/ja.js';
 import type { Translation as DefaultTranslation } from '@shoelace-style/localize';
 
 // Extend the controller and apply our own translation interface for better typings
 export class LocalizeController extends DefaultLocalizationController<Translation> {
   static {
-    registerTranslation(en);
+    registerTranslation(en, ja, fr);
   }
 }
 

--- a/packages/components/src/tag.test.translations.ts
+++ b/packages/components/src/tag.test.translations.ts
@@ -1,0 +1,46 @@
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import GlideCoreTag from './tag.js';
+
+GlideCoreTag.shadowRootOptions.mode = 'open';
+
+it('renders dynamic string in Japanese', async () => {
+  const element = await fixture<GlideCoreTag>(
+    html`<glide-core-tag removable-label="test-aria-label"
+      ><span slot="prefix">Prefix</span
+      ><span data-content>Tag</span></glide-core-tag
+    >`,
+  );
+
+  document.documentElement.setAttribute('lang', 'ja');
+  await elementUpdated(element);
+
+  const iconButton = element.shadowRoot?.querySelector('button');
+
+  expect(iconButton).to.have.attribute(
+    'aria-label',
+    `タグを削除: test-aria-label`,
+  );
+
+  expect(iconButton).to.have.attribute('type', 'button');
+});
+
+it('renders dynamic string in French', async () => {
+  const element = await fixture<GlideCoreTag>(
+    html`<glide-core-tag removable-label="test-aria-label"
+      ><span slot="prefix">Prefix</span
+      ><span data-content>Tag</span></glide-core-tag
+    >`,
+  );
+
+  document.documentElement.setAttribute('lang', 'fr');
+  await elementUpdated(element);
+
+  const iconButton = element.shadowRoot?.querySelector('button');
+
+  expect(iconButton).to.have.attribute(
+    'aria-label',
+    `Supprimer la balise : test-aria-label`,
+  );
+
+  expect(iconButton).to.have.attribute('type', 'button');
+});

--- a/packages/components/src/translations/fr.json
+++ b/packages/components/src/translations/fr.json
@@ -1,0 +1,10 @@
+{
+  "close": "Fermer",
+  "dismiss": "Congédier",
+  "open": "Ouvrir",
+  "selectAll": "Tout sélectionner",
+  "clearEntry": "Effacer l’entrée",
+  "moreInformation": "Plus d’informations",
+  "notifications": "Notifications",
+  "removeTag": "Supprimer la balise : {label}"
+}

--- a/packages/components/src/translations/fr.ts
+++ b/packages/components/src/translations/fr.ts
@@ -1,0 +1,20 @@
+import type { Translation } from '../library/localize.js';
+
+const translation: Translation = {
+  $code: 'fr',
+  $name: 'French',
+  $dir: 'ltr',
+
+  // These come from ./fr.json
+  close: 'Fermer',
+  dismiss: 'Congédier',
+  open: 'Ouvrir',
+  selectAll: 'Tout sélectionner',
+  clearEntry: 'Effacer l’entrée',
+  moreInformation: 'Plus d’informations',
+  notifications: 'Notifications',
+
+  removeTag: (label: string) => `Supprimer la balise : ${label}`,
+};
+
+export default translation;

--- a/packages/components/src/translations/ja.json
+++ b/packages/components/src/translations/ja.json
@@ -1,0 +1,10 @@
+{
+  "close": "閉じる",
+  "dismiss": "無視",
+  "open": "オープン",
+  "selectAll": "すべて選択",
+  "clearEntry": "入力のクリア",
+  "moreInformation": "詳細情報",
+  "notifications": "通知",
+  "removeTag": "タグを削除: {label}"
+}

--- a/packages/components/src/translations/ja.ts
+++ b/packages/components/src/translations/ja.ts
@@ -1,0 +1,20 @@
+import type { Translation } from '../library/localize.js';
+
+const translation: Translation = {
+  $code: 'ja',
+  $name: 'Japanese',
+  $dir: 'ltr',
+
+  // These come from ./ja.json
+  close: '閉じる',
+  dismiss: '無視',
+  open: 'オープン',
+  selectAll: 'すべて選択',
+  clearEntry: '入力のクリア',
+  moreInformation: '詳細情報',
+  notifications: '通知',
+
+  removeTag: (label: string) => `タグを削除: ${label}`,
+};
+
+export default translation;


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Adds and registers Japanese and French translations

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

Change the `lang` attribute of the `html` tag for the Storybook Iframe to "ja" or "fr", and confirm the labels are changed accordingly. Can also use a regional code, such as "ja-JP" or "fr-FR"

For example, the Modal's close title:

<img width="715" alt="image" src="https://github.com/user-attachments/assets/7f052b23-ff80-48b1-b55f-021d691e010c">


## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
