### PR TITLE
Don't dispatch events when Dropdown's `value` changes

### DIFF
--- a/.changeset/tough-rice-remain.md
+++ b/.changeset/tough-rice-remain.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown's `readonly` attribute is reflected.

--- a/.changeset/warm-ladybugs-hammer.md
+++ b/.changeset/warm-ladybugs-hammer.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Dropdown doesn't dispatch events when `value` is changed programmatically.

--- a/src/dropdown.test.events.multiple.ts
+++ b/src/dropdown.test.events.multiple.ts
@@ -78,7 +78,7 @@ it('dispatches one "input" event when Select All is clicked', async () => {
   expect(spy.calledOnce).to.be.true;
 });
 
-it('dispatches one "change" event when `value` is changed programmatically', async () => {
+it('does not dispatch a "change" event when `value` is changed programmatically', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown
       label="Label"
@@ -112,7 +112,7 @@ it('dispatches one "change" event when `value` is changed programmatically', asy
   });
 
   await aTimeout(0);
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.called).to.be.false;
 });
 
 it('continues to dispatch "change" events upon selection after `value` is changed programmatically', async () => {
@@ -156,7 +156,7 @@ it('continues to dispatch "change" events upon selection after `value` is change
   expect(event instanceof Event).to.be.true;
 });
 
-it('dispatches one "input" event when `value` is changed programmatically', async () => {
+it('does not dispatch an "input" event when `value` is changed programmatically', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown
       label="Label"
@@ -190,7 +190,7 @@ it('dispatches one "input" event when `value` is changed programmatically', asyn
   });
 
   await aTimeout(0);
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.called).to.be.false;
 });
 
 it('continues to dispatch "input" events upon selection after `value` is changed programmatically', async () => {

--- a/src/dropdown.test.events.single.ts
+++ b/src/dropdown.test.events.single.ts
@@ -7,7 +7,7 @@ import GlideCoreDropdown from './dropdown.js';
 
 GlideCoreDropdown.shadowRootOptions.mode = 'open';
 
-it('dispatches one "change" event when `value` is changed programmatically', async () => {
+it('does not dispatch a "change" event when `value` is changed programmatically', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
       <glide-core-dropdown-option
@@ -31,7 +31,7 @@ it('dispatches one "change" event when `value` is changed programmatically', asy
   });
 
   await aTimeout(0);
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.called).to.be.false;
 });
 
 it('continues to dispatch "change" events upon selection after `value` is changed programmatically', async () => {
@@ -60,7 +60,7 @@ it('continues to dispatch "change" events upon selection after `value` is change
   expect(event instanceof Event).to.be.true;
 });
 
-it('dispatches one "input" event when `value` is changed programmatically', async () => {
+it('does not dispatch an "input" event when `value` is changed programmatically', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
       <glide-core-dropdown-option
@@ -84,7 +84,7 @@ it('dispatches one "input" event when `value` is changed programmatically', asyn
   });
 
   await aTimeout(0);
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.called).to.be.false;
 });
 
 it('continues to dispatch "input" events upon selection after `value` is changed programmatically', async () => {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Brings Dropdown in line with native and fixes a related bug for one of our consumers.

I have a followup PR on the way that does the same for when `selected` is changed programmatically. Though that one will take more time and doesn't appear to be blocking anyone at the moment.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to Dropdown in Storybook.
2. Use DevTools to add a "change" listener to Dropdown:
    `$0.addEventListener('change', (event) => console.log('change'))`
3. Change Dropdown's `value` programmatically: 
    `$0.value = ['one']`
4. Check that no event was dispatched. Rinse and repeat for "input" events.

## 📸 Images/Videos of Functionality

NA
