### PR TITLE
Allow Checkbox and Toggle to be forced checked or unchecked

### DIFF
--- a/.changeset/moody-bees-itch.md
+++ b/.changeset/moody-bees-itch.md
@@ -1,0 +1,18 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Checkbox and Toggle can now be forced checked or unchecked.
+
+To do this, add a "change" or "input" listener that sets `checked` to the
+desired state after waiting for the component to update so your `checked`
+change isn't reverted after the update completes:
+
+```ts
+document
+  .querySelector('glide-core-toggle')
+  .addEventListener('change', async (event) => {
+    await event.target.updateComplete;
+    event.target.checked = false;
+  });
+```

--- a/src/checkbox.test.basics.ts
+++ b/src/checkbox.test.basics.ts
@@ -83,7 +83,10 @@ it('can have a description', async () => {
 
 it('can have a name', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox name="name"></glide-core-checkbox> `,
+    html`<glide-core-checkbox
+      label="Label"
+      name="name"
+    ></glide-core-checkbox> `,
   );
 
   expect(component.getAttribute('name')).to.equal('name');
@@ -92,7 +95,10 @@ it('can have a name', async () => {
 
 it('can have a summary', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox summary="Summary"></glide-core-checkbox> `,
+    html`<glide-core-checkbox
+      label="Label"
+      summary="Summary"
+    ></glide-core-checkbox> `,
   );
 
   expect(component.getAttribute('summary')).to.equal('Summary');
@@ -115,7 +121,7 @@ it('can have a tooltip', async () => {
 
 it('can be checked', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox checked></glide-core-checkbox> `,
+    html`<glide-core-checkbox label="Label" checked></glide-core-checkbox> `,
   );
 
   expect(component.hasAttribute('checked')).to.be.true;
@@ -124,7 +130,7 @@ it('can be checked', async () => {
 
 it('can be disabled', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox disabled></glide-core-checkbox> `,
+    html`<glide-core-checkbox label="Label" disabled></glide-core-checkbox> `,
   );
 
   expect(component.hasAttribute('disabled')).to.be.true;
@@ -133,7 +139,10 @@ it('can be disabled', async () => {
 
 it('can be indeterminate', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox indeterminate></glide-core-checkbox> `,
+    html`<glide-core-checkbox
+      label="Label"
+      indeterminate
+    ></glide-core-checkbox> `,
   );
 
   expect(component.hasAttribute('indeterminate')).to.be.true;
@@ -142,7 +151,7 @@ it('can be indeterminate', async () => {
 
 it('can be required', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox required></glide-core-checkbox> `,
+    html`<glide-core-checkbox label="Label" required></glide-core-checkbox> `,
   );
 
   expect(component.hasAttribute('required')).to.be.true;

--- a/src/checkbox.test.events.ts
+++ b/src/checkbox.test.events.ts
@@ -52,7 +52,7 @@ it('dispatches an "invalid" event on submit when required and unchecked', async 
   const form = document.createElement('form');
 
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox required></glide-core-checkbox>`,
+    html`<glide-core-checkbox label="Label" required></glide-core-checkbox>`,
     { parentNode: form },
   );
 
@@ -80,7 +80,7 @@ it('dispatches an "invalid" event after `reportValidity` is called when required
   const form = document.createElement('form');
 
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox required></glide-core-checkbox>`,
+    html`<glide-core-checkbox label="Label" required></glide-core-checkbox>`,
     { parentNode: form },
   );
 
@@ -111,7 +111,11 @@ it('does not dispatch an "invalid" event after `checkValidity` is called when re
   const form = document.createElement('form');
 
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox disabled required></glide-core-checkbox>`,
+    html`<glide-core-checkbox
+      label="Label"
+      disabled
+      required
+    ></glide-core-checkbox>`,
     { parentNode: form },
   );
 
@@ -145,7 +149,11 @@ it('does not dispatch an "invalid" event when `reportValidity` is called when re
   const form = document.createElement('form');
 
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox disabled required></glide-core-checkbox>`,
+    html`<glide-core-checkbox
+      label="Label"
+      disabled
+      required
+    ></glide-core-checkbox>`,
     { parentNode: form },
   );
 

--- a/src/checkbox.test.focus.ts
+++ b/src/checkbox.test.focus.ts
@@ -73,7 +73,7 @@ it('does not focus the input after `checkValidity` is called', async () => {
 
 it('blurs the input and reports validity if `blur` is called', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox required></glide-core-checkbox>`,
+    html`<glide-core-checkbox label="Label" required></glide-core-checkbox>`,
   );
 
   component.focus();

--- a/src/checkbox.test.form.ts
+++ b/src/checkbox.test.form.ts
@@ -66,6 +66,7 @@ it('has `formData` value when checked and indeterminate', async () => {
 
   await fixture<GlideCoreCheckbox>(
     html`<glide-core-checkbox
+      label="Label"
       name="name"
       value="value"
       checked

--- a/src/checkbox.test.interactions.ts
+++ b/src/checkbox.test.interactions.ts
@@ -13,7 +13,7 @@ GlideCoreCheckbox.shadowRootOptions.mode = 'open';
 
 it('is checked after being clicked', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox></glide-core-checkbox>`,
+    html`<glide-core-checkbox label="Label"></glide-core-checkbox>`,
   );
 
   component.click();
@@ -25,7 +25,7 @@ it('is checked after being clicked', async () => {
 
 it('is unchecked after being clicked', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox checked></glide-core-checkbox>`,
+    html`<glide-core-checkbox label="Label" checked></glide-core-checkbox>`,
   );
 
   component.click();
@@ -37,7 +37,10 @@ it('is unchecked after being clicked', async () => {
 
 it('is checked and not indeterminate after being clicked when unchecked and indeterminate', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox indeterminate></glide-core-checkbox>`,
+    html`<glide-core-checkbox
+      label="Label"
+      indeterminate
+    ></glide-core-checkbox>`,
   );
 
   component.click();
@@ -56,7 +59,11 @@ it('is checked and not indeterminate after being clicked when unchecked and inde
 
 it('is unchecked and not indeterminate after being clicked when checked and indeterminate', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox checked indeterminate></glide-core-checkbox>`,
+    html`<glide-core-checkbox
+      label="Label"
+      checked
+      indeterminate
+    ></glide-core-checkbox>`,
   );
 
   component.click();
@@ -75,7 +82,11 @@ it('is unchecked and not indeterminate after being clicked when checked and inde
 
 it('is still checked after being clicked when checked but disabled', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox checked disabled></glide-core-checkbox>`,
+    html`<glide-core-checkbox
+      label="Label"
+      checked
+      disabled
+    ></glide-core-checkbox>`,
   );
 
   component.click();
@@ -87,8 +98,42 @@ it('is still checked after being clicked when checked but disabled', async () =>
 
 it('is still unchecked after being clicked when unchecked and disabled', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox disabled></glide-core-checkbox>`,
+    html`<glide-core-checkbox label="Label" disabled></glide-core-checkbox>`,
   );
+
+  component.click();
+  await elementUpdated(component);
+
+  expect(component.hasAttribute('checked')).to.be.false;
+  expect(component.checked).to.equal(false);
+});
+
+it('is unchecked after being clicked then forcibly unchecked via a "input" listener', async () => {
+  const component = await fixture<GlideCoreCheckbox>(
+    html`<glide-core-checkbox label="Label"></glide-core-checkbox>`,
+  );
+
+  component.addEventListener('input', async () => {
+    await component.updateComplete;
+    component.checked = false;
+  });
+
+  component.click();
+  await elementUpdated(component);
+
+  expect(component.hasAttribute('checked')).to.be.false;
+  expect(component.checked).to.equal(false);
+});
+
+it('is unchecked after being clicked then forcibly unchecked via an "change" listener', async () => {
+  const component = await fixture<GlideCoreCheckbox>(
+    html`<glide-core-checkbox label="Label"></glide-core-checkbox>`,
+  );
+
+  component.addEventListener('change', async () => {
+    await component.updateComplete;
+    component.checked = false;
+  });
 
   component.click();
   await elementUpdated(component);
@@ -99,7 +144,11 @@ it('is still unchecked after being clicked when unchecked and disabled', async (
 
 it('is still indeterminate after being clicked when unchecked and disabled', async () => {
   const component = await fixture<GlideCoreCheckbox>(
-    html`<glide-core-checkbox disabled indeterminate></glide-core-checkbox>`,
+    html`<glide-core-checkbox
+      label="Label"
+      disabled
+      indeterminate
+    ></glide-core-checkbox>`,
   );
 
   component.click();

--- a/src/input.ts
+++ b/src/input.ts
@@ -485,8 +485,8 @@ export default class GlideCoreInput extends LitElement {
     ow(this.#inputElementRef.value, ow.object.instanceOf(HTMLInputElement));
     this.value = this.#inputElementRef.value?.value;
 
-    // Unlike "input" events, "change" events aren't composed. So we manually
-    // dispatch them from the host.
+    // Unlike "input" events, "change" events aren't composed. So we have to
+    // manually dispatch them.
     this.dispatchEvent(new Event(event.type, event));
   }
 

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -332,8 +332,8 @@ export default class GlideCoreTextarea extends LitElement {
 
     this.value = this.#textareaElementRef.value.value;
 
-    // Unlike "input" events, "change" events aren't composed. So we manually
-    // dispatch them from the host.
+    // Unlike "input" events, "change" events aren't composed. So we have to
+    // manually dispatch them.
     this.dispatchEvent(new Event(event.type, event));
   }
 

--- a/src/toggle.test.interactions.ts
+++ b/src/toggle.test.interactions.ts
@@ -68,3 +68,43 @@ it('is still unchecked after being clicked when unchecked and disabled', async (
   const input = component.shadowRoot?.querySelector('[data-test="input"]');
   expect(input?.getAttribute('aria-checked')).to.equal('false');
 });
+
+it('is unchecked after being clicked then forcibly unchecked via a "change" listener', async () => {
+  const component = await fixture<GlideCoreToggle>(
+    html`<glide-core-toggle label="Label"></glide-core-toggle>`,
+  );
+
+  component.addEventListener('change', async () => {
+    await component.updateComplete;
+    component.checked = false;
+  });
+
+  component.click();
+  await elementUpdated(component);
+
+  expect(component.hasAttribute('checked')).to.be.false;
+  expect(component.checked).to.equal(false);
+
+  const input = component.shadowRoot?.querySelector('[data-test="input"]');
+  expect(input?.getAttribute('aria-checked')).to.equal('false');
+});
+
+it('is unchecked after being clicked then forcibly unchecked via an "input" listener', async () => {
+  const component = await fixture<GlideCoreToggle>(
+    html`<glide-core-toggle label="Label"></glide-core-toggle>`,
+  );
+
+  component.addEventListener('input', async () => {
+    await component.updateComplete;
+    component.checked = false;
+  });
+
+  component.click();
+  await elementUpdated(component);
+
+  expect(component.hasAttribute('checked')).to.be.false;
+  expect(component.checked).to.equal(false);
+
+  const input = component.shadowRoot?.querySelector('[data-test="input"]');
+  expect(input?.getAttribute('aria-checked')).to.equal('false');
+});


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to Checkbox in Storybook.
2. Add a "change" listener that forcibly unchecks Checkbox: 

   ```
   $0.addEventListener('change', async (event) => {
      await event.target.updateComplete;
      event.target.checked = false;
    })
      ```
4. Click Checkbox.
5. Check that Checkbox remains unchecked.
6. Do the same with an "input" listener.
7. Do the same for Toggle.

## 📸 Images/Videos of Functionality

N/A
