### PR TITLE
Use `callCount` instead of `calledOnce` and `notCalled`

### DIFF
--- a/src/button-group.button.test.basics.ts
+++ b/src/button-group.button.test.basics.ts
@@ -151,5 +151,5 @@ it('throws when icon-only and no "prefix" slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });

--- a/src/button-group.test.events.ts
+++ b/src/button-group.test.events.ts
@@ -86,7 +86,7 @@ it('does not emit an "change" event when clicked button is clicked and already s
   });
 
   await aTimeout(0);
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not emit an "input" event when clicked button is clicked and already selected', async () => {
@@ -113,7 +113,7 @@ it('does not emit an "input" event when clicked button is clicked and already se
   });
 
   await aTimeout(0);
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('emits a "change" event when arrowing', async () => {
@@ -266,7 +266,7 @@ it('does not emit a "change" event when an already selected button is selected v
   component.addEventListener('change', spy);
 
   sendKeys({ press: 'Space' });
-  expect(spy.called).to.be.false;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not emit a "change" event a button is selected programmatically', async () => {
@@ -292,7 +292,7 @@ it('does not emit a "change" event a button is selected programmatically', async
     buttons[1].selected = true;
   });
 
-  expect(spy.called).to.be.false;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not emit a "input" event a button is selected programmatically', async () => {
@@ -318,5 +318,5 @@ it('does not emit a "input" event a button is selected programmatically', async 
     buttons[1].selected = true;
   });
 
-  expect(spy.called).to.be.false;
+  expect(spy.callCount).to.equal(0);
 });

--- a/src/button.test.basics.ts
+++ b/src/button.test.basics.ts
@@ -270,5 +270,5 @@ it('throws if it does not have a default slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });

--- a/src/checkbox-group.test.basics.ts
+++ b/src/checkbox-group.test.basics.ts
@@ -165,7 +165,7 @@ it('throws if it does not have a default slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('throws if the default slot is the incorrect type', async () => {

--- a/src/checkbox-group.test.events.ts
+++ b/src/checkbox-group.test.events.ts
@@ -123,7 +123,7 @@ it('does not dispatch an "invalid" event after `checkValidity` is called when no
   component.checkValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "invalid" event after `checkValidity` is called when disabled but required and the checkbox is unchecked', async () => {
@@ -142,7 +142,7 @@ it('does not dispatch an "invalid" event after `checkValidity` is called when di
   component.checkValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "invalid" event when `reportValidity` is called when not required,', async () => {
@@ -161,7 +161,7 @@ it('does not dispatch an "invalid" event when `reportValidity` is called when no
   component.reportValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "invalid" event when `reportValidity` is called when disabled but required and the checkbox is unchecked', async () => {
@@ -180,5 +180,5 @@ it('does not dispatch an "invalid" event when `reportValidity` is called when di
   component.reportValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });

--- a/src/checkbox.test.events.ts
+++ b/src/checkbox.test.events.ts
@@ -104,7 +104,7 @@ it('does not dispatch an "invalid" event after `checkValidity` is called when no
   component.checkValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "invalid" event after `checkValidity` is called when required and unchecked but disabled', async () => {
@@ -121,7 +121,7 @@ it('does not dispatch an "invalid" event after `checkValidity` is called when re
   component.checkValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "invalid" event when `reportValidity` is called when not required,', async () => {
@@ -138,7 +138,7 @@ it('does not dispatch an "invalid" event when `reportValidity` is called when no
   component.reportValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "invalid" event when `reportValidity` is called when required and unchecked but disabled', async () => {
@@ -155,5 +155,5 @@ it('does not dispatch an "invalid" event when `reportValidity` is called when re
   component.reportValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });

--- a/src/dropdown.test.basics.ts
+++ b/src/dropdown.test.basics.ts
@@ -326,5 +326,5 @@ it('does not throw if the default slot only contains whitespace', async () => {
     }
   }
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });

--- a/src/dropdown.test.events.filterable.ts
+++ b/src/dropdown.test.events.filterable.ts
@@ -78,5 +78,5 @@ it('does not dispatch "input" events on input', async () => {
   component.focus();
   await sendKeys({ type: ' one ' });
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });

--- a/src/dropdown.test.events.multiple.ts
+++ b/src/dropdown.test.events.multiple.ts
@@ -49,7 +49,7 @@ it('dispatches one "change" event when an option is selected via click', async (
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "change" event when an option is selected via Enter', async () => {
@@ -89,7 +89,7 @@ it('dispatches one "change" event when an option is selected via Enter', async (
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "change" event when an option is selected via Space', async () => {
@@ -129,7 +129,7 @@ it('dispatches one "change" event when an option is selected via Space', async (
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "input" event when an option is selected via click', async () => {
@@ -172,7 +172,7 @@ it('dispatches one "input" event when an option is selected via click', async ()
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "input" event when an option is selected via Enter', async () => {
@@ -212,7 +212,7 @@ it('dispatches one "input" event when an option is selected via Enter', async ()
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "input" event when an option is selected via Space', async () => {
@@ -252,7 +252,7 @@ it('dispatches one "input" event when an option is selected via Space', async ()
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "change" event when Select All is clicked', async () => {
@@ -287,7 +287,7 @@ it('dispatches one "change" event when Select All is clicked', async () => {
   });
 
   await aTimeout(0);
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "input" event when Select All is clicked', async () => {
@@ -322,7 +322,7 @@ it('dispatches one "input" event when Select All is clicked', async () => {
   });
 
   await aTimeout(0);
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('does not dispatch a "change" event when `value` is changed programmatically', async () => {
@@ -359,7 +359,7 @@ it('does not dispatch a "change" event when `value` is changed programmatically'
   });
 
   await aTimeout(0);
-  expect(spy.called).to.be.false;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('continues to dispatch "change" events upon selection after `value` is changed programmatically', async () => {
@@ -437,7 +437,7 @@ it('does not dispatch an "input" event when `value` is changed programmatically'
   });
 
   await aTimeout(0);
-  expect(spy.called).to.be.false;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('continues to dispatch "input" events upon selection after `value` is changed programmatically', async () => {
@@ -519,7 +519,7 @@ it('dispatches one "change" event when an option is selected after Select All is
   });
 
   await aTimeout(0);
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "input" event when an option is selected after Select All is clicked', async () => {
@@ -560,7 +560,7 @@ it('dispatches one "input" event when an option is selected after Select All is 
   });
 
   await aTimeout(0);
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "change" event when a tag is removed', async () => {
@@ -594,7 +594,7 @@ it('dispatches one "change" event when a tag is removed', async () => {
   component.addEventListener('change', spy);
 
   await aTimeout(0);
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "input" event when a tag is removed', async () => {
@@ -628,5 +628,5 @@ it('dispatches one "input" event when a tag is removed', async () => {
   component.addEventListener('input', spy);
 
   await aTimeout(0);
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });

--- a/src/dropdown.test.events.single.ts
+++ b/src/dropdown.test.events.single.ts
@@ -35,7 +35,7 @@ it('dispatches one "change" event when an option is selected via click', async (
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "change" event when an option is selected via Enter', async () => {
@@ -70,7 +70,7 @@ it('dispatches one "change" event when an option is selected via Enter', async (
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "change" event when an option is selected via Space', async () => {
@@ -105,7 +105,7 @@ it('dispatches one "change" event when an option is selected via Space', async (
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "input" event when an option is selected via click', async () => {
@@ -135,7 +135,7 @@ it('dispatches one "input" event when an option is selected via click', async ()
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "input" event when an option is selected via Enter', async () => {
@@ -170,7 +170,7 @@ it('dispatches one "input" event when an option is selected via Enter', async ()
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches one "input" event when an option is selected via Space', async () => {
@@ -205,7 +205,7 @@ it('dispatches one "input" event when an option is selected via Space', async ()
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
-  expect(spy.calledOnce).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('does not dispatch a "change" event when `value` is changed programmatically', async () => {
@@ -232,7 +232,7 @@ it('does not dispatch a "change" event when `value` is changed programmatically'
   });
 
   await aTimeout(0);
-  expect(spy.called).to.be.false;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('continues to dispatch "change" events upon selection after `value` is changed programmatically', async () => {
@@ -285,7 +285,7 @@ it('does not dispatch an "input" event when `value` is changed programmatically'
   });
 
   await aTimeout(0);
-  expect(spy.called).to.be.false;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch a "change" event when an already selected option is selected', async () => {
@@ -312,7 +312,7 @@ it('does not dispatch a "change" event when an already selected option is select
   });
 
   await aTimeout(0);
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "input" event when an already selected option is selected', async () => {
@@ -339,7 +339,7 @@ it('does not dispatch an "input" event when an already selected option is select
   });
 
   await aTimeout(0);
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('continues to dispatch "input" events upon selection after `value` is changed programmatically', async () => {

--- a/src/dropdown.test.events.ts
+++ b/src/dropdown.test.events.ts
@@ -96,7 +96,7 @@ it('does not dispatch an "invalid" event when `checkValidity` is called when not
   component.checkValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "invalid" event when `checkValidity` is called when required, disabled, and no option is selected', async () => {
@@ -122,7 +122,7 @@ it('does not dispatch an "invalid" event when `checkValidity` is called when req
   component.checkValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "invalid" event when `reportValidity` is called when not required,', async () => {
@@ -143,7 +143,7 @@ it('does not dispatch an "invalid" event when `reportValidity` is called when no
   component.reportValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "invalid" event when `reportValidity` is called when required, disabled, and no option is selected', async () => {
@@ -169,7 +169,7 @@ it('does not dispatch an "invalid" event when `reportValidity` is called when re
   component.reportValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch a "change" event when an option is selected programmatically', async () => {
@@ -198,7 +198,7 @@ it('does not dispatch a "change" event when an option is selected programmatical
   });
 
   await aTimeout(0);
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch a "input" event when an option is selected programmatically', async () => {
@@ -227,5 +227,5 @@ it('does not dispatch a "input" event when an option is selected programmaticall
   });
 
   await aTimeout(0);
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });

--- a/src/dropdown.test.interactions.single.ts
+++ b/src/dropdown.test.interactions.single.ts
@@ -356,7 +356,7 @@ it('throws when `value` is changed programmatically to include more than one val
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('updates `value` when an option `value` is changed programmatically', async () => {

--- a/src/form-controls-layout.test.basics.ts
+++ b/src/form-controls-layout.test.basics.ts
@@ -60,7 +60,7 @@ it('throws if it does not have a default slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('throws if its default slot is the incorrect type', async () => {

--- a/src/icon-button.test.basics.ts
+++ b/src/icon-button.test.basics.ts
@@ -163,5 +163,5 @@ it('throws if it does not have a default slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });

--- a/src/input.test.events.ts
+++ b/src/input.test.events.ts
@@ -108,7 +108,7 @@ it('does not dispatch an "invalid" event after `checkValidity` is called when no
   input.checkValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "invalid" event after `checkValidity` is called when required and no value but disabled', async () => {
@@ -125,7 +125,7 @@ it('does not dispatch an "invalid" event after `checkValidity` is called when re
   input.checkValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "invalid" event when `reportValidity` is called when not required,', async () => {
@@ -144,7 +144,7 @@ it('does not dispatch an "invalid" event when `reportValidity` is called when no
   input.reportValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an "invalid" event when `reportValidity` is called when required and no value but disabled', async () => {
@@ -161,5 +161,5 @@ it('does not dispatch an "invalid" event when `reportValidity` is called when re
   input.reportValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });

--- a/src/label.test.basics.ts
+++ b/src/label.test.basics.ts
@@ -166,7 +166,7 @@ it('throws if it does not have a default slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('throws if it does not have a "control" slot', async () => {
@@ -185,7 +185,7 @@ it('throws if it does not have a "control" slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 
   // It's not clear to me why the error logged by Ow shows up in the console
   // here and not in the above test or elsewhere. A bug in Web Test Runner?

--- a/src/library/expect-argument-error.ts
+++ b/src/library/expect-argument-error.ts
@@ -32,7 +32,7 @@ export default async function (callback: () => Promise<unknown>) {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 
   // eslint-disable-next-line unicorn/prefer-add-event-listener
   window.onerror = onerror;

--- a/src/menu.options.test.basics.ts
+++ b/src/menu.options.test.basics.ts
@@ -25,7 +25,7 @@ it('throws if it does not have a default slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('throws if the default slot is the incorrect type', async () => {
@@ -57,5 +57,5 @@ it('does not throw if the default slot only contains whitespace', async () => {
     }
   }
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });

--- a/src/menu.test.basics.ts
+++ b/src/menu.test.basics.ts
@@ -213,7 +213,7 @@ it('throws if it does not have a "target" slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('sets accessibility attributes', async () => {

--- a/src/modal.icon-button.test.basics.ts
+++ b/src/modal.icon-button.test.basics.ts
@@ -75,5 +75,5 @@ it('throws if it does not have a default slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });

--- a/src/modal.tertiary-icon.test.basics.ts
+++ b/src/modal.tertiary-icon.test.basics.ts
@@ -93,5 +93,5 @@ it('throws if it does not have a default slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });

--- a/src/modal.test.basics.ts
+++ b/src/modal.test.basics.ts
@@ -270,7 +270,7 @@ it('throws if it does not have a default slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('throws an error when the "primary" footer slot has the incorrect type', async () => {

--- a/src/modal.test.events.ts
+++ b/src/modal.test.events.ts
@@ -20,11 +20,11 @@ it('dispatches a "close" event when the modal is closed via the "close" method',
   element.addEventListener('close', spy);
   element.showModal();
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 
   element.close();
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches a "close" event when the modal is closed via the close button', async () => {
@@ -47,7 +47,7 @@ it('dispatches a "close" event when the modal is closed via the close button', a
 
   button?.click();
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('dispatches a "close" event when the modal is closed via the escape key', async () => {
@@ -64,7 +64,7 @@ it('dispatches a "close" event when the modal is closed via the escape key', asy
 
   await sendKeys({ press: 'Escape' });
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('does not dispatch a "close" event when the modal is open and non-escape keys are pressed', async () => {
@@ -83,11 +83,11 @@ it('does not dispatch a "close" event when the modal is open and non-escape keys
   // Tests only a couple keys.
   await sendKeys({ press: ' ' });
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 
   await sendKeys({ press: 'Enter' });
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('dispatches a "close" event when the modal is closed via "show-back-button"', async () => {
@@ -110,7 +110,7 @@ it('dispatches a "close" event when the modal is closed via "show-back-button"',
 
   button?.click();
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('does not emit a "close" event when clicking inside the dialog and the mouse is not positioned on a "close" button', async () => {
@@ -136,7 +136,7 @@ it('does not emit a "close" event when clicking inside the dialog and the mouse 
     position: [Math.ceil(left + 1), Math.ceil(top + 1)],
   });
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it(`does not emit a "close" event if a mousedown event's origin does not come from the dialog element`, async () => {
@@ -160,7 +160,7 @@ it(`does not emit a "close" event if a mousedown event's origin does not come fr
 
   button?.dispatchEvent(new Event('mousedown', { bubbles: true }));
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('emits a "close" event when clicking outside the dialog', async () => {
@@ -186,5 +186,5 @@ it('emits a "close" event when clicking outside the dialog', async () => {
     position: [Math.floor(left - 1), Math.floor(top - 1)],
   });
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });

--- a/src/split-link.test.interactions.ts
+++ b/src/split-link.test.interactions.ts
@@ -23,7 +23,7 @@ it('navigates when the spacebar is pressed', async () => {
 
   await sendKeys({ press: ' ' });
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 
   window.open = windowOpen;
 });

--- a/src/tab.group.test.interactions.ts
+++ b/src/tab.group.test.interactions.ts
@@ -413,7 +413,7 @@ it('scrolls using keyboard when there is overflow and only a few pixels of overf
 
   expect(tabGroup?.tabElements[3]).to.have.focus;
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 
   spy.resetHistory();
 
@@ -430,5 +430,5 @@ it('scrolls using keyboard when there is overflow and only a few pixels of overf
 
   expect(tabGroup?.tabElements[0]).to.have.focus;
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });

--- a/src/tag.test.basics.ts
+++ b/src/tag.test.basics.ts
@@ -127,7 +127,7 @@ it('throws an error when the default slot is empty', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('does not throw an error when the default slot is non-empty', async () => {
@@ -141,7 +141,7 @@ it('does not throw an error when the default slot is non-empty', async () => {
     }
   }
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('toggles the "activate" and "deactivate" clases when the button is clicked', async () => {

--- a/src/textarea.test.events.ts
+++ b/src/textarea.test.events.ts
@@ -93,7 +93,7 @@ it('does not dispatch an `invalid` event after `checkValidity` is called when no
   textarea.checkValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an `invalid` event after `checkValidity` is called when required, no value, and disabled', async () => {
@@ -109,7 +109,7 @@ it('does not dispatch an `invalid` event after `checkValidity` is called when re
   textarea.checkValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an `invalid` event when `reportValidity` is called when not required,', async () => {
@@ -125,7 +125,7 @@ it('does not dispatch an `invalid` event when `reportValidity` is called when no
   textarea.reportValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an `invalid` event when `reportValidity` is called when required, no value, and disabled', async () => {
@@ -141,7 +141,7 @@ it('does not dispatch an `invalid` event when `reportValidity` is called when re
   textarea.reportValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('dispatches an `invalid` event after `requestSubmit` is called when `maxlength` exceeded', async () => {
@@ -216,7 +216,7 @@ it('does not dispatch an `invalid` event after `checkValidity` is called when `m
   textarea.checkValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an `invalid` event after `checkValidity` is called when `maxlength` exceeded and disabled', async () => {
@@ -234,7 +234,7 @@ it('does not dispatch an `invalid` event after `checkValidity` is called when `m
   textarea.checkValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an `invalid` event when `reportValidity` is called and `maxlength` is not exceeded,', async () => {
@@ -252,7 +252,7 @@ it('does not dispatch an `invalid` event when `reportValidity` is called and `ma
   textarea.reportValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not dispatch an `invalid` event when `reportValidity` is called `maxlength` exceeded and disabled,', async () => {
@@ -270,5 +270,5 @@ it('does not dispatch an `invalid` event when `reportValidity` is called `maxlen
   textarea.reportValidity();
   await aTimeout(0);
 
-  expect(spy.notCalled).to.be.true;
+  expect(spy.callCount).to.equal(0);
 });

--- a/src/tooltip.test.basics.ts
+++ b/src/tooltip.test.basics.ts
@@ -72,7 +72,7 @@ it('throws if it does not have a default slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('throws if it does not have a "target" slot', async () => {
@@ -88,5 +88,5 @@ it('throws if it does not have a "target" slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });

--- a/src/tree.test.basics.ts
+++ b/src/tree.test.basics.ts
@@ -150,7 +150,7 @@ it('throws if it does not have a default slot', async () => {
     }
   }
 
-  expect(spy.called).to.be.true;
+  expect(spy.callCount).to.equal(1);
 });
 
 it('throws if the default slot is the incorrect type', async () => {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Good catch, @danwenzel. Also swapped out `spy.called` where possible.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A
