### PR TITLE
Fix multiselect Dropdown layout bug

### DIFF
--- a/.changeset/spicy-rats-press.md
+++ b/.changeset/spicy-rats-press.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown's input field now expands to fill the available space.

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -266,7 +266,7 @@ const meta: Meta = {
   },
   render(arguments_) {
     /* eslint-disable unicorn/explicit-length-check */
-    return html`<form style="display: block; height: 12rem;">
+    return html`<form style="display: block; height: 12rem; width: 20rem;">
       <glide-core-dropdown
         label=${arguments_.label || nothing}
         name=${arguments_.name || nothing}
@@ -332,7 +332,7 @@ export const SingleSelectionHorizontalWithIcon: StoryObj = {
   },
   render(arguments_) {
     /* eslint-disable unicorn/explicit-length-check */
-    return html`<form style="display: block; height: 12rem;">
+    return html`<form style="display: block; height: 12rem; width: 20rem;">
       <glide-core-dropdown
         label=${arguments_.label || nothing}
         name=${arguments_.name || nothing}
@@ -413,7 +413,7 @@ export const SingleSelectionVerticalWithIcon: StoryObj = {
   name: 'Single Selection (Vertical With Icon)',
   render(arguments_) {
     /* eslint-disable unicorn/explicit-length-check */
-    return html`<form style="display: block; height: 12rem;">
+    return html`<form style="display: block; height: 12rem; width: 20rem;">
       <glide-core-dropdown
         label=${arguments_.label || nothing}
         name=${arguments_.name || nothing}
@@ -491,7 +491,7 @@ export const SingleSelectionHorizontalWithFiltering: StoryObj = {
   name: 'Single Selection (Horizontal With Filtering)',
   render(arguments_) {
     /* eslint-disable unicorn/explicit-length-check */
-    return html`<form style="display: block; height: 12rem;">
+    return html`<form style="display: block; height: 12rem; width: 20rem;">
       <glide-core-dropdown
         label=${arguments_.label || nothing}
         name=${arguments_.name || nothing}
@@ -589,7 +589,7 @@ export const MultipleSelectionHorizontalWithFiltering: StoryObj = {
   name: 'Multiple Selection (Horizontal With Filtering)',
   render(arguments_) {
     /* eslint-disable unicorn/explicit-length-check */
-    return html`<form style="display: block; height: 12rem;">
+    return html`<form style="display: block; height: 12rem; width: 20rem;">
       <glide-core-dropdown
         label=${arguments_.label || nothing}
         name=${arguments_.name || nothing}

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -36,7 +36,6 @@ export default [
       font-style: var(--glide-core-body-sm-font-style);
       font-weight: var(--glide-core-body-sm-font-weight);
       gap: var(--glide-core-spacing-xs);
-      justify-content: space-between;
       min-inline-size: var(--min-inline-size);
       padding-inline: var(--glide-core-spacing-sm);
       text-align: start;
@@ -135,9 +134,14 @@ export default [
       }
     }
 
+    .tag-overflow-text-and-button {
+      column-gap: var(--glide-core-spacing-md);
+      display: flex;
+      margin-inline-start: auto;
+    }
+
     .tag-overflow-text {
       color: var(--glide-core-text-link);
-      margin-inline-end: var(--glide-core-spacing-md);
     }
 
     .button {
@@ -159,6 +163,7 @@ export default [
       block-size: var(--button-and-input-height);
       border: none;
       cursor: inherit;
+      flex-grow: 1;
       font-size: inherit;
       min-inline-size: var(--min-inline-size);
       padding: 0;

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -487,66 +487,72 @@ export default class GlideCoreDropdown extends LitElement {
                 ${this.internalLabel}
               </div>`;
             })}
-            ${when(this.selectedOptions.length > this.#tagOverflowLimit, () => {
-              return html`<div
-                aria-hidden="true"
-                class="tag-overflow-text"
-                id="tag-overflow-text"
-                data-test="tag-overflow-text"
-              >
-                +
-                <span data-test="tag-overflow-count">
-                  ${this.selectedOptions.length - this.#tagOverflowLimit}
-                </span>
-                more
-              </div>`;
-            })}
 
-            <button
-              aria-hidden=${this.isFilterable}
-              aria-expanded=${this.open}
-              aria-haspopup="listbox"
-              aria-labelledby="selected-option-labels label"
-              aria-describedby="description"
-              aria-controls="options"
-              class="button"
-              data-test="button"
-              id="button"
-              tabindex=${this.isFilterable || this.disabled ? '-1' : '0'}
-              type="button"
-              ${ref(this.#buttonElementRef)}
-            >
+            <div class="tag-overflow-text-and-button">
               ${when(
-                this.isFiltering,
+                this.selectedOptions.length > this.#tagOverflowLimit,
                 () => {
-                  return html`<div data-test="magnifying-glass-icon">
-                    ${magnifyingGlassIcon}
+                  return html`<div
+                    aria-hidden="true"
+                    class="tag-overflow-text"
+                    id="tag-overflow-text"
+                    data-test="tag-overflow-text"
+                  >
+                    +
+                    <span data-test="tag-overflow-count">
+                      ${this.selectedOptions.length - this.#tagOverflowLimit}
+                    </span>
+                    more
                   </div>`;
                 },
-                () => {
-                  return html`<svg
-                    aria-label=${this.#localize.term('open')}
-                    class=${classMap({
-                      'caret-icon': true,
-                      disabled: this.disabled,
-                      readonly: this.readonly,
-                    })}
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                  >
-                    <path
-                      d="M6 9L12 15L18 9"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>`;
-                },
               )}
-            </button>
+
+              <button
+                aria-hidden=${this.isFilterable}
+                aria-expanded=${this.open}
+                aria-haspopup="listbox"
+                aria-labelledby="selected-option-labels label"
+                aria-describedby="description"
+                aria-controls="options"
+                class="button"
+                data-test="button"
+                id="button"
+                tabindex=${this.isFilterable || this.disabled ? '-1' : '0'}
+                type="button"
+                ${ref(this.#buttonElementRef)}
+              >
+                ${when(
+                  this.isFiltering,
+                  () => {
+                    return html`<div data-test="magnifying-glass-icon">
+                      ${magnifyingGlassIcon}
+                    </div>`;
+                  },
+                  () => {
+                    return html`<svg
+                      aria-label=${this.#localize.term('open')}
+                      class=${classMap({
+                        'caret-icon': true,
+                        disabled: this.disabled,
+                        readonly: this.readonly,
+                      })}
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                    >
+                      <path
+                        d="M6 9L12 15L18 9"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>`;
+                  },
+                )}
+              </button>
+            </div>
           </div>
 
           <div

--- a/src/label.styles.ts
+++ b/src/label.styles.ts
@@ -35,8 +35,15 @@ export default [
       column-gap: var(--glide-core-spacing-xs);
       display: flex;
 
-      /* Prevent it from growing larger than its column percentage when a child of Form Controls Layout. */
-      min-inline-size: 0;
+      /* 
+        Prevents it from growing larger than its column percentage when a child of Form Controls 
+        Layout. Also allows for an ellipsis on the label. See the linked comment for why it's "3ch" 
+        instead of "0".
+
+        - https://css-tricks.com/flexbox-truncated-text/#aa-the-solution-is-min-width-0-on-the-flex-child
+        - https://github.com/CrowdStrike/glide-core/pull/317#issuecomment-2297025365 
+      */
+      min-inline-size: 3ch;
 
       &.middle,
       &.left {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

@ynotdraw and I caught this while testing the release. 

"+2 more" is in the middle of Dropdown when Dropdown is past a certain width. It's apparently a long-standing bug that was revealed by the story styling [change](https://github.com/CrowdStrike/glide-core/pull/316/files#diff-d657fb324b7fa1e40672fe03e99fc8e7d0a14a9bdfe1a48906b0f5903aee7973) I just made. Dropdown's `<input>` also wasn't expand to fill available space.

I [added](https://github.com/CrowdStrike/glide-core/pull/317/files#diff-d657fb324b7fa1e40672fe03e99fc8e7d0a14a9bdfe1a48906b0f5903aee7973R269)  `width` to the `<form>` so the overview story looks a little cleaner.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to the Dropdown story.
2. Remove the `width` from `<form>` so Dropdown expands.
3. Make sure the text overflow label ("+2 more") and the caret are right aligned—and that the `<input>` fills the remaining space.

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

## Before

<img width="1618" alt="image" src="https://github.com/user-attachments/assets/34961e32-c8e0-498a-a249-ce596e3fee01">

## After

<img width="554" alt="image" src="https://github.com/user-attachments/assets/c4e30781-53d4-42f7-b4af-2d8175762866">


<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
