### PR TITLE
Adjust modal background color and set a max-width

### DIFF
--- a/.changeset/chilly-phones-tap.md
+++ b/.changeset/chilly-phones-tap.md
@@ -2,4 +2,5 @@
 '@crowdstrike/glide-core': patch
 ---
 
-Removed the opacity from the Modal background so that content no longer bleeds into it.
+- Removed the opacity from the Modal background so that content no longer bleeds into it.
+- Modal is now given a maximum width to prevent it from colliding with the horizontal edges of the browser window as the screen width adjusts.

--- a/src/modal.styles.ts
+++ b/src/modal.styles.ts
@@ -35,6 +35,7 @@ export default [
       font-family: var(--glide-core-body-xs-font-family);
       inline-size: 35rem;
       max-block-size: 75vh;
+      max-inline-size: 90vw;
       opacity: 0;
       padding: 1.25rem;
 


### PR DESCRIPTION
## 🚀 Description

- The background-color of Modal used to have an alpha and when paired with backdrop-filter made the background bleed through.  They no longer want this! So the CSS was updated to use the `surface/modal` color instead.
- It was requested that Modals shouldn't stretch edge-to-edge of the browser, but instead have a max-width, no matter the `size` variant


## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Visit https://glide-core.crowdstrike-ux.workers.dev/adjust-modal-background-color?path=/docs/modal--overview
- Verify the background no longer bleeds through
- Verify the larger modal sizes no longer touch the ends of the browser window
  - NOTE: There is a weird in-between state where it will temporarily touch at a certain breakpoint in the Overview storybook stories, but if you go to the full screen view like in a real app this won't happen

## 📸 Images/Videos of Functionality

| Before  | After | Notes |
| ------------- | ------------- | ------------- |
| <img width="1468" alt="Screenshot 2024-08-08 at 7 41 06 PM" src="https://github.com/user-attachments/assets/6e252463-21a2-436c-8f14-5345ef9a5114">  | <img width="1465" alt="Screenshot 2024-08-08 at 7 40 32 PM" src="https://github.com/user-attachments/assets/034a2a76-379f-4ddd-8f80-8bef747f9cd3">  | Light mode, it's hard to tell the difference |
| <img width="1465" alt="Screenshot 2024-08-08 at 7 41 36 PM" src="https://github.com/user-attachments/assets/e47e4802-bb54-4fa9-879a-2be7227f26d1">  | <img width="1467" alt="Screenshot 2024-08-08 at 7 41 52 PM" src="https://github.com/user-attachments/assets/fd182b5c-21dd-4802-a231-eafc4a1ec7e0">  | Dark mode you can see the changes a bit better  |
| <img width="1148" alt="Screenshot 2024-08-08 at 7 42 40 PM" src="https://github.com/user-attachments/assets/1587885f-e4c7-42ab-b807-8fda9cc5f9a9">  | <img width="1168" alt="Screenshot 2024-08-08 at 7 43 24 PM" src="https://github.com/user-attachments/assets/28a743e3-7aa2-4663-b90f-2c7b6923143e">  | Width capped at 90vw no matter the `size`. You can see in the before screenshot how it hugged the edges of the horizontal axis. No good!  |
