### PR TITLE
Don't focus Dropdown when an option is selected

### DIFF
--- a/.changeset/hungry-pears-destroy.md
+++ b/.changeset/hungry-pears-destroy.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown no longer steals focus when an option is selected.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,7 +59,7 @@
     "test:development:web-test-runner": "web-test-runner --watch",
     "test:production": "npm-run-all --parallel test:production:* start:production:stylesheets --aggregate-output --print-label",
     "test:production:web-test-runner": "web-test-runner",
-    "postinstall": "pnpm dlx playwright install --with-deps"
+    "postinstall": "pnpm dlx playwright@1.45.3 install --with-deps"
   },
   "engines": {
     "node": ">= 20",

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -1188,7 +1188,6 @@ export default class GlideCoreDropdown extends LitElement {
         this.#value = event.target.value ? [event.target.value] : [];
         this.open = false;
         this.ariaActivedescendant = '';
-        this.focus();
 
         if (this.isFilterable && this.#inputElementRef.value) {
           this.isFiltering = false;


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to Dropdown in Storybook.
2. Click anywhere outside of Dropdown to focus `<body>`.
3. Use DevTools to log the active element: 
    `setInterval(() => console.log(document.activeElement.contentWindow.document.activeElement), 1000)`
5. Programmatically set `selected` on one of Dropdown's option.
6. Make sure focus remains on `<body>`.

## 📸 Images/Videos of Functionality

N/A

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
