### PR TITLE
Adjust tooltip offset

### DIFF
--- a/.changeset/clean-ghosts-lay.md
+++ b/.changeset/clean-ghosts-lay.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Updated the Tooltip offset to be closer to the target.

--- a/packages/components/src/tooltip.ts
+++ b/packages/components/src/tooltip.ts
@@ -191,7 +191,7 @@ export default class GlideCoreTooltip extends LitElement {
                   placement: this.placement,
                   strategy: 'fixed',
                   middleware: [
-                    offset(10),
+                    offset(6),
                     flip({
                       fallbackStrategy: 'initialPlacement',
                     }),


### PR DESCRIPTION
## 🚀 Description

Working with design, we adjusted the tooltip offset. The ticket called for `4px` but after a few rounds of feedback with design, we landed on this instead.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Visit https://glide-core.crowdstrike-ux.workers.dev/update-tooltip-offset?path=/docs/tooltip--overview and view the new tooltip offset

## 📸 Images/Videos of Functionality

| Before  | After |
| ------------- | ------------- |
| <img width="1877" alt="Screenshot 2024-07-29 at 8 45 58 AM" src="https://github.com/user-attachments/assets/b6635728-988d-4678-a153-19d0eec822fd">  | <img width="1877" alt="Screenshot 2024-07-29 at 8 45 53 AM" src="https://github.com/user-attachments/assets/b73b5794-4eed-4305-8ddd-548055882054"> |




