### PR TITLE
Button Group Button's background shouldn't be transparent

### DIFF
--- a/.changeset/cool-pigs-return.md
+++ b/.changeset/cool-pigs-return.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Updated Button Group Button's background color to no longer be transparent so that the background won't bleed through the component.

--- a/src/button-group.button.styles.ts
+++ b/src/button-group.button.styles.ts
@@ -35,6 +35,7 @@ export default [
     .component {
       align-items: center;
       appearance: none;
+      background-color: var(--glide-core-surface-page);
       cursor: pointer;
       display: flex;
       font-family: var(--glide-core-font-sans);


### PR DESCRIPTION
## 🚀 Description

Button Group Button's background is transparent, so content can bleed into it.  Looking at the designs, the background color is set to `surface/page`.  This PR updates that.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Go to https://glide-core.crowdstrike-ux.workers.dev/fix-button-group-background?path=/docs/button-group--overview
- Set the background-color behind the Button Group to something
- Verify the background-color of each Button Group Button sticks, rather than the background bleeding through

## 📸 Images/Videos of Functionality

| Before  | After |
| ------------- | ------------- |
| <img width="849" alt="Screenshot 2024-08-22 at 9 56 26 AM" src="https://github.com/user-attachments/assets/2fd50173-d7a3-44b9-b02f-8542682ad1ab">  | <img width="849" alt="Screenshot 2024-08-22 at 9 56 58 AM" src="https://github.com/user-attachments/assets/5b6e0fb6-d299-46aa-adc5-5115948dcfef">  |




