### PR TITLE
Use Ow more consistently to narrow types

### DIFF
--- a/.changeset/giant-gifts-whisper.md
+++ b/.changeset/giant-gifts-whisper.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Menu no longer opens, showing an empty menu, when no options are provided.

--- a/packages/components/src/checkbox.ts
+++ b/packages/components/src/checkbox.ts
@@ -4,9 +4,9 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { svg } from 'lit/static-html.js';
 import { when } from 'lit/directives/when.js';
 import checkedIcon from './icons/checked.js';
+import ow from './library/ow.js';
 import styles from './checkbox.styles.js';
 
 declare global {
@@ -15,10 +15,19 @@ declare global {
   }
 }
 
-const indeterminateIcon = svg`
-  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" class="indeterminate-icon">
+const indeterminateIcon = html`
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 14 14"
+    fill="none"
+    class="indeterminate-icon"
+  >
     <rect x="0.5" y="0.5" width="13" height="13" rx="3.5" />
-    <path d="M3 5C3 3.89543 3.89543 3 5 3H9.79289C10.2383 3 10.4614 3.53857 10.1464 3.85355L3.85355 10.1464C3.53857 10.4614 3 10.2383 3 9.79289V5Z" fill="currentColor"/>
+    <path
+      d="M3 5C3 3.89543 3.89543 3 5 3H9.79289C10.2383 3 10.4614 3.53857 10.1464 3.85355L3.85355 10.1464C3.53857 10.4614 3 10.2383 3 9.79289V5Z"
+      fill="currentColor"
+    />
   </svg>
 `;
 
@@ -259,14 +268,14 @@ export default class GlideCoreCheckbox extends LitElement {
   }
 
   override updated() {
-    if (this.#inputElementRef.value) {
-      // `indeterminate` needs to be updated both on initial render and after it has
-      // changed. This handles both cases.
-      //
-      // TODO
-      // No need for this when browsers support the ":indeterminate" on the host.
-      this.#inputElementRef.value.indeterminate = this.indeterminate;
-    }
+    ow(this.#inputElementRef.value, ow.object.instanceOf(HTMLInputElement));
+
+    // `indeterminate` needs to be updated both on initial render and after it has
+    // changed. This handles both cases.
+    //
+    // TODO
+    // No need for this when browsers support the ":indeterminate" on the host.
+    this.#inputElementRef.value.indeterminate = this.indeterminate;
   }
 
   constructor() {

--- a/packages/components/src/drawer.ts
+++ b/packages/components/src/drawer.ts
@@ -133,7 +133,7 @@ export default class GlideCoreDrawer extends LitElement {
   #onDefaultSlotChange() {
     owSlot(this.#defaultSlotElementRef.value);
 
-    const slotElements = this.#defaultSlotElementRef.value!.assignedElements();
+    const slotElements = this.#defaultSlotElementRef.value.assignedElements();
 
     setContainingBlock({
       elements: slotElements,

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -1025,7 +1025,9 @@ export default class GlideCoreDropdown extends LitElement {
   }
 
   #onInputInput() {
-    if (this.#inputElementRef.value && this.activeOption) {
+    ow(this.#inputElementRef.value, ow.object.instanceOf(HTMLInputElement));
+
+    if (this.activeOption) {
       this.open = true;
       this.ariaActivedescendant = this.activeOption.id;
       this.isFiltering = this.#inputElementRef.value.value.trim() !== '';

--- a/packages/components/src/form-controls-layout.ts
+++ b/packages/components/src/form-controls-layout.ts
@@ -40,13 +40,11 @@ export default class GlideCoreFormControlsLayout extends LitElement {
   set split(split: 'left' | 'middle') {
     this.#split = split;
 
-    const assignedElements = this.#slotElementRef.value?.assignedElements();
+    owSlot(this.#slotElementRef.value);
 
-    if (assignedElements) {
-      for (const element of assignedElements) {
-        if ('privateSplit' in element) {
-          element.privateSplit = this.split;
-        }
+    for (const element of this.#slotElementRef.value.assignedElements()) {
+      if ('privateSplit' in element) {
+        element.privateSplit = this.split;
       }
     }
   }
@@ -79,16 +77,14 @@ export default class GlideCoreFormControlsLayout extends LitElement {
   #split: 'left' | 'middle' = 'left';
 
   #assertHorizontalControls() {
-    const assignedElements = this.#slotElementRef.value?.assignedElements();
+    owSlot(this.#slotElementRef.value);
 
-    if (assignedElements) {
-      for (const element of assignedElements) {
-        if ('orientation' in element) {
-          ow(
-            element.orientation === 'horizontal',
-            ow.boolean.true.message('Only horizontal controls are supported.'),
-          );
-        }
+    for (const element of this.#slotElementRef.value.assignedElements()) {
+      if ('orientation' in element) {
+        ow(
+          element.orientation === 'horizontal',
+          ow.boolean.true.message('Only horizontal controls are supported.'),
+        );
       }
     }
   }
@@ -106,13 +102,9 @@ export default class GlideCoreFormControlsLayout extends LitElement {
 
     this.#assertHorizontalControls();
 
-    const assignedElements = this.#slotElementRef.value?.assignedElements();
-
-    if (assignedElements) {
-      for (const element of assignedElements) {
-        if ('privateSplit' in element) {
-          element.privateSplit = this.split;
-        }
+    for (const element of this.#slotElementRef.value.assignedElements()) {
+      if ('privateSplit' in element) {
+        element.privateSplit = this.split;
       }
     }
   }

--- a/packages/components/src/input.ts
+++ b/packages/components/src/input.ts
@@ -12,6 +12,7 @@ import {
 } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import magnifyingGlassIcon from './icons/magnifying-glass.js';
+import ow from './library/ow.js';
 import styles from './input.styles.js';
 
 declare global {
@@ -435,8 +436,9 @@ export default class GlideCoreInput extends LitElement {
   }
 
   #onChange(event: Event) {
-    this.value = this.#inputElement!.value;
+    ow(this.#inputElement, ow.object.instanceOf(HTMLInputElement));
 
+    this.value = this.#inputElement.value;
     this.#setValidityToInputValidity();
 
     // Unlike "input" events, "change" events aren't composed. So we manually
@@ -458,9 +460,8 @@ export default class GlideCoreInput extends LitElement {
   }
 
   #onInput() {
-    const value = this.#inputElement!.value;
-    this.value = value;
-
+    ow(this.#inputElement, ow.object.instanceOf(HTMLInputElement));
+    this.value = this.#inputElement.value;
     this.#setValidityToInputValidity();
   }
 

--- a/packages/components/src/label.ts
+++ b/packages/components/src/label.ts
@@ -4,7 +4,7 @@ import { LocalizeController } from './library/localize.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
-import { owSlot } from './library/ow.js';
+import ow, { owSlot } from './library/ow.js';
 import styles from './label.styles.js';
 
 import { svg } from 'lit';
@@ -238,29 +238,30 @@ export default class GlideCoreLabel extends LitElement {
 
     const labelElement = this.#labelElementRef.value;
 
-    if (defaultSlotAssignedElement && labelElement) {
-      if (defaultSlotAssignedElement.textContent) {
-        this.label = defaultSlotAssignedElement.textContent;
-      }
+    ow(defaultSlotAssignedElement, ow.object.instanceOf(Element));
+    ow(labelElement, ow.object.instanceOf(HTMLElement));
 
-      const observer = new ResizeObserver(() => {
-        // `getBoundingClientRect` is used so we're comparing apples to apples.
-        //
-        // `clientWidth` on `defaultSlotAssignedElement` is zero if the element
-        // is `display` is `inline`. `labelElement`, on the other hand, isn't
-        // inline.
-        //
-        // But `clientWidth` returns an integer and `getBoundingClientRect().width`
-        // return a float. So using `clientWidth` for `labelElement` would mean the
-        // width of `defaultSlotAssignedElement` is always fractionally greater than
-        // that of `labelElement`.
-        this.isLabelTooltip =
-          defaultSlotAssignedElement.getBoundingClientRect().width >
-          labelElement.getBoundingClientRect().width;
-      });
-
-      observer.observe(labelElement);
+    if (defaultSlotAssignedElement.textContent) {
+      this.label = defaultSlotAssignedElement.textContent;
     }
+
+    const observer = new ResizeObserver(() => {
+      // `getBoundingClientRect` is used so we're comparing apples to apples.
+      //
+      // `clientWidth` on `defaultSlotAssignedElement` is zero if the element
+      // is `display` is `inline`. `labelElement`, on the other hand, isn't
+      // inline.
+      //
+      // But `clientWidth` returns an integer and `getBoundingClientRect().width`
+      // return a float. So using `clientWidth` for `labelElement` would mean the
+      // width of `defaultSlotAssignedElement` is always fractionally greater than
+      // that of `labelElement`.
+      this.isLabelTooltip =
+        defaultSlotAssignedElement.getBoundingClientRect().width >
+        labelElement.getBoundingClientRect().width;
+    });
+
+    observer.observe(labelElement);
   }
 
   #onDescriptionSlotChange() {

--- a/packages/components/src/library/ow.ts
+++ b/packages/components/src/library/ow.ts
@@ -9,7 +9,9 @@ const isDevelopment =
  *
  * @param slot - The slot to assert against.
  */
-export function owSlot(slot?: HTMLSlotElement) {
+export function owSlot(
+  slot?: HTMLSlotElement,
+): asserts slot is HTMLSlotElement {
   if (!isDevelopment) {
     return;
   }
@@ -40,7 +42,7 @@ export function owSlot(slot?: HTMLSlotElement) {
 export function owSlotType(
   slot?: HTMLSlotElement,
   slotted: (typeof Element | typeof Text)[] = [],
-) {
+): asserts slot is HTMLSlotElement {
   if (!isDevelopment) {
     return;
   }

--- a/packages/components/src/menu.test.basics.ts
+++ b/packages/components/src/menu.test.basics.ts
@@ -174,21 +174,13 @@ it('is not opened when initially `open` and its target is `disabled`', async () 
 });
 
 it('throws if it does not have a default slot', async () => {
-  const spy = sinon.spy();
-
-  try {
-    await fixture<GlideCoreMenu>(
+  await expectArgumentError(() => {
+    return fixture<GlideCoreMenu>(
       html`<glide-core-menu
         ><button slot="target">Target</button></glide-core-menu
       >`,
     );
-  } catch (error) {
-    if (error instanceof ArgumentError) {
-      spy();
-    }
-  }
-
-  expect(spy.called).to.be.true;
+  });
 });
 
 it('throws if the default slot is the incorrect type', async () => {

--- a/packages/components/src/menu.test.interactions.ts
+++ b/packages/components/src/menu.test.interactions.ts
@@ -33,7 +33,7 @@ class GlideCoreNestedSlot extends LitElement {
 GlideCoreMenu.shadowRootOptions.mode = 'open';
 GlideCoreNestedSlot.shadowRootOptions.mode = 'open';
 
-it('opens when clicked', async () => {
+it('opens on click', async () => {
   const component = await fixture<GlideCoreMenu>(
     html`<glide-core-menu>
       <button slot="target">Target</button>
@@ -55,6 +55,28 @@ it('opens when clicked', async () => {
   expect(component.open).to.be.true;
   expect(defaultSlot?.checkVisibility({ checkVisibilityCSS: true })).to.be.true;
   expect(target?.ariaExpanded).to.equal('true');
+});
+
+it('does not open on click when there are no options', async () => {
+  const component = await fixture<GlideCoreMenu>(
+    html`<glide-core-menu>
+      <button slot="target">Target</button>
+      <glide-core-menu-options> </glide-core-menu-options>
+    </glide-core-menu>`,
+  );
+
+  component.querySelector('button')?.click();
+
+  const defaultSlot =
+    component?.shadowRoot?.querySelector<HTMLSlotElement>('slot:not([name])');
+
+  const options = component.querySelector('glide-core-menu-options');
+  const target = component.querySelector('button');
+
+  expect(component.open).to.be.false;
+  expect(defaultSlot?.checkVisibility({ checkVisibilityCSS: true })).to.not.ok;
+  expect(options?.getAttribute('aria-activedescendant')).to.equal('');
+  expect(target?.ariaExpanded).to.equal('false');
 });
 
 it('does not open when `disabled` is set on its target', async () => {
@@ -273,6 +295,29 @@ it('opens on Space', async () => {
   expect(defaultSlot?.checkVisibility({ checkVisibilityCSS: true })).to.be.true;
   expect(options?.getAttribute('aria-activedescendant')).to.equal(link?.id);
   expect(target?.ariaExpanded).to.equal('true');
+});
+
+it('does not open on Space when there are no options', async () => {
+  const component = await fixture<GlideCoreMenu>(
+    html`<glide-core-menu>
+      <button slot="target">Target</button>
+      <glide-core-menu-options> </glide-core-menu-options>
+    </glide-core-menu>`,
+  );
+
+  component.querySelector('button')?.focus();
+  await sendKeys({ press: ' ' });
+
+  const defaultSlot =
+    component?.shadowRoot?.querySelector<HTMLSlotElement>('slot:not([name])');
+
+  const options = component.querySelector('glide-core-menu-options');
+  const target = component.querySelector('button');
+
+  expect(component.open).to.be.false;
+  expect(defaultSlot?.checkVisibility({ checkVisibilityCSS: true })).to.not.ok;
+  expect(options?.getAttribute('aria-activedescendant')).to.equal('');
+  expect(target?.ariaExpanded).to.equal('false');
 });
 
 it('opens when opened programmatically', async () => {

--- a/packages/components/src/menu.ts
+++ b/packages/components/src/menu.ts
@@ -12,10 +12,10 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { nanoid } from 'nanoid';
 import { offsetParent } from 'composed-offset-position';
-import { owSlot, owSlotType } from './library/ow.js';
 import GlideCoreMenuButton from './menu.button.js';
 import GlideCoreMenuLink from './menu.link.js';
 import GlideCoreMenuOptions from './menu.options.js';
+import ow, { owSlot, owSlotType } from './library/ow.js';
 import styles from './menu.styles.js';
 
 declare global {
@@ -110,13 +110,14 @@ export default class GlideCoreMenu extends LitElement {
   }
 
   override firstUpdated() {
+    ow(this.#optionsElement, ow.object.instanceOf(GlideCoreMenuOptions));
     owSlot(this.#defaultSlotElementRef.value);
     owSlot(this.#targetSlotElementRef.value);
     owSlotType(this.#defaultSlotElementRef.value, [GlideCoreMenuOptions]);
 
     const firstOption = this.#optionElements?.at(0);
 
-    if (this.open && firstOption && this.#optionsElement) {
+    if (this.open && firstOption) {
       this.#setUpFloatingUi();
 
       firstOption.privateActive = true;
@@ -220,6 +221,7 @@ export default class GlideCoreMenu extends LitElement {
   };
 
   #onDefaultSlotChange() {
+    ow(this.#optionsElement, ow.object.instanceOf(GlideCoreMenuOptions));
     owSlot(this.#defaultSlotElementRef.value);
     owSlotType(this.#defaultSlotElementRef.value, [GlideCoreMenuOptions]);
 
@@ -229,9 +231,7 @@ export default class GlideCoreMenu extends LitElement {
       firstOption.privateActive = true;
     }
 
-    if (this.#optionsElement) {
-      this.#optionsElement.privateSize = this.size;
-    }
+    this.#optionsElement.privateSize = this.size;
   }
 
   #onDefaultSlotClick() {
@@ -248,8 +248,8 @@ export default class GlideCoreMenu extends LitElement {
       event.target instanceof GlideCoreMenuLink;
 
     if (isButtonOrLink && this.#activeOption && this.#optionsElement) {
-      this.#activeOption.privateActive = false;
       event.target.privateActive = true;
+      this.#activeOption.privateActive = false;
       this.#optionsElement.ariaActivedescendant = event.target.id;
     }
   }
@@ -289,11 +289,9 @@ export default class GlideCoreMenu extends LitElement {
   }
 
   #onSlotKeydown(event: KeyboardEvent) {
-    if (
-      [' ', 'Enter', 'Escape'].includes(event.key) &&
-      this.open &&
-      this.#optionsElement
-    ) {
+    ow(this.#optionsElement, ow.object.instanceOf(GlideCoreMenuOptions));
+
+    if ([' ', 'Enter', 'Escape'].includes(event.key) && this.open) {
       this.open = false;
       this.#optionsElement.ariaActivedescendant = '';
       this.focus();
@@ -309,8 +307,7 @@ export default class GlideCoreMenu extends LitElement {
     if (
       [' ', 'ArrowUp', 'ArrowDown'].includes(event.key) &&
       !this.open &&
-      this.#activeOption &&
-      this.#optionsElement
+      this.#activeOption
     ) {
       event.preventDefault(); // Prevent scroll.
 
@@ -320,7 +317,19 @@ export default class GlideCoreMenu extends LitElement {
       return;
     }
 
-    if (this.open && this.#activeOption && this.#optionElements) {
+    if (this.open) {
+      ow(this.#optionElements, ow.array);
+      ow(this.#optionsElement, ow.object.instanceOf(GlideCoreMenuOptions));
+
+      ow(
+        this.#activeOption,
+        ow.object.is(
+          (object) =>
+            object instanceof GlideCoreMenuButton ||
+            object instanceof GlideCoreMenuLink,
+        ),
+      );
+
       const activeOptionIndex = this.#optionElements.indexOf(
         this.#activeOption,
       );
@@ -332,9 +341,9 @@ export default class GlideCoreMenu extends LitElement {
       if (event.key === 'ArrowUp' && !event.metaKey) {
         event.preventDefault(); // Prevent scroll.
 
-        const option = this.#optionElements?.at(activeOptionIndex - 1);
+        const option = this.#optionElements.at(activeOptionIndex - 1);
 
-        if (option && activeOptionIndex !== 0 && this.#optionsElement) {
+        if (option && activeOptionIndex !== 0) {
           this.#activeOption.privateActive = false;
           this.#optionsElement.ariaActivedescendant = option.id;
           option.privateActive = true;
@@ -343,10 +352,10 @@ export default class GlideCoreMenu extends LitElement {
         return;
       }
 
-      if (event.key === 'ArrowDown' && !event.metaKey && this.#optionsElement) {
+      if (event.key === 'ArrowDown' && !event.metaKey) {
         event.preventDefault(); // Prevent scroll.
 
-        const option = this.#optionElements?.at(activeOptionIndex + 1);
+        const option = this.#optionElements.at(activeOptionIndex + 1);
 
         if (option) {
           this.#activeOption.privateActive = false;
@@ -364,9 +373,9 @@ export default class GlideCoreMenu extends LitElement {
       ) {
         event.preventDefault(); // Prevent scroll.
 
-        const option = this.#optionElements?.at(0);
+        const option = this.#optionElements.at(0);
 
-        if (option && this.#optionsElement) {
+        if (option) {
           this.#activeOption.privateActive = false;
           this.#optionsElement.ariaActivedescendant = option.id;
           option.privateActive = true;
@@ -382,9 +391,9 @@ export default class GlideCoreMenu extends LitElement {
       ) {
         event.preventDefault(); // Prevent scroll.
 
-        const option = this.#optionElements?.at(-1);
+        const option = this.#optionElements.at(-1);
 
-        if (option && this.#optionsElement) {
+        if (option) {
           this.#activeOption.privateActive = false;
           this.#optionsElement.ariaActivedescendant = option.id;
           option.privateActive = true;
@@ -397,6 +406,8 @@ export default class GlideCoreMenu extends LitElement {
 
   #onTargetSlotChange() {
     owSlot(this.#targetSlotElementRef.value);
+    ow(this.#targetElement, ow.object.instanceOf(Element));
+    ow(this.#optionsElement, ow.object.instanceOf(GlideCoreMenuOptions));
 
     this.#setIsTargetDisabled();
 
@@ -421,26 +432,13 @@ export default class GlideCoreMenu extends LitElement {
       }
     });
 
-    const assignedElements = this.#targetSlotElementRef.value
-      ?.assignedElements()
-      .at(0);
+    observer.observe(this.#targetElement, { attributes: true });
 
-    if (assignedElements) {
-      observer.observe(assignedElements, { attributes: true });
-    }
-
-    if (this.#targetElement && this.#optionsElement) {
-      this.#targetElement.ariaHasPopup = 'true';
-      this.#targetElement.ariaExpanded = this.open ? 'true' : 'false';
-      this.#targetElement.id = nanoid();
-
-      this.#targetElement.setAttribute(
-        'aria-controls',
-        this.#optionsElement.id,
-      );
-
-      this.#optionsElement.ariaLabelledby = this.#targetElement.id;
-    }
+    this.#targetElement.ariaHasPopup = 'true';
+    this.#targetElement.ariaExpanded = this.open ? 'true' : 'false';
+    this.#targetElement.id = nanoid();
+    this.#targetElement.setAttribute('aria-controls', this.#optionsElement.id);
+    this.#optionsElement.ariaLabelledby = this.#targetElement.id;
   }
 
   #onTargetSlotClick() {
@@ -453,7 +451,9 @@ export default class GlideCoreMenu extends LitElement {
       this.#targetElement.ariaExpanded = this.open ? 'true' : 'false';
     }
 
-    this.open = !this.open;
+    if (this.#optionElements && this.#optionElements.length > 0) {
+      this.open = !this.open;
+    }
 
     if (this.open && this.#activeOption && this.#optionsElement) {
       this.#optionsElement.ariaActivedescendant = this.#activeOption.id;

--- a/packages/components/src/modal.tertiary-icon.ts
+++ b/packages/components/src/modal.tertiary-icon.ts
@@ -3,8 +3,8 @@ import { LitElement, html } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { owSlot } from './library/ow.js';
 import GlideCoreTooltip from './tooltip.js';
+import ow, { owSlot } from './library/ow.js';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -53,7 +53,8 @@ export default class GlideCoreModalTertiaryIcon extends LitElement {
   }
 
   setContainingBlock(containingBlock: HTMLElement) {
-    this.#tooltipElementRef.value!.containingBlock = containingBlock;
+    ow(this.#tooltipElementRef.value, ow.object.instanceOf(GlideCoreTooltip));
+    this.#tooltipElementRef.value.containingBlock = containingBlock;
   }
 
   #defaultSlotElementRef = createRef<HTMLSlotElement>();

--- a/packages/components/src/modal.ts
+++ b/packages/components/src/modal.ts
@@ -4,12 +4,12 @@ import { LocalizeController } from './library/localize.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
-import { owSlot, owSlotType } from './library/ow.js';
 import { setContainingBlock } from './library/set-containing-block.js';
 import { when } from 'lit/directives/when.js';
 import GlideCoreButton from './button.js';
 import GlideCoreModalIconButton from './modal.icon-button.js';
 import GlideCoreModalTertiaryIcon from './modal.tertiary-icon.js';
+import ow, { owSlot, owSlotType } from './library/ow.js';
 import styles from './modal.styles.js';
 
 declare global {
@@ -347,14 +347,19 @@ export default class GlideCoreModal extends LitElement {
   }
 
   #onDefaultSlotChange() {
+    ow(
+      this.#componentElementRef.value,
+      ow.object.instanceOf(HTMLDialogElement),
+    );
+
     owSlot(this.#defaultSlotElementRef.value);
 
     const defaultSlotElements =
-      this.#defaultSlotElementRef.value!.assignedElements();
+      this.#defaultSlotElementRef.value.assignedElements();
 
     setContainingBlock({
       elements: defaultSlotElements,
-      containingBlock: this.#componentElementRef.value!,
+      containingBlock: this.#componentElementRef.value,
     });
   }
 
@@ -369,21 +374,27 @@ export default class GlideCoreModal extends LitElement {
   }
 
   #onFooterMenuTertiarySlotChange() {
+    ow(
+      this.#componentElementRef.value,
+      ow.object.instanceOf(HTMLDialogElement),
+    );
+
     owSlotType(this.#footerMenuTertiarySlotElementRef.value, [
       GlideCoreModalTertiaryIcon,
       GlideCoreButton,
     ]);
 
-    const tertiarySlotElements =
-      this.#footerMenuTertiarySlotElementRef.value!.assignedElements();
+    const tertiarySlotAssignedElements =
+      this.#footerMenuTertiarySlotElementRef.value.assignedElements();
 
-    const tertiaryIcons: GlideCoreModalTertiaryIcon[] =
-      tertiarySlotElements.filter((element) => {
+    const tertiaryIcons = tertiarySlotAssignedElements.filter(
+      (element): element is GlideCoreModalTertiaryIcon => {
         return element instanceof GlideCoreModalTertiaryIcon;
-      });
+      },
+    );
 
     for (const tertiaryIcon of tertiaryIcons) {
-      tertiaryIcon.setContainingBlock(this.#componentElementRef.value!);
+      tertiaryIcon.setContainingBlock(this.#componentElementRef.value);
     }
   }
 

--- a/packages/components/src/textarea.ts
+++ b/packages/components/src/textarea.ts
@@ -5,6 +5,7 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
+import ow from './library/ow.js';
 import styles from './textarea.styles.js';
 
 declare global {
@@ -243,7 +244,12 @@ export default class GlideCoreTextarea extends LitElement {
   }
 
   #onChange(event: Event) {
-    const textAreaValue = this.#textareaElementRef.value!.value;
+    ow(
+      this.#textareaElementRef.value,
+      ow.object.instanceOf(HTMLTextAreaElement),
+    );
+
+    const textAreaValue = this.#textareaElementRef.value.value;
     this.value = textAreaValue;
 
     this.#onUpdateValidityState();
@@ -253,7 +259,12 @@ export default class GlideCoreTextarea extends LitElement {
   }
 
   #onInput() {
-    const textAreaValue = this.#textareaElementRef.value!.value;
+    ow(
+      this.#textareaElementRef.value,
+      ow.object.instanceOf(HTMLTextAreaElement),
+    );
+
+    const textAreaValue = this.#textareaElementRef.value.value;
     this.value = textAreaValue;
     this.#internals.setFormValue(this.value);
 

--- a/packages/components/src/toasts.ts
+++ b/packages/components/src/toasts.ts
@@ -3,6 +3,7 @@ import { LitElement, html } from 'lit';
 import { LocalizeController } from './library/localize.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement } from 'lit/decorators.js';
+import ow from './library/ow.js';
 import styles from './toasts.styles.js';
 
 declare global {
@@ -19,7 +20,7 @@ export interface Toast {
 }
 
 /**
- * @description A container and controller for toast messages
+ * @description A container and controller for toast messages.
 
  */
 @customElement('glide-core-toasts')
@@ -44,7 +45,8 @@ export default class GlideCoreToasts extends LitElement {
       },
     );
 
-    this.#componentElementRef.value!.append(toastElement);
+    ow(this.#componentElementRef.value, ow.object.instanceOf(Element));
+    this.#componentElementRef.value.append(toastElement);
 
     toastElement.addEventListener(
       'close',

--- a/packages/components/src/tree.item.menu.ts
+++ b/packages/components/src/tree.item.menu.ts
@@ -8,6 +8,7 @@ import { owSlot, owSlotType } from './library/ow.js';
 import GlideCoreMenu from './menu.js';
 import GlideCoreMenuButton from './menu.button.js';
 import GlideCoreMenuLink from './menu.link.js';
+import ow from './library/ow.js';
 import styles from './tree.item.menu.styles.js';
 import type { Placement } from '@floating-ui/dom';
 
@@ -84,7 +85,8 @@ export default class GlideCoreTreeItemMenu extends LitElement {
   }
 
   setContainingBlock(containingBlock: Element) {
-    this.#menuElementRef.value!.setContainingBlock(containingBlock);
+    ow(this.#menuElementRef.value, ow.object.instanceOf(Element));
+    this.#menuElementRef.value.setContainingBlock(containingBlock);
   }
 
   #defaultSlotElementRef = createRef<HTMLSlotElement>();

--- a/packages/components/src/tree.item.ts
+++ b/packages/components/src/tree.item.ts
@@ -119,11 +119,11 @@ export default class GlideCoreTreeItem extends LitElement {
             `,
           )}
         </div>
-        <slot name="prefix" @slotchange=${this.#onPrefixSlotChange}></slot>
+        <slot name="prefix"></slot>
         <div class="label">${this.label}</div>
         <div class="icon-container">
-          <slot name="menu" @slotchange=${this.#onMenuSlotChange}></slot>
-          <slot name="suffix" @slotchange=${this.#onSuffixSlotChange}></slot>
+          <slot name="menu"></slot>
+          <slot name="suffix"></slot>
         </div>
       </div>
       <div class="child-items" role="group">
@@ -173,15 +173,6 @@ export default class GlideCoreTreeItem extends LitElement {
   @state()
   private childTreeItems: GlideCoreTreeItem[] = [];
 
-  @state()
-  private hasMenuSlot = false;
-
-  @state()
-  private hasPrefixSlot = false;
-
-  @state()
-  private hasSuffixSlot = false;
-
   #labelContainerElementRef = createRef<HTMLInputElement>();
 
   get #ariaExpanded() {
@@ -202,18 +193,6 @@ export default class GlideCoreTreeItem extends LitElement {
 
   get #indentationWidth() {
     return `${(this.level - 1) * 20}px`;
-  }
-
-  #onMenuSlotChange() {
-    this.hasMenuSlot = this.menuSlotAssignedElements.length > 0;
-  }
-
-  #onPrefixSlotChange() {
-    this.hasPrefixSlot = this.prefixSlotAssignedElements.length > 0;
-  }
-
-  #onSuffixSlotChange() {
-    this.hasSuffixSlot = this.suffixSlotAssignedElements.length > 0;
   }
 
   #setupChildren() {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- Adds narrowing support to `owSlot` and `owSlotType`.
- Uses `ow` to narrow instead of conditionals in various components.
- Uses `ow` to eliminate casts in various components.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to Menu in Storybook locally.
2. Remove [the options](https://github.com/CrowdStrike/glide-core/blob/main/packages/components/src/menu.stories.ts#L124-L130).
3. Press Space when Menu is focused. Or click Menu.
4. Make sure an empty menu isn't shown.

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
