### PR TITLE
Don't strip `<kbd>`s in Storybook code examples

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -100,6 +100,7 @@ export default {
             const isSlotted = $element.attr('slot');
             const isScriptTag = $element.prop('tagName') === 'SCRIPT';
             const isStyleTag = $element.prop('tagName') === 'STYLE';
+            const isKbdTag = $element.prop('tagName') === 'KBD'; // Tooltip
 
             if (isScriptTag) {
               if ($element.attr('type') === 'ignore') {
@@ -110,7 +111,12 @@ export default {
               }
             } else if (isStyleTag) {
               $element.remove();
-            } else if (!isCoreElement && !isSlotted && !isScriptTag) {
+            } else if (
+              !isCoreElement &&
+              !isSlotted &&
+              !isScriptTag &&
+              !isKbdTag
+            ) {
               if ($element.children().length === 0) {
                 $element.replaceWith($element.text());
               } else {

--- a/src/textarea.stories.ts
+++ b/src/textarea.stories.ts
@@ -50,6 +50,16 @@ const meta: Meta = {
     value: '',
   },
   argTypes: {
+    'addEventListener(event, listener)': {
+      control: false,
+      table: {
+        type: {
+          summary: 'method',
+          detail:
+            'event: "change" | "input" | "invalid", listener: (event: Event) => void',
+        },
+      },
+    },
     label: {
       control: 'text',
       table: {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

### Before

![image](https://github.com/user-attachments/assets/accd287d-c9e3-4ebc-98fb-1c78b095fa95)

### After

![image](https://github.com/user-attachments/assets/f27d331a-1e6e-48ef-87b9-ca90948591e1)

