### PR TITLE
Don't open Menu when its target is disabled programmatically

### DIFF
--- a/.changeset/olive-eggs-obey.md
+++ b/.changeset/olive-eggs-obey.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Menu no longer opens when its target is disabled programmatically.

--- a/packages/components/src/menu.test.interactions.ts
+++ b/packages/components/src/menu.test.interactions.ts
@@ -1,8 +1,14 @@
 import './menu.link.js';
 import './menu.options.js';
 import { LitElement } from 'lit';
+import {
+  assert,
+  elementUpdated,
+  expect,
+  fixture,
+  html,
+} from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreMenu from './menu.js';
 
@@ -51,7 +57,7 @@ it('opens when clicked', async () => {
   expect(target?.ariaExpanded).to.equal('true');
 });
 
-it('does not open when clicked when its target is `disabled`', async () => {
+it('does not open when `disabled` is set on its target', async () => {
   const component = await fixture<GlideCoreMenu>(
     html`<glide-core-menu>
       <button slot="target" disabled>Target</button>
@@ -76,7 +82,36 @@ it('does not open when clicked when its target is `disabled`', async () => {
   expect(target?.ariaExpanded).to.equal('false');
 });
 
-it('does not open when clicked when its target is `aria-disabled`', async () => {
+it('does not open when `disabled` is set programmatically on its target', async () => {
+  const component = await fixture<GlideCoreMenu>(
+    html`<glide-core-menu>
+      <button slot="target">Target</button>
+
+      <glide-core-menu-options>
+        <glide-core-menu-link label="Link"></glide-core-menu-link>
+      </glide-core-menu-options>
+    </glide-core-menu>`,
+  );
+
+  const target = component.querySelector('button');
+  assert(target);
+
+  target.click();
+  target.disabled = true;
+  await elementUpdated(component);
+
+  const defaultSlot =
+    component?.shadowRoot?.querySelector<HTMLSlotElement>('slot:not([name])');
+
+  const options = component.querySelector('glide-core-menu-options');
+
+  expect(component.open).to.be.false;
+  expect(defaultSlot?.checkVisibility({ checkVisibilityCSS: true })).not.ok;
+  expect(options?.getAttribute('aria-activedescendant')).to.equal('');
+  expect(target?.ariaExpanded).to.equal('false');
+});
+
+it('does not open when `aria-disabled` is set on its target', async () => {
   const component = await fixture<GlideCoreMenu>(
     html`<glide-core-menu>
       <button aria-disabled="true" slot="target">Target</button>
@@ -87,7 +122,38 @@ it('does not open when clicked when its target is `aria-disabled`', async () => 
     </glide-core-menu>`,
   );
 
-  component.querySelector('button')?.click();
+  const target = component.querySelector('button');
+
+  target?.click();
+
+  const defaultSlot =
+    component?.shadowRoot?.querySelector<HTMLSlotElement>('slot:not([name])');
+
+  const options = component.querySelector('glide-core-menu-options');
+
+  expect(component.open).to.be.false;
+  expect(defaultSlot?.checkVisibility({ checkVisibilityCSS: true })).not.ok;
+  expect(options?.getAttribute('aria-activedescendant')).to.equal('');
+  expect(target?.ariaExpanded).to.equal('false');
+});
+
+it('does not open when `aria-disabled` is set programmatically on its target', async () => {
+  const component = await fixture<GlideCoreMenu>(
+    html`<glide-core-menu>
+      <button slot="target">Target</button>
+
+      <glide-core-menu-options>
+        <glide-core-menu-link label="Link"></glide-core-menu-link>
+      </glide-core-menu-options>
+    </glide-core-menu>`,
+  );
+
+  const button = component.querySelector('button');
+  assert(button);
+
+  button?.click();
+  button.ariaDisabled = 'true';
+  await elementUpdated(component);
 
   const defaultSlot =
     component?.shadowRoot?.querySelector<HTMLSlotElement>('slot:not([name])');
@@ -233,56 +299,6 @@ it('opens when opened programmatically', async () => {
   expect(defaultSlot?.checkVisibility({ checkVisibilityCSS: true })).to.be.true;
   expect(options?.getAttribute('aria-activedescendant')).to.equal(link?.id);
   expect(target?.ariaExpanded).to.equal('true');
-});
-
-it('does not open when opened programmatically and its target is `disabled`', async () => {
-  const component = await fixture<GlideCoreMenu>(
-    html`<glide-core-menu>
-      <button slot="target" disabled>Target</button>
-
-      <glide-core-menu-options>
-        <glide-core-menu-link label="Link"></glide-core-menu-link>
-      </glide-core-menu-options>
-    </glide-core-menu>`,
-  );
-
-  component.open = true;
-  await elementUpdated(component);
-
-  const defaultSlot =
-    component?.shadowRoot?.querySelector<HTMLSlotElement>('slot:not([name])');
-
-  const options = component.querySelector('glide-core-menu-options');
-  const target = component.querySelector('button');
-
-  expect(defaultSlot?.checkVisibility({ checkVisibilityCSS: true })).not.ok;
-  expect(options?.getAttribute('aria-activedescendant')).to.equal('');
-  expect(target?.ariaExpanded).to.equal('false');
-});
-
-it('does not open when opened programmatically and its target is `aria-disabled`', async () => {
-  const component = await fixture<GlideCoreMenu>(
-    html`<glide-core-menu>
-      <button aria-disabled="true" slot="target">Target</button>
-
-      <glide-core-menu-options>
-        <glide-core-menu-link label="Link"></glide-core-menu-link>
-      </glide-core-menu-options>
-    </glide-core-menu>`,
-  );
-
-  component.open = true;
-  await elementUpdated(component);
-
-  const defaultSlot =
-    component?.shadowRoot?.querySelector<HTMLSlotElement>('slot:not([name])');
-
-  const options = component.querySelector('glide-core-menu-options');
-  const target = component.querySelector('button');
-
-  expect(defaultSlot?.checkVisibility({ checkVisibilityCSS: true })).not.ok;
-  expect(options?.getAttribute('aria-activedescendant')).to.equal('');
-  expect(target?.ariaExpanded).to.equal('false');
 });
 
 // See the `document` click listener comment in `menu.ts` for an explanation.


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Adds a Mutation Observer to Menu that observes when its target's `disabled` and `aria-disabled` attributes change.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to Menu in Storybook.
2. Open DevTools and set `disabled` or `aria-disabled` on Menu's target.
3. Check that Menu doesn't open when clicked.

## 📸 Images/Videos of Functionality

N/A
