### PR TITLE
Register "glide-core-label" as "glide-core-private-label"

### DIFF
--- a/src/checkbox-group.styles.ts
+++ b/src/checkbox-group.styles.ts
@@ -10,7 +10,7 @@ export default [
       }
     }
 
-    glide-core-label::part(tooltips-and-label) {
+    glide-core-private-label::part(tooltips-and-label) {
       align-items: flex-start;
     }
 

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -178,7 +178,7 @@ export default class GlideCoreCheckboxGroup extends LitElement {
       data-test="component"
       ${ref(this.#componentElementRef)}
     >
-      <glide-core-label
+      <glide-core-private-label
         split=${ifDefined(this.privateSplit ?? undefined)}
         ?hide=${this.hideLabel}
         ?disabled=${this.disabled}
@@ -199,7 +199,7 @@ export default class GlideCoreCheckboxGroup extends LitElement {
         </div>
 
         <slot id="description" name="description" slot="description"></slot>
-      </glide-core-label>
+      </glide-core-private-label>
     </div>`;
   }
 

--- a/src/checkbox.test.focus.ts
+++ b/src/checkbox.test.focus.ts
@@ -89,6 +89,6 @@ it('blurs the input and reports validity if `blur` is called', async () => {
   expect(component.validity.valid).to.equal(false);
 
   expect(
-    component.shadowRoot?.querySelector('glide-core-label')?.error,
+    component.shadowRoot?.querySelector('glide-core-private-label')?.error,
   ).to.equal(true);
 });

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -192,7 +192,7 @@ export default class GlideCoreCheckbox extends LitElement {
           </label>
         `,
         () =>
-          html`<glide-core-label
+          html`<glide-core-private-label
             orientation=${this.orientation}
             split=${ifDefined(this.privateSplit ?? undefined)}
             ?disabled=${this.disabled}
@@ -257,7 +257,7 @@ export default class GlideCoreCheckbox extends LitElement {
             <div id="summary" slot="summary">${this.summary}</div>
 
             <slot id="description" name="description" slot="description"></slot>
-          </glide-core-label>`,
+          </glide-core-private-label>`,
       )}
     </div>`;
   }

--- a/src/dropdown.test.focus.ts
+++ b/src/dropdown.test.focus.ts
@@ -51,6 +51,6 @@ it('closes and reports validity when it loses focus', async () => {
   expect(component.validity.valid).to.equal(false);
 
   expect(
-    component.shadowRoot?.querySelector('glide-core-label')?.error,
+    component.shadowRoot?.querySelector('glide-core-private-label')?.error,
   ).to.equal(true);
 });

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -8,7 +8,6 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
-import { svg } from 'lit/static-html.js';
 import { when } from 'lit/directives/when.js';
 import GlideCoreDropdownOption from './dropdown.option.js';
 import GlideCoreTag from './tag.js';
@@ -329,7 +328,7 @@ export default class GlideCoreDropdown extends LitElement {
       })}
       @blur=${this.#onBlur}
     >
-      <glide-core-label
+      <glide-core-private-label
         split=${ifDefined(this.privateSplit ?? undefined)}
         orientation=${this.orientation}
         ?disabled=${this.disabled}
@@ -477,7 +476,7 @@ export default class GlideCoreDropdown extends LitElement {
                   </div>`;
                 },
                 () => {
-                  return svg`<svg
+                  return html`<svg
                     aria-label=${this.#localize.term('open')}
                     class=${classMap({
                       'caret-icon': true,
@@ -541,7 +540,7 @@ export default class GlideCoreDropdown extends LitElement {
         </div>
 
         <slot id="description" name="description" slot="description"></slot>
-      </glide-core-label>
+      </glide-core-private-label>
     </div>`;
   }
 

--- a/src/icons/checked.ts
+++ b/src/icons/checked.ts
@@ -1,6 +1,6 @@
-import { svg } from 'lit/static-html.js';
+import { html } from 'lit';
 
-export default svg`
+export default html`
   <svg
     fill="none"
     viewBox="0 0 24 24"

--- a/src/input.test.focus.ts
+++ b/src/input.test.focus.ts
@@ -50,9 +50,9 @@ it('blurs the input and reports validity if `blur` is called', async () => {
 
   expect(input.validity.valid).to.equal(false);
 
-  expect(input.shadowRoot?.querySelector('glide-core-label')?.error).to.equal(
-    true,
-  );
+  expect(
+    input.shadowRoot?.querySelector('glide-core-private-label')?.error,
+  ).to.equal(true);
 });
 
 it('focuses the input after `reportValidity` is called when required and no value', async () => {

--- a/src/input.ts
+++ b/src/input.ts
@@ -187,7 +187,7 @@ export default class GlideCoreInput extends LitElement {
 
   override render() {
     return html`
-      <glide-core-label
+      <glide-core-private-label
         class=${classMap({
           left: this.privateSplit === 'left',
           middle: this.privateSplit === 'middle',
@@ -352,7 +352,7 @@ export default class GlideCoreInput extends LitElement {
               `
             : nothing}
         </div>
-      </glide-core-label>
+      </glide-core-private-label>
     `;
   }
 

--- a/src/label.test.basics.ts
+++ b/src/label.test.basics.ts
@@ -8,17 +8,17 @@ import sinon from 'sinon';
 GlideCoreLabel.shadowRootOptions.mode = 'open';
 
 it('registers', async () => {
-  expect(window.customElements.get('glide-core-label')).to.equal(
+  expect(window.customElements.get('glide-core-private-label')).to.equal(
     GlideCoreLabel,
   );
 });
 
 it('has defaults', async () => {
   const component = await fixture<GlideCoreLabel>(
-    html`<glide-core-label>
+    html`<glide-core-private-label>
       <label for="input">Label</label>
       <input id="input" slot="control" />
-    </glide-core-label>`,
+    </glide-core-private-label>`,
   );
 
   expect(component.getAttribute('error')).to.equal(null);
@@ -36,12 +36,12 @@ it('has defaults', async () => {
 
 it('is accessible', async () => {
   const component = await fixture<GlideCoreLabel>(
-    html`<glide-core-label>
+    html`<glide-core-private-label>
       <label for="input">Label</label>
       <input id="input" slot="control" />
       <div slot="tooltip">Tooltip</div>
       <div slot="description">Description</div>
-    </glide-core-label>`,
+    </glide-core-private-label>`,
   );
 
   await expect(component).to.be.accessible();
@@ -49,10 +49,10 @@ it('is accessible', async () => {
 
 it('can have a label', async () => {
   const component = await fixture<GlideCoreLabel>(
-    html`<glide-core-label>
+    html`<glide-core-private-label>
       <label for="input">Label</label>
       <input id="input" slot="control" />
-    </glide-core-label>`,
+    </glide-core-private-label>`,
   );
 
   const assignedElements = component.shadowRoot
@@ -64,11 +64,11 @@ it('can have a label', async () => {
 
 it('can have a description', async () => {
   const component = await fixture<GlideCoreLabel>(
-    html`<glide-core-label>
+    html`<glide-core-private-label>
       <label for="input">Label</label>
       <input id="input" slot="control" />
       <div slot="description">Description</div>
-    </glide-core-label>`,
+    </glide-core-private-label>`,
   );
 
   const assignedElements = component.shadowRoot
@@ -80,11 +80,11 @@ it('can have a description', async () => {
 
 it('can have a tooltip', async () => {
   const component = await fixture<GlideCoreLabel>(
-    html`<glide-core-label>
+    html`<glide-core-private-label>
       <label for="input">Label</label>
       <input id="input" slot="control" />
       <div slot="tooltip">Tooltip</div>
-    </glide-core-label>`,
+    </glide-core-private-label>`,
   );
 
   const assignedElements = component.shadowRoot
@@ -96,10 +96,10 @@ it('can have a tooltip', async () => {
 
 it('can be required', async () => {
   const component = await fixture<GlideCoreLabel>(
-    html`<glide-core-label required>
+    html`<glide-core-private-label required>
       <label for="input">Label</label>
       <input id="input" slot="control" />
-    </glide-core-label>`,
+    </glide-core-private-label>`,
   );
 
   expect(component.hasAttribute('required')).to.be.true;
@@ -111,10 +111,10 @@ it('can be required', async () => {
 
 it('can have an `error`', async () => {
   const component = await fixture<GlideCoreLabel>(
-    html`<glide-core-label ?error=${true}>
+    html`<glide-core-private-label ?error=${true}>
       <label for="input">Label</label>
       <input id="input" slot="control" />
-    </glide-core-label>`,
+    </glide-core-private-label>`,
   );
 
   expect(component.hasAttribute('error')).to.be.true;
@@ -123,11 +123,11 @@ it('can have an `error`', async () => {
 
 it('places the tooltip on the bottom when horizontal', async () => {
   const component = await fixture<GlideCoreLabel>(
-    html`<glide-core-label>
+    html`<glide-core-private-label>
       <label for="input">Label</label>
       <input id="input" slot="control" />
       <div slot="tooltip">Tooltip</div>
-    </glide-core-label>`,
+    </glide-core-private-label>`,
   );
 
   expect(
@@ -139,11 +139,11 @@ it('places the tooltip on the bottom when horizontal', async () => {
 
 it('places the tooltip on the right when vertical', async () => {
   const component = await fixture<GlideCoreLabel>(
-    html`<glide-core-label orientation="vertical">
+    html`<glide-core-private-label orientation="vertical">
       <label for="input">Label</label>
       <input id="input" slot="control" />
       <div slot="tooltip">Tooltip</div>
-    </glide-core-label>`,
+    </glide-core-private-label>`,
   );
 
   expect(
@@ -158,7 +158,9 @@ it('throws if it does not have a default slot', async () => {
 
   try {
     await fixture(
-      html`<glide-core-label><input slot="control" /></glide-core-label>`,
+      html`<glide-core-private-label
+        ><input slot="control"
+      /></glide-core-private-label>`,
     );
   } catch (error) {
     if (error instanceof ArgumentError) {
@@ -175,9 +177,9 @@ it('throws if it does not have a "control" slot', async () => {
 
   try {
     await fixture(
-      html`<glide-core-label>
+      html`<glide-core-private-label>
         <label>Label</label>
-      </glide-core-label>`,
+      </glide-core-private-label>`,
     );
   } catch (error) {
     if (error instanceof ArgumentError) {

--- a/src/label.ts
+++ b/src/label.ts
@@ -30,7 +30,7 @@ const infoCircleIcon = svg`
 
 declare global {
   interface HTMLElementTagNameMap {
-    'glide-core-label': GlideCoreLabel;
+    'glide-core-private-label': GlideCoreLabel;
   }
 }
 
@@ -45,7 +45,7 @@ declare global {
  * @slot description - Additional information or context.
  * @slot tooltip - Content for the tooltip.
  */
-@customElement('glide-core-label')
+@customElement('glide-core-private-label')
 export default class GlideCoreLabel extends LitElement {
   static override shadowRootOptions: ShadowRootInit = {
     ...LitElement.shadowRootOptions,

--- a/src/radio-group.styles.ts
+++ b/src/radio-group.styles.ts
@@ -33,7 +33,7 @@ export default [
       }
     }
 
-    glide-core-label::part(tooltips-and-label) {
+    glide-core-private-label::part(tooltips-and-label) {
       align-items: flex-start;
     }
   `,

--- a/src/radio-group.test.focus.ts
+++ b/src/radio-group.test.focus.ts
@@ -146,7 +146,7 @@ it('reports validity if blurred', async () => {
 
   expect(
     component.shadowRoot
-      ?.querySelector('glide-core-label')
+      ?.querySelector('glide-core-private-label')
       ?.hasAttribute('error'),
   ).to.be.false;
 
@@ -158,7 +158,7 @@ it('reports validity if blurred', async () => {
 
   expect(
     component.shadowRoot
-      ?.querySelector('glide-core-label')
+      ?.querySelector('glide-core-private-label')
       ?.hasAttribute('error'),
   ).to.be.true;
 });

--- a/src/radio-group.ts
+++ b/src/radio-group.ts
@@ -135,7 +135,7 @@ export default class GlideCoreRadioGroup extends LitElement {
         @keydown=${this.#onKeydown}
         ${ref(this.#componentElementRef)}
       >
-        <glide-core-label
+        <glide-core-private-label
           orientation="horizontal"
           split=${ifDefined(this.privateSplit ?? undefined)}
           ?disabled=${this.disabled}
@@ -164,7 +164,7 @@ export default class GlideCoreRadioGroup extends LitElement {
 
           <slot name="tooltip" slot="tooltip"></slot>
           <slot id="description" name="description" slot="description"></slot>
-        </glide-core-label>
+        </glide-core-private-label>
       </div>
     `;
   }

--- a/src/textarea.styles.ts
+++ b/src/textarea.styles.ts
@@ -1,7 +1,7 @@
 import { css } from 'lit';
 
 export default css`
-  glide-core-label::part(tooltips-and-label) {
+  glide-core-private-label::part(tooltips-and-label) {
     align-items: flex-start;
     margin-block-start: var(--glide-core-spacing-sm);
   }

--- a/src/textarea.test.validity.ts
+++ b/src/textarea.test.validity.ts
@@ -125,6 +125,6 @@ it('blurs the textarea and reports validity if `blur` is called', async () => {
 
   expect(textarea.validity.valid).to.equal(false);
 
-  expect(textarea.shadowRoot?.querySelector('glide-core-label')?.error).to.be
-    .true;
+  expect(textarea.shadowRoot?.querySelector('glide-core-private-label')?.error)
+    .to.be.true;
 });

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -129,7 +129,7 @@ export default class GlideCoreTextarea extends LitElement {
   }
 
   override render() {
-    return html`<glide-core-label
+    return html`<glide-core-private-label
       split=${ifDefined(this.privateSplit ?? undefined)}
       orientation=${this.orientation}
       ?disabled=${this.disabled}
@@ -186,7 +186,7 @@ export default class GlideCoreTextarea extends LitElement {
               ${this.value.length}/${this.maxlength}
             </div>`,
         )}
-      </div></glide-core-label
+      </div></glide-core-private-label
     >`;
   }
 

--- a/src/toggle.ts
+++ b/src/toggle.ts
@@ -63,7 +63,7 @@ export default class GlideCoreToggle extends LitElement {
 
   override render() {
     return html`<div data-test="component">
-      <glide-core-label
+      <glide-core-private-label
         orientation=${this.orientation}
         split=${ifDefined(this.privateSplit ?? undefined)}
         ?disabled=${this.disabled}
@@ -120,7 +120,7 @@ export default class GlideCoreToggle extends LitElement {
           name="description"
           slot="description"
         ></slot>
-      </glide-core-label>
+      </glide-core-private-label>
     </div>`;
   }
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Glide Core Label [can't](https://github.com/CrowdStrike/glide-core/blob/main/package.json#L29) be imported. But it is registered globally.

Registering it "glide-core-private-label" instead won't stop anyone from using it—much like our other "private" prefixes won't. But it'll send a clear message that it may change or become unavailable without notice should someone use it.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A