### PR TITLE
Add popover attribute to Toasts

### DIFF
--- a/.changeset/fresh-tools-cry.md
+++ b/.changeset/fresh-tools-cry.md
@@ -1,0 +1,10 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Add popover attribute to Toasts
+
+Ensures that toasts will appear at the top layer,
+avoiding the need to play z-index wars with other elements
+
+Also, toasts now get picked up by screenreaders properly

--- a/src/toasts.styles.ts
+++ b/src/toasts.styles.ts
@@ -3,17 +3,24 @@ import { css } from 'lit';
 export default [
   css`
     .component {
-      display: flex;
+      background-color: transparent;
+      border: none;
+      display: none;
       flex-direction: column;
       gap: var(--glide-core-spacing-md);
       inline-size: 24.25rem;
       inset-block-start: 0;
       inset-inline-end: 0;
+      margin: 0 0 auto auto;
       max-block-size: 100%;
       max-inline-size: 100%;
       overflow: hidden;
       padding: var(--glide-core-spacing-sm);
       position: fixed;
+
+      &:popover-open {
+        display: flex;
+      }
     }
   `,
 ];

--- a/src/toasts.test.basics.ts
+++ b/src/toasts.test.basics.ts
@@ -134,3 +134,32 @@ it('removes a closed toast from the DOM', async () => {
 
   expect(toasts?.length).to.equal(0);
 });
+
+it('is hidden unless there are toasts displayed', async () => {
+  const component = await fixture<GlideCoreToasts>(
+    html`<glide-core-toasts></glide-core-toasts>`,
+  );
+
+  const shadowComponent = component.shadowRoot?.querySelector('.component');
+  assert(shadowComponent);
+
+  expect(shadowComponent.hasAttribute('popover')).to.equal(false);
+  expect(getComputedStyle(shadowComponent).display).to.equal('none');
+
+  component.add({
+    label: 'Test toast',
+    description: 'Test toast description',
+    variant: 'informational',
+  });
+
+  expect(shadowComponent.getAttribute('popover')).to.equal('manual');
+  expect(getComputedStyle(shadowComponent).display).to.equal('flex');
+
+  const toasts = component.shadowRoot?.querySelectorAll('glide-core-toast');
+  assert(toasts);
+  const toast = toasts[0];
+  toast.close();
+  toast.dispatchEvent(new Event('close', { bubbles: true }));
+
+  expect(getComputedStyle(shadowComponent).display).to.equal('none');
+});

--- a/src/toasts.ts
+++ b/src/toasts.ts
@@ -33,6 +33,9 @@ export default class GlideCoreToasts extends LitElement {
   static override styles = styles;
 
   add(toast: Toast) {
+    ow(this.#componentElementRef.value, ow.object.instanceOf(Element));
+    this.#componentElementRef.value.popover = 'manual';
+    this.#componentElementRef.value.showPopover();
     const { variant, label, description, duration } = toast;
 
     const toastElement = Object.assign(
@@ -45,13 +48,19 @@ export default class GlideCoreToasts extends LitElement {
       },
     );
 
-    ow(this.#componentElementRef.value, ow.object.instanceOf(Element));
     this.#componentElementRef.value.append(toastElement);
 
     toastElement.addEventListener(
       'close',
       () => {
         toastElement.remove();
+
+        if (
+          this.#componentElementRef.value?.querySelectorAll('glide-core-toast')
+            .length === 0
+        ) {
+          this.#componentElementRef.value?.hidePopover();
+        }
       },
       { once: true },
     );


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Ensures that toasts will appear at the top layer,
avoiding the need to play z-index wars with other elements

### Before

![image](https://github.com/user-attachments/assets/9ac9a3e7-d9ed-4591-9976-bafa5731d785)

### After

![image](https://github.com/user-attachments/assets/4504f4d6-e8b5-401d-b8d0-d1fbfa4a704d)
## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

Go to [Toasts](https://glide-core.crowdstrike-ux.workers.dev/toasts-popover?path=/docs/toasts--overview), and confirm they look correct. 

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
