### PR TITLE
Dispatch a single "change" and "input" event when `value` is changed …

### DIFF
--- a/.changeset/lemon-swans-greet.md
+++ b/.changeset/lemon-swans-greet.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown no longer dispatches multiple "change" and "input" events when `value` is changed programmatically.

--- a/packages/components/src/dropdown.test.events.multiple.ts
+++ b/packages/components/src/dropdown.test.events.multiple.ts
@@ -76,6 +76,80 @@ it('dispatches one "input" event when Select All is clicked', async () => {
   expect(spy.calledOnce).to.be.true;
 });
 
+it('dispatches one "change" event when `value` is changed programmatically', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      open
+      multiple
+    >
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const spy = sinon.spy();
+  component.addEventListener('change', spy);
+
+  setTimeout(() => {
+    component.value = ['one', 'two'];
+  });
+
+  await aTimeout(0);
+  expect(spy.calledOnce).to.be.true;
+});
+
+it('dispatches one "input" event when `value` is changed programmatically', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      open
+      multiple
+    >
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const spy = sinon.spy();
+  component.addEventListener('input', spy);
+
+  setTimeout(() => {
+    component.value = ['one', 'two'];
+  });
+
+  await aTimeout(0);
+  expect(spy.calledOnce).to.be.true;
+});
+
 it('dispatches a "change" event when an option is selected after Select All is clicked', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown

--- a/packages/components/src/dropdown.test.events.single.ts
+++ b/packages/components/src/dropdown.test.events.single.ts
@@ -1,0 +1,60 @@
+import './dropdown.option.js';
+import * as sinon from 'sinon';
+import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import GlideCoreDropdown from './dropdown.js';
+
+GlideCoreDropdown.shadowRootOptions.mode = 'open';
+
+it('dispatches one "change" event when `value` is changed programmatically', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const spy = sinon.spy();
+  component.addEventListener('change', spy);
+
+  setTimeout(() => {
+    component.value = ['one'];
+  });
+
+  await aTimeout(0);
+  expect(spy.calledOnce).to.be.true;
+});
+
+it('dispatches one "input" event when `value` is changed programmatically', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const spy = sinon.spy();
+  component.addEventListener('input', spy);
+
+  setTimeout(() => {
+    component.value = ['one'];
+  });
+
+  await aTimeout(0);
+  expect(spy.calledOnce).to.be.true;
+});


### PR DESCRIPTION

<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Open Dropdown in Storybook.
2. Use DevTools to add a "change" and an "input" event listener to Dropdown.
3. Use DevTools to change `value` programmatically.
4. Check that only one "change" and one "input" event is dispatched for both single-select and multiselect.

## 📸 Images/Videos of Functionality

N/A