### PR TITLE
Fix Menu not responding to hover and not calling target's click handler

### DIFF
--- a/.changeset/tasty-cheetahs-nail.md
+++ b/.changeset/tasty-cheetahs-nail.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Fix Menu options not responding to hover and closing without calling the target's click handler.

--- a/packages/components/src/menu.test.events.ts
+++ b/packages/components/src/menu.test.events.ts
@@ -1,0 +1,40 @@
+import './menu.link.js';
+import './menu.options.js';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import GlideCoreMenu from './menu.js';
+
+it('dispatches a "click" event when a link is clicked', async () => {
+  const component = await fixture<GlideCoreMenu>(
+    html`<glide-core-menu open>
+      <button slot="target">Target</button>
+
+      <glide-core-menu-options>
+        <glide-core-menu-link label="Link"></glide-core-menu-link>
+      </glide-core-menu-options>
+    </glide-core-menu>`,
+  );
+
+  setTimeout(() => document.querySelector('glide-core-menu-link')?.click());
+
+  const event = await oneEvent(component, 'click');
+  expect(event instanceof PointerEvent).to.be.true;
+  expect(event.bubbles).to.be.true;
+});
+
+it('dispatches a "click" event when a button is clicked', async () => {
+  const component = await fixture<GlideCoreMenu>(
+    html`<glide-core-menu open>
+      <button slot="target">Target</button>
+
+      <glide-core-menu-options>
+        <glide-core-menu-button label="Link"></glide-core-menu-button>
+      </glide-core-menu-options>
+    </glide-core-menu>`,
+  );
+
+  setTimeout(() => document.querySelector('glide-core-menu-button')?.click());
+
+  const event = await oneEvent(component, 'click');
+  expect(event instanceof PointerEvent).to.be.true;
+  expect(event.bubbles).to.be.true;
+});

--- a/packages/components/src/menu.test.interactions.ts
+++ b/packages/components/src/menu.test.interactions.ts
@@ -1,10 +1,31 @@
 import './menu.link.js';
 import './menu.options.js';
+import { LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreMenu from './menu.js';
 
+@customElement('glide-core-nested-slot')
+class GlideCoreNestedSlot extends LitElement {
+  static override shadowRootOptions: ShadowRootInit = {
+    ...LitElement.shadowRootOptions,
+    mode: 'closed',
+  };
+
+  override render() {
+    return html`<glide-core-menu open>
+      <button slot="target">Target</button>
+
+      <glide-core-menu-options>
+        <slot></slot>
+      </glide-core-menu-options>
+    </glide-core-menu>`;
+  }
+}
+
 GlideCoreMenu.shadowRootOptions.mode = 'open';
+GlideCoreNestedSlot.shadowRootOptions.mode = 'open';
 
 it('opens when clicked', async () => {
   const component = await fixture<GlideCoreMenu>(
@@ -546,6 +567,28 @@ it('activates a menu link on "mouseover"', async () => {
   expect(options?.getAttribute('aria-activedescendant')).to.equal(links[1].id);
 });
 
+it('activates a menu link on "mouseover" when the link is in a nested slot', async () => {
+  const component = await fixture<GlideCoreMenu>(html`
+    <glide-core-nested-slot>
+      <glide-core-menu-link label="One"></glide-core-menu-link>
+      <glide-core-menu-link label="Two"></glide-core-menu-link>
+    </glide-core-nested-slot>
+  `);
+
+  const links = component.querySelectorAll('glide-core-menu-link');
+
+  const options = component.shadowRoot?.querySelector(
+    'glide-core-menu-options',
+  );
+
+  links[1].dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+  await elementUpdated(component);
+
+  expect(links[0].privateActive).to.be.false;
+  expect(links[1].privateActive).to.be.true;
+  expect(options?.getAttribute('aria-activedescendant')).to.equal(links[1].id);
+});
+
 it('activates a menu button on "mouseover"', async () => {
   const component = await fixture<GlideCoreMenu>(html`
     <glide-core-menu open>
@@ -567,6 +610,28 @@ it('activates a menu button on "mouseover"', async () => {
   expect(buttons[0].privateActive).to.be.false;
   expect(buttons[1].privateActive).to.be.true;
   expect(options?.getAttribute('aria-activedescendant')).equal(buttons[1].id);
+});
+
+it('activates a menu button on "mouseover" when the button is in a nested slot', async () => {
+  const component = await fixture<GlideCoreMenu>(html`
+    <glide-core-nested-slot>
+      <glide-core-menu-button label="One"></glide-core-menu-button>
+      <glide-core-menu-button label="Two"></glide-core-menu-button>
+    </glide-core-nested-slot>
+  `);
+
+  const links = component.querySelectorAll('glide-core-menu-button');
+
+  const options = component.shadowRoot?.querySelector(
+    'glide-core-menu-options',
+  );
+
+  links[1].dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+  await elementUpdated(component);
+
+  expect(links[0].privateActive).to.be.false;
+  expect(links[1].privateActive).to.be.true;
+  expect(options?.getAttribute('aria-activedescendant')).to.equal(links[1].id);
 });
 
 it('activates the next option on ArrowDown', async () => {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

#### Hover

1. Navigate to Tree in Storybook.
2. Expand Tree and click its kebab to open Menu.
3. Check that each option has a hover state when hovered.

#### Click

1. Navigate to Menu in Storybook.
2. Use DevTools to add a click listener to one of Menu's options.
3. Check that the listener is called when the option is clicked.


## 📸 Images/Videos of Functionality

N/A
