### PR TITLE
Add no-only-tests rule

### DIFF
--- a/packages/components/eslint.config.js
+++ b/packages/components/eslint.config.js
@@ -4,6 +4,7 @@ import eslintGlideCorePlugin from '@crowdstrike/glide-core-eslint-plugin';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
 import globals from 'globals';
 import js from '@eslint/js';
+import noOnlyTests from 'eslint-plugin-no-only-tests';
 import sortClassMembers from 'eslint-plugin-sort-class-members';
 import stylistic from '@stylistic/eslint-plugin';
 import typescriptEslint from 'typescript-eslint';
@@ -27,6 +28,7 @@ export default [
     plugins: {
       '@stylistic': stylistic,
       '@crowdstrike/glide-core-eslint-plugin': eslintGlideCorePlugin,
+      'no-only-tests': noOnlyTests,
     },
     languageOptions: {
       parserOptions: {
@@ -111,6 +113,8 @@ export default [
         'always',
         { exceptAfterSingleLine: false },
       ],
+
+      'no-only-tests/no-only-tests': 'error',
 
       // We work with the DOM enough that this rule also became tiresome.
       'unicorn/no-null': 'off',

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -99,6 +99,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-lit": "^1.11.0",
     "eslint-plugin-lit-a11y": "^4.1.2",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-sort-class-members": "^1.20.0",
     "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
     "eslint-plugin-unicorn": "^50.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       eslint-plugin-lit-a11y:
         specifier: ^4.1.2
         version: 4.1.2(eslint@8.57.0)
+      eslint-plugin-no-only-tests:
+        specifier: ^3.1.0
+        version: 3.1.0
       eslint-plugin-sort-class-members:
         specifier: ^1.20.0
         version: 1.20.0(eslint@8.57.0)
@@ -2994,6 +2997,10 @@ packages:
     engines: {node: '>= 12'}
     peerDependencies:
       eslint: '>= 5'
+
+  eslint-plugin-no-only-tests@3.1.0:
+    resolution: {integrity: sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==}
+    engines: {node: '>=5.0.0'}
 
   eslint-plugin-sort-class-members@1.20.0:
     resolution: {integrity: sha512-xNaik4GQ/pRwd1soIVI28HEXZbrWoLR5krau2+E8YcHj7N09UviPg5mYhf/rELG29bIFJdXDOFJazN90+luMOw==}
@@ -8937,6 +8944,8 @@ snapshots:
       parse5: 6.0.1
       parse5-htmlparser2-tree-adapter: 6.0.1
       requireindex: 1.2.0
+
+  eslint-plugin-no-only-tests@3.1.0: {}
 
   eslint-plugin-sort-class-members@1.20.0(eslint@8.57.0):
     dependencies:


### PR DESCRIPTION
We sometimes set a test to `it.only()` to isolate just a single test within a test file, for easier debugging. But this is meant to be temporary.

This lint rule prevents us from accidentally committing and merging such an `it.only()`

https://github.com/funbox/eslint-plugin-no-only-tests

<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
