### PR TITLE
Reset Dropdown's #isExternalSelectAllOrExternalValueChange upon selec…

### DIFF
--- a/.changeset/quiet-schools-retire.md
+++ b/.changeset/quiet-schools-retire.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown now emits "change" and "input" events after `value` is changed programmatically.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,7 +59,7 @@
     "test:development:web-test-runner": "web-test-runner --watch",
     "test:production": "npm-run-all --parallel test:production:* start:production:stylesheets --aggregate-output --print-label",
     "test:production:web-test-runner": "web-test-runner",
-    "postinstall": "pnpm dlx playwright install --with-deps"
+    "postinstall": "pnpm dlx playwright@1.45.3 install --with-deps"
   },
   "engines": {
     "node": ">= 20",

--- a/packages/components/src/dropdown.test.events.multiple.ts
+++ b/packages/components/src/dropdown.test.events.multiple.ts
@@ -1,5 +1,5 @@
 import * as sinon from 'sinon';
-import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import GlideCoreDropdown from './dropdown.js';
 import GlideCoreDropdownOption from './dropdown.option.js';
 
@@ -113,6 +113,47 @@ it('dispatches one "change" event when `value` is changed programmatically', asy
   expect(spy.calledOnce).to.be.true;
 });
 
+it('continues to dispatch "change" events upon selection after `value` is changed programmatically', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      open
+      multiple
+    >
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.value = ['one', 'two'];
+
+  setTimeout(() => {
+    component
+      .querySelector<GlideCoreDropdownOption>(
+        'glide-core-dropdown-option:last-of-type',
+      )
+      ?.click();
+  });
+
+  const event = await oneEvent(component, 'change');
+  expect(event instanceof Event).to.be.true;
+});
+
 it('dispatches one "input" event when `value` is changed programmatically', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown
@@ -148,6 +189,47 @@ it('dispatches one "input" event when `value` is changed programmatically', asyn
 
   await aTimeout(0);
   expect(spy.calledOnce).to.be.true;
+});
+
+it('continues to dispatch "input" events upon selection after `value` is changed programmatically', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      open
+      multiple
+    >
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.value = ['one', 'two'];
+
+  setTimeout(() => {
+    component
+      .querySelector<GlideCoreDropdownOption>(
+        'glide-core-dropdown-option:last-of-type',
+      )
+      ?.click();
+  });
+
+  const event = await oneEvent(component, 'input');
+  expect(event instanceof Event).to.be.true;
 });
 
 it('dispatches a "change" event when an option is selected after Select All is clicked', async () => {

--- a/packages/components/src/dropdown.test.events.single.ts
+++ b/packages/components/src/dropdown.test.events.single.ts
@@ -1,6 +1,6 @@
 import './dropdown.option.js';
 import * as sinon from 'sinon';
-import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import GlideCoreDropdown from './dropdown.js';
 
 GlideCoreDropdown.shadowRootOptions.mode = 'open';
@@ -32,6 +32,32 @@ it('dispatches one "change" event when `value` is changed programmatically', asy
   expect(spy.calledOnce).to.be.true;
 });
 
+it('continues to dispatch "change" events upon selection after `value` is changed programmatically', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.value = ['two'];
+
+  setTimeout(() => {
+    component.querySelector('glide-core-dropdown-option')?.click();
+  });
+
+  const event = await oneEvent(component, 'change');
+  expect(event instanceof Event).to.be.true;
+});
+
 it('dispatches one "input" event when `value` is changed programmatically', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
@@ -57,4 +83,30 @@ it('dispatches one "input" event when `value` is changed programmatically', asyn
 
   await aTimeout(0);
   expect(spy.calledOnce).to.be.true;
+});
+
+it('continues to dispatch "input" events upon selection after `value` is changed programmatically', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.value = ['two'];
+
+  setTimeout(() => {
+    component.querySelector('glide-core-dropdown-option')?.click();
+  });
+
+  const event = await oneEvent(component, 'input');
+  expect(event instanceof Event).to.be.true;
 });

--- a/packages/components/src/dropdown.ts
+++ b/packages/components/src/dropdown.ts
@@ -142,6 +142,8 @@ export default class GlideCoreDropdown extends LitElement {
       option.selected = value.some((value) => value && value === option.value);
     }
 
+    this.#isExternalSelectAllOrExternalValueChange = false;
+
     // These events are normally dispatched when an option is selected. However, the consumer
     // changing `value` programmatically can result in multiple selections and deselections, and
     // thus multiple events. `this.#isValueOrExternalSelectAllChange` is set above and used in


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to Dropdown in Storybook.
2. Change Dropdown's `value` programmatically: `$0.value = ['one']`.
3. Use DevTools to add a "change" listener to Dropdown:
    `$0.addEventListener('change', (event) => console.log('change'))`
4. Open Dropdown and click the second option.
5. Make sure "change" was logged.

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A
