### PR TITLE
Add typed events (POC)

### DIFF
--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -16,6 +16,28 @@ import magnifyingGlassIcon from './icons/magnifying-glass.js';
 import ow, { owSlotType } from './library/ow.js';
 import styles from './dropdown.styles.js';
 
+interface GlideCoreDropdownEvents {
+  change: Event;
+  custom: CustomEvent<boolean>;
+}
+
+interface AllEvents extends HTMLElementEventMap, GlideCoreDropdownEvents {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+interface GlideCoreDropdown {
+  addEventListener<Type extends keyof AllEvents>(
+    type: Type,
+    listener: (this: GlideCoreDropdown, event: AllEvents[Type]) => void,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+
+  removeEventListener<Type extends keyof AllEvents>(
+    type: Type,
+    listener: (this: GlideCoreDropdown, event: AllEvents[Type]) => void,
+    options?: boolean | EventListenerOptions,
+  ): void;
+}
+
 declare global {
   interface HTMLElementTagNameMap {
     'glide-core-dropdown': GlideCoreDropdown;
@@ -33,7 +55,8 @@ declare global {
  * @slot description - Additional information or context.
  */
 @customElement('glide-core-dropdown')
-export default class GlideCoreDropdown extends LitElement {
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+class GlideCoreDropdown extends LitElement {
   static formAssociated = true;
 
   static override shadowRootOptions: ShadowRootInit = {
@@ -1277,3 +1300,5 @@ export default class GlideCoreDropdown extends LitElement {
     }
   }
 }
+
+export default GlideCoreDropdown;


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

I looked into typing our events a while back but gave up after seeing the implementation. We've since had a couple people ask about them. 

Supporting typed events will add some boilerplate for us as well as a couple unfortunate ESLint disables. Not sure what I have is the best solution. But the boilerplate is minimal and I haven't run into any issues.

What do you think? I left some detailed thoughts of my own [below](https://github.com/CrowdStrike/glide-core/pull/274#issuecomment-2265416254).

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

### Before

#### Element properties are untyped

<img width="481" alt="image" src="https://github.com/user-attachments/assets/524a5802-4001-4a0a-9620-e18247f0343c">

#### Unsupported event types successfully typecheck

<img width="557" alt="image" src="https://github.com/user-attachments/assets/e5e0a141-0da1-4794-abba-c0cd8cb71dbc">

#### `this` is typed as `HTMLElement`

<img width="493" alt="image" src="https://github.com/user-attachments/assets/e5c8659e-f498-46cd-96fd-0df4853a8c1a">


## After

#### Element properties are typed

<img width="629" alt="image" src="https://github.com/user-attachments/assets/5be16a33-4be9-4e32-85ca-500dac6fea64">

#### Unsupported event types fail to typecheck

<img width="554" alt="image" src="https://github.com/user-attachments/assets/8bc70748-e0c7-4037-937c-4775a55d4e7a">

#### `this` is typed as as the component

<img width="493" alt="image" src="https://github.com/user-attachments/assets/6d6b547e-7678-4663-a6cc-50a62dc8d26e">

