### PR TITLE
Use 80vw in Modal as suggested (after merge)

### DIFF
--- a/.changeset/early-balloons-repair.md
+++ b/.changeset/early-balloons-repair.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Decrease the max-width of Modal.

--- a/src/modal.styles.ts
+++ b/src/modal.styles.ts
@@ -35,7 +35,7 @@ export default [
       font-family: var(--glide-core-body-xs-font-family);
       inline-size: 35rem;
       max-block-size: 75vh;
-      max-inline-size: 90vw;
+      max-inline-size: 80vw;
       opacity: 0;
       padding: 1.25rem;
 


### PR DESCRIPTION
## 🚀 Description

Got more feedback from design that they wanted `80vw` instead.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test


## 📸 Images/Videos of Functionality


https://github.com/user-attachments/assets/d9ebcf22-84d4-4cb3-90b5-4cce3fd4c909

