### PR TITLE
Allow setting the placement of tree item menu

### DIFF
--- a/.changeset/rude-pots-cheer.md
+++ b/.changeset/rude-pots-cheer.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Allow setting the placement of tree item menu

--- a/packages/components/src/tree.item.menu.test.basics.ts
+++ b/packages/components/src/tree.item.menu.test.basics.ts
@@ -3,6 +3,8 @@ import GlideCoreTreeItemMenu from './tree.item.menu.js';
 import expectArgumentError from './library/expect-argument-error.js';
 import sinon from 'sinon';
 
+GlideCoreTreeItemMenu.shadowRootOptions.mode = 'open';
+
 it('registers', async () => {
   expect(window.customElements.get('glide-core-tree-item-menu')).to.equal(
     GlideCoreTreeItemMenu,
@@ -37,4 +39,28 @@ it('throws if the default slot is the incorrect type', async () => {
   // it.
   await waitUntil(() => stub.calledTwice);
   stub.restore();
+});
+
+it('defaults the placement of the menu to bottom start', async () => {
+  const treeItemMenu = await fixture<GlideCoreTreeItemMenu>(html`
+    <glide-core-tree-item-menu>
+      <glide-core-menu-link label="One" url="/one"> </glide-core-menu-link>
+    </glide-core-tree-item-menu>
+  `);
+
+  expect(
+    treeItemMenu.shadowRoot?.querySelector('glide-core-menu')?.placement,
+  ).to.equal('bottom-start');
+});
+
+it('can set placement of the menu', async () => {
+  const treeItemMenu = await fixture<GlideCoreTreeItemMenu>(html`
+    <glide-core-tree-item-menu placement="bottom-end">
+      <glide-core-menu-link label="One" url="/one"> </glide-core-menu-link>
+    </glide-core-tree-item-menu>
+  `);
+
+  expect(
+    treeItemMenu.shadowRoot?.querySelector('glide-core-menu')?.placement,
+  ).to.equal('bottom-end');
 });

--- a/packages/components/src/tree.item.menu.ts
+++ b/packages/components/src/tree.item.menu.ts
@@ -3,12 +3,13 @@ import './menu.js';
 import './menu.options.js';
 import { LitElement, html } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { owSlot, owSlotType } from './library/ow.js';
 import GlideCoreMenu from './menu.js';
 import GlideCoreMenuButton from './menu.button.js';
 import GlideCoreMenuLink from './menu.link.js';
 import styles from './tree.item.menu.styles.js';
+import type { Placement } from '@floating-ui/dom';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -31,6 +32,9 @@ export default class GlideCoreTreeItemMenu extends LitElement {
 
   static override styles = styles;
 
+  @property({ reflect: true })
+  placement: Placement = 'bottom-start';
+
   override firstUpdated() {
     owSlot(this.#defaultSlotElementRef.value);
 
@@ -42,7 +46,11 @@ export default class GlideCoreTreeItemMenu extends LitElement {
 
   override render() {
     return html`
-      <glide-core-menu class="component" ${ref(this.#menuElementRef)}>
+      <glide-core-menu
+        class="component"
+        placement=${this.placement}
+        ${ref(this.#menuElementRef)}
+      >
         <glide-core-menu-options>
           <slot
             @slotchange=${this.#onDefaultSlotChange}

--- a/packages/components/src/tree.stories.ts
+++ b/packages/components/src/tree.stories.ts
@@ -27,6 +27,7 @@ const meta: Meta = {
     'slot="default"': '',
     '<glide-core-tree-item>.label': 'Branch',
     '<glide-core-tree-item>.selected': false,
+    '<glide-core-tree-item-menu>.placement': 'bottom-start',
   },
   play(context) {
     const links = context.canvasElement.querySelectorAll(
@@ -57,7 +58,12 @@ const meta: Meta = {
                 name="settings"
               ></glide-core-example-icon>
             </glide-core-tree-item-icon-button>
-            ${treeItemMenu}
+            <glide-core-tree-item-menu
+              slot="menu"
+              placement=${arguments_['<glide-core-tree-item-menu>.placement']}
+            >
+              ${treeItemMenu}
+            </glide-core-tree-item-menu>
           </glide-core-tree-item>
           <glide-core-tree-item label="Sub-branch">
             <glide-core-tree-item label="Sub-leaf 1"></glide-core-tree-item>
@@ -89,6 +95,30 @@ const meta: Meta = {
         type: { summary: 'string' },
       },
       type: { name: 'string', required: true },
+    },
+    '<glide-core-tree-item-menu>.placement': {
+      control: { type: 'select' },
+      options: [
+        'bottom',
+        'left',
+        'right',
+        'top',
+        'bottom-start',
+        'bottom-end',
+        'left-start',
+        'left-end',
+        'right-start',
+        'right-end',
+        'top-start',
+        'top-end',
+      ],
+      table: {
+        defaultValue: { summary: '"bottom-start"' },
+        type: {
+          summary:
+            '"bottom" | "left" | "right" | "top" | "bottom-start" | "bottom-end" | "left-start" | "left-end" | "right-start" | "right-end" | "top-start"| "top-end"',
+        },
+      },
     },
     'addEventListener(event)': {
       table: {
@@ -247,7 +277,11 @@ export const TreeItemWithMenu: StoryObj = {
           label=${arguments_['<glide-core-tree-item>.label']}
           ?selected=${arguments_['<glide-core-tree-item>.selected'] || nothing}
           >
-          ${treeItemMenu}
+          <glide-core-tree-item-menu slot="menu" placement=${
+            arguments_['<glide-core-tree-item-menu>.placement']
+          }>
+            ${treeItemMenu}
+          </glide-core-tree-item-menu>
         </glide-core-tree-item></glide-core-tree-item>
       </glide-core-tree>
     </div>
@@ -265,7 +299,11 @@ export const TreeItemWithPrefixSuffixAndMenu: StoryObj = {
           >
           <glide-core-example-icon slot="prefix" name="share"></glide-core-example-icon>
           <glide-core-example-icon slot="suffix" name="settings"></glide-core-example-icon>
-          ${treeItemMenu}
+          <glide-core-tree-item-menu slot="menu" placement=${
+            arguments_['<glide-core-tree-item-menu>.placement']
+          }>
+            ${treeItemMenu}
+          </glide-core-tree-item-menu>
         </glide-core-tree-item></glide-core-tree-item>
       </glide-core-tree>
     </div>
@@ -273,33 +311,25 @@ export const TreeItemWithPrefixSuffixAndMenu: StoryObj = {
 };
 
 const treeItemMenu = html`
-  <glide-core-tree-item-menu slot="menu">
-    <glide-core-menu-link label="Edit" url="/edit">
-      <glide-core-example-icon
-        slot="icon"
-        name="pencil"
-      ></glide-core-example-icon>
-    </glide-core-menu-link>
+  <glide-core-menu-link label="Edit" url="/edit">
+    <glide-core-example-icon
+      slot="icon"
+      name="pencil"
+    ></glide-core-example-icon>
+  </glide-core-menu-link>
 
-    <glide-core-menu-link label="Move" url="/move">
-      <glide-core-example-icon
-        slot="icon"
-        name="move"
-      ></glide-core-example-icon>
-    </glide-core-menu-link>
+  <glide-core-menu-link label="Move" url="/move">
+    <glide-core-example-icon slot="icon" name="move"></glide-core-example-icon>
+  </glide-core-menu-link>
 
-    <glide-core-menu-link label="Share" url="/share">
-      <glide-core-example-icon
-        slot="icon"
-        name="share"
-      ></glide-core-example-icon>
-    </glide-core-menu-link>
+  <glide-core-menu-link label="Share" url="/share">
+    <glide-core-example-icon slot="icon" name="share"></glide-core-example-icon>
+  </glide-core-menu-link>
 
-    <glide-core-menu-link label="Settings" url="/settings">
-      <glide-core-example-icon
-        slot="icon"
-        name="settings"
-      ></glide-core-example-icon>
-    </glide-core-menu-link>
-  </glide-core-tree-item-menu>
+  <glide-core-menu-link label="Settings" url="/settings">
+    <glide-core-example-icon
+      slot="icon"
+      name="settings"
+    ></glide-core-example-icon>
+  </glide-core-menu-link>
 `;


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Allows setting the `placement` of the Tree Item Menu to something other than the default (`bottom-start`)


## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
