### PR TITLE
Don't assert in Form Controls Layout's `split` setter

### DIFF
--- a/.changeset/metal-lizards-pump.md
+++ b/.changeset/metal-lizards-pump.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Prevent Form Controls Layout from throwing on rerender.

--- a/packages/components/src/form-controls-layout.ts
+++ b/packages/components/src/form-controls-layout.ts
@@ -40,11 +40,11 @@ export default class GlideCoreFormControlsLayout extends LitElement {
   set split(split: 'left' | 'middle') {
     this.#split = split;
 
-    owSlot(this.#slotElementRef.value);
-
-    for (const element of this.#slotElementRef.value.assignedElements()) {
-      if ('privateSplit' in element) {
-        element.privateSplit = this.split;
+    if (this.#slotElementRef.value) {
+      for (const element of this.#slotElementRef.value.assignedElements()) {
+        if ('privateSplit' in element) {
+          element.privateSplit = this.split;
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Form Controls Layout's `split` control is broken in Storybook. 

Storybook rerenders components when one of the controls is interacted with. So the `split` setter was running before Form Control Layout's default slot was established, causing the `ow` assertion in the `split` setter to fail. I removed the assertion.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to Form Controls Layout in Storybook.
2. Check the console for errors.
3. Play with the `split` control. Make sure it works.

## 📸 Images/Videos of Functionality

N/A
