### PR TITLE
Adjusted padding of Dropdown to match Input and Textarea

### DIFF
--- a/.changeset/stupid-ties-drum.md
+++ b/.changeset/stupid-ties-drum.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Adjusted the padding of Dropdown to match Input and Textarea.

--- a/packages/components/src/dropdown.styles.ts
+++ b/packages/components/src/dropdown.styles.ts
@@ -38,7 +38,7 @@ export default [
       gap: var(--glide-core-spacing-xs);
       justify-content: space-between;
       min-inline-size: var(--min-inline-size);
-      padding-inline: var(--glide-core-spacing-xs);
+      padding-inline: var(--glide-core-spacing-sm);
       text-align: start;
       user-select: none;
       white-space: nowrap;


### PR DESCRIPTION
## 🚀 Description

Working on a few tasks with colors and what not and noticed the Dropdown padding is slightly different than Input and Textarea. This PR fixes that.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Toggle between Dropdown, Input, and Textarea
- They should all be using the same padding
- See below!

## 📸 Images/Videos of Functionality

As you'd expect, this makes the Dropdown a bit longer.


| Before  | After |
| ------------- | ------------- |
| <img width="1838" alt="Screenshot 2024-08-01 at 12 13 10 PM" src="https://github.com/user-attachments/assets/3c363dae-d149-4173-a7f5-f5ab46292efe">  | <img width="1838" alt="Screenshot 2024-08-01 at 12 13 21 PM" src="https://github.com/user-attachments/assets/b87f316b-4733-426b-95ee-3cd290c6e78d">l  |
| <img width="543" alt="Screenshot 2024-08-01 at 12 14 02 PM" src="https://github.com/user-attachments/assets/7b763496-d62c-4ea3-9832-0118a43d7b0e">  | <img width="551" alt="Screenshot 2024-08-01 at 12 14 17 PM" src="https://github.com/user-attachments/assets/392ec686-8287-487e-ae4b-68eede4ba867"> |

You can view the above images yourself by comparing:

- https://glide-core.crowdstrike-ux.workers.dev/main/iframe.html?args=&id=dropdown--multiple-selection-horizontal-with-filtering&viewMode=story
- https://glide-core.crowdstrike-ux.workers.dev/adjust-dropdown-padding/iframe.html?args=&id=dropdown--multiple-selection-horizontal-with-filtering&viewMode=story

Here's another comparison between Input, Textarea, and Dropdown now with padding. It looks like Textarea's label is a bit nudged down in both `main` and this PR. I can maybe look at that next and see what design thinks. I'm not sure if the label should always be in the same spot not matter the component. 

### Before

https://github.com/user-attachments/assets/777365ba-4c91-4f84-8344-475abcab89e6

### After

https://github.com/user-attachments/assets/9301c607-c25c-46c4-b738-cf6951a231a4

