### PR TITLE
Add a progressive enhancement to Textarea to grow in height

### DIFF
--- a/.changeset/forty-meals-taste.md
+++ b/.changeset/forty-meals-taste.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Textarea now has a progressive enhancement where it'll grow in height as needed up to a maximum of 5 lines in browsers that support [`field-sizing`](https://caniuse.com/mdn-css_properties_field-sizing).

--- a/src/textarea.styles.ts
+++ b/src/textarea.styles.ts
@@ -1,5 +1,20 @@
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
 import visuallyHidden from './styles/visually-hidden.js';
+
+/**
+ * `field-sizing` is only supported in Chrome and Edge
+ * at the moment (https://caniuse.com/mdn-css_properties_field-sizing),
+ * making this a progressive enhancement. This functionality is additive,
+ * rather than required for use with our components.
+ *
+ * `field-sizing` is also not recognized by lit-plugin, so we are seeing
+ * https://github.com/runem/lit-analyzer/issues/157 when
+ * attempting to use it directly in our CSS below. This use of unsafeCSS
+ * is a workaround for that bug for the time being.
+ */
+const fieldSizingContent = unsafeCSS(`
+  field-sizing: content;
+`);
 
 export default css`
   glide-core-private-label::part(tooltips-and-label) {
@@ -23,10 +38,13 @@ export default css`
     font-family: var(--glide-core-body-xs-font-family);
     font-size: var(--glide-core-body-sm-font-size);
     font-weight: var(--glide-core-body-xs-font-weight);
-    min-block-size: 1.1875rem;
+    max-block-size: 5lh;
+    min-block-size: 3lh;
     padding: var(--glide-core-spacing-xs) var(--glide-core-spacing-sm);
     resize: vertical;
     transition: border-color 200ms ease-in-out;
+
+    ${fieldSizingContent};
 
     &:hover {
       border-color: var(--glide-core-border-base);


### PR DESCRIPTION
## 🚀 Description

Allow the Textarea element to grow in size up to 5 line heights.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Go to https://glide-core.crowdstrike-ux.workers.dev/add-autogrow-to-textarea?path=/docs/textarea--overview using Google Chrome
- Write/Expand text up to 5 lines, verifying the height of the Textarea grows
- The 6th line should no longer grow but scroll instead
- Delete all of the lines but 3 - the Textarea should have a min-height of 3 line height

- Go to https://glide-core.crowdstrike-ux.workers.dev/add-autogrow-to-textarea?path=/docs/textarea--overview using Safari and Firefox
- The growing feature does not work, but the user can resize the Textarea with the drag handler as usual

## 📸 Images/Videos of Functionality

**In Chrome**

This is the expected behavior. Notice how it grows from 3 lines to 5 before scrolling. Anything past 5, it retains scrolling. As lines are deleted, it'll shrink to remain between 3-5 lines.

https://github.com/user-attachments/assets/b037da17-9993-46e5-bf9d-ec873a65fe76

**In Safari**

This is the expected behavior. No growing, no shrinking, only scrolling and a max/min height when dragged to resize.

https://github.com/user-attachments/assets/1c1f4a4c-626c-412d-9dcc-2392d992d83f

**In Firefox**

This is the expected behavior. No growing, no shrinking, only scrolling and a max/min height when dragged to resize.

https://github.com/user-attachments/assets/23b04b39-82c9-4dae-a4ca-4572cec77b07



