### PR TITLE
Dropdown filtering enhancements

### DIFF
--- a/.changeset/ten-cows-approve.md
+++ b/.changeset/ten-cows-approve.md
@@ -1,0 +1,8 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- When filterable and an option is selected, Dropdown now sets the underlying `<input>`'s `value` instead of `placeholder` to match the updated interaction specification.
+- Pressing `Meta` + `Backspace` when the insertion point is at the beginning of a filterable Dropdown now removes every non-overflowing, selected option.
+- Dropdown now has a `click()` method.
+- Dropdown no longer shows an empty menu when opened after every option have been filtered out.

--- a/src/accordion.stories.ts
+++ b/src/accordion.stories.ts
@@ -59,9 +59,9 @@ const meta: Meta = {
     label: 'Label',
     'slot="default"': 'Content',
     'addEventListener(event, listener)': '',
+    open: false,
     'slot="prefix"': '',
     'slot="suffix"': '',
-    open: false,
   },
   argTypes: {
     label: {

--- a/src/checkbox.test.interactions.ts
+++ b/src/checkbox.test.interactions.ts
@@ -195,3 +195,16 @@ it('has no tooltip when minimal and with a short label', async () => {
   const tooltip = component.shadowRoot?.querySelector('[data-test="tooltip"]');
   expect(tooltip?.checkVisibility()).to.be.false;
 });
+
+it('remains unchecked when its "click" event is canceled', async () => {
+  const component = await fixture<GlideCoreCheckbox>(
+    html`<glide-core-checkbox label="Label"></glide-core-checkbox>`,
+  );
+
+  component.addEventListener('click', (event) => {
+    event.preventDefault();
+  });
+
+  component.click();
+  expect(component.checked).to.be.false;
+});

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -102,6 +102,10 @@ export default [
       padding: var(--padding);
       position: absolute;
       scroll-behavior: smooth;
+
+      &.hidden {
+        display: none;
+      }
     }
 
     .select-all {
@@ -170,12 +174,6 @@ export default [
 
       &:focus {
         outline: none;
-      }
-
-      &.single.selection:not(:focus) {
-        &::placeholder {
-          color: inherit;
-        }
       }
 
       &::placeholder {

--- a/src/dropdown.test.focus.filterable.ts
+++ b/src/dropdown.test.focus.filterable.ts
@@ -1,5 +1,6 @@
 import './dropdown.option.js';
 import { aTimeout, assert, expect, fixture, html } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
 import { sendMouse } from '@web/test-runner-commands';
 import GlideCoreDropdown from './dropdown.js';
 import GlideCoreDropdownOption from './dropdown.option.js';
@@ -208,4 +209,35 @@ it('does not focus the input when `checkValidity` is called', async () => {
 
   component.checkValidity();
   expect(component.shadowRoot?.activeElement).to.equal(null);
+});
+
+it('sets the `value` of the `<input>` to the selected option when focus is lost', async () => {
+  document.body.tabIndex = -1;
+
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
+      ${defaultSlot}
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for it to open.
+  await aTimeout(0);
+
+  const option = component.querySelector('glide-core-dropdown-option');
+  assert(option);
+
+  option.selected = true;
+
+  // Now type something other than "One" so we can check that it's reverted
+  // back to "One" when focus is lost.
+  component.focus();
+  await sendKeys({ type: 'o' });
+
+  document.body.focus();
+
+  const input = component.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(input?.value).to.equal('One');
 });

--- a/src/dropdown.test.interactions.multiple.ts
+++ b/src/dropdown.test.interactions.multiple.ts
@@ -7,6 +7,7 @@ import {
   expect,
   fixture,
   html,
+  oneEvent,
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import { sendMouse } from '@web/test-runner-commands';
@@ -1455,4 +1456,30 @@ it('cannot be tabbed to when `disabled`', async () => {
 
   await sendKeys({ down: 'Tab' });
   expect(document.activeElement).to.equal(document.body);
+});
+
+it('clicks the button when `click()` is called', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" multiple>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const button = component.shadowRoot?.querySelector('[data-test="button"]');
+  assert(button);
+
+  setTimeout(() => {
+    component.click();
+  });
+
+  const event = await oneEvent(button, 'click');
+  expect(event instanceof PointerEvent).to.be.true;
 });

--- a/src/dropdown.test.interactions.single.ts
+++ b/src/dropdown.test.interactions.single.ts
@@ -8,6 +8,7 @@ import {
   expect,
   fixture,
   html,
+  oneEvent,
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreDropdown from './dropdown.js';
@@ -726,4 +727,25 @@ it('cannot be tabbed to when `disabled`', async () => {
 
   await sendKeys({ down: 'Tab' });
   expect(document.activeElement).to.equal(document.body);
+});
+
+it('clicks the button when `click()` is called', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder">
+      <glide-core-dropdown-option
+        label="Label"
+        value="value"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const button = component.shadowRoot?.querySelector('[data-test="button"]');
+  assert(button);
+
+  setTimeout(() => {
+    component.click();
+  });
+
+  const event = await oneEvent(button, 'click');
+  expect(event instanceof PointerEvent).to.be.true;
 });

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -79,6 +79,14 @@ export default class GlideCoreDropdown extends LitElement {
 
     if (isOpen && !this.disabled) {
       this.#show();
+    } else if (
+      !this.multiple &&
+      this.#inputElementRef.value &&
+      this.selectedOptions.length > 0
+    ) {
+      this.#inputElementRef.value.value = this.selectedOptions[0].label;
+      this.isFiltering = false;
+      this.#hide();
     } else {
       this.#hide();
     }
@@ -174,6 +182,29 @@ export default class GlideCoreDropdown extends LitElement {
   @property({ reflect: true })
   variant?: 'quiet';
 
+  private get activeOption() {
+    return this.#optionElementsIncludingSelectAll?.find(
+      ({ privateActive }) => privateActive,
+    );
+  }
+
+  checkValidity() {
+    this.isCheckingValidity = true;
+    const validity = this.#internals.checkValidity();
+    this.isCheckingValidity = false;
+
+    return validity;
+  }
+
+  override click() {
+    if (this.#inputElementRef.value) {
+      this.#inputElementRef.value.click();
+      this.#inputElementRef.value.select();
+    } else {
+      this.#buttonElementRef.value?.click();
+    }
+  }
+
   private get selectedOptions() {
     return this.#optionElements.filter(
       (option): option is GlideCoreDropdownOption => {
@@ -197,12 +228,6 @@ export default class GlideCoreDropdown extends LitElement {
     return this.#optionElements.some(({ selected }) => selected);
   }
 
-  private get activeOption() {
-    return this.#optionElementsIncludingSelectAll?.find(
-      ({ privateActive }) => privateActive,
-    );
-  }
-
   private get internalLabel() {
     return !this.isFilterable && this.selectedOptions.length === 0
       ? html`<span class="placeholder">${this.placeholder}</span>`
@@ -211,14 +236,6 @@ export default class GlideCoreDropdown extends LitElement {
           this.selectedOptions.at(-1)?.label
         ? this.selectedOptions.at(-1)?.label
         : '';
-  }
-
-  checkValidity() {
-    this.isCheckingValidity = true;
-    const validity = this.#internals.checkValidity();
-    this.isCheckingValidity = false;
-
-    return validity;
   }
 
   override connectedCallback() {
@@ -462,17 +479,13 @@ export default class GlideCoreDropdown extends LitElement {
                 aria-labelledby="selected-option-labels label"
                 autocapitalize="off"
                 autocomplete="off"
-                class=${classMap({
-                  input: true,
-                  selection: Boolean(this.selectedOptions.at(0)),
-                  single: !this.multiple,
-                })}
+                class="input"
                 data-test="input"
                 id="input"
                 placeholder=${this.multiple ||
                 !this.selectedOptions.at(-1)?.label
                   ? this.placeholder ?? ''
-                  : this.selectedOptions.at(-1)?.label ?? ''}
+                  : ''}
                 role="combobox"
                 spellcheck="false"
                 tabindex=${this.disabled ? '-1' : '0'}
@@ -558,7 +571,10 @@ export default class GlideCoreDropdown extends LitElement {
 
           <div
             aria-labelledby=${this.isFilterable ? 'input' : 'button'}
-            class="options"
+            class=${classMap({
+              options: true,
+              hidden: this.isOptionsHidden,
+            })}
             data-test="options"
             id="options"
             role="listbox"
@@ -651,6 +667,9 @@ export default class GlideCoreDropdown extends LitElement {
 
   @state()
   private isFiltering = false;
+
+  @state()
+  private isOptionsHidden = false;
 
   @state()
   private isReportValidityOrSubmit = false;
@@ -1087,8 +1106,9 @@ export default class GlideCoreDropdown extends LitElement {
       // the event most likely originated from an Enter press. And, if Dropdown is part
       // of a form, Enter should result in a submit and the dropdown shouldn't be opened.
       // Thus we return, with or without a form for consistency.
-    } else if (!this.open && event.detail !== 0 && this.activeOption) {
+    } else if (event.detail !== 0) {
       this.open = true;
+      this.#inputElementRef.value?.select();
     }
   }
 
@@ -1135,11 +1155,13 @@ export default class GlideCoreDropdown extends LitElement {
         firstVisibleOption.privateActive = true;
       }
 
-      this.open =
+      this.open = true;
+
+      this.isOptionsHidden =
         !this.#optionElementsNotHidden ||
         this.#optionElementsNotHidden.length === 0
-          ? false
-          : true;
+          ? true
+          : false;
     }
   }
 
@@ -1154,11 +1176,32 @@ export default class GlideCoreDropdown extends LitElement {
     if (
       lastSelectedAndNotOverflowingOption &&
       event.key === 'Backspace' &&
+      !event.metaKey &&
       this.multiple &&
       this.#inputElementRef.value &&
       this.#inputElementRef.value.selectionStart === 0
     ) {
       lastSelectedAndNotOverflowingOption.selected = false;
+      return;
+    }
+
+    const selectedAndNotOverflowingOptions = this.selectedOptions.filter(
+      (_, index) => index <= this.#tagOverflowLimit - 1,
+    );
+
+    if (
+      lastSelectedAndNotOverflowingOption &&
+      event.key === 'Backspace' &&
+      event.metaKey &&
+      this.multiple &&
+      this.#inputElementRef.value &&
+      this.#inputElementRef.value.selectionStart === 0
+    ) {
+      for (const option of selectedAndNotOverflowingOptions) {
+        option.selected = false;
+      }
+
+      return;
     }
   }
 
@@ -1260,6 +1303,10 @@ export default class GlideCoreDropdown extends LitElement {
         // also don't want any changes to focus or the state of `this.open` as a result.
       } else if (!this.multiple && event.target.selected) {
         this.#value = event.target.value ? [event.target.value] : [];
+
+        if (this.#inputElementRef.value) {
+          this.#inputElementRef.value.value = event.target.label;
+        }
       }
     }
 
@@ -1426,7 +1473,6 @@ export default class GlideCoreDropdown extends LitElement {
 
   #unfilter() {
     if (this.isFilterable && this.#inputElementRef.value) {
-      this.#inputElementRef.value.value = '';
       this.isFiltering = false;
 
       for (const option of this.#optionElements) {

--- a/src/input.stories.ts
+++ b/src/input.stories.ts
@@ -288,27 +288,6 @@ export const Description: StoryObj = {
   },
 };
 
-export const Readonly: StoryObj = {
-  args: {
-    readonly: true,
-    value: 'Some example text',
-  },
-};
-
-export const Disabled: StoryObj = {
-  args: {
-    disabled: true,
-    value: 'Some example text',
-  },
-};
-
-export const Placeholder: StoryObj = {
-  args: {
-    placholder: 'Placeholder...',
-    value: '',
-  },
-};
-
 export const Clearable: StoryObj = {
   args: {
     clearable: true,

--- a/src/textarea.stories.ts
+++ b/src/textarea.stories.ts
@@ -253,7 +253,7 @@ export const Description: StoryObj = {
           label=${arguments_.label}
           ?readonly=${arguments_.readonly}
           ?disabled=${arguments_.disabled}
-          maxlength=${arguments_.maxlength}
+          maxlength=${arguments_.maxlength || nothing}
         >
           ${arguments_['slot="tooltip"']
             ? html`<span slot="tooltip">${arguments_['slot="tooltip"']}</span>`
@@ -264,25 +264,6 @@ export const Description: StoryObj = {
           </div>
         </glide-core-textarea>
       </form>`;
-  },
-};
-
-export const Readonly: StoryObj = {
-  args: {
-    readonly: true,
-  },
-};
-
-export const Disabled: StoryObj = {
-  args: {
-    disabled: true,
-  },
-};
-
-export const Placeholder: StoryObj = {
-  args: {
-    placholder: 'Placeholder...',
-    value: '',
   },
 };
 

--- a/src/toggle.test.interactions.ts
+++ b/src/toggle.test.interactions.ts
@@ -108,3 +108,21 @@ it('is unchecked after being clicked then forcibly unchecked via an "input" list
   const input = component.shadowRoot?.querySelector('[data-test="input"]');
   expect(input?.getAttribute('aria-checked')).to.equal('false');
 });
+
+it('remains unchecked when its "click" event is canceled', async () => {
+  const component = await fixture<GlideCoreToggle>(
+    html`<glide-core-toggle label="Label"></glide-core-toggle>`,
+  );
+
+  component.addEventListener('click', async (event) => {
+    event.preventDefault();
+  });
+
+  component.click();
+
+  expect(component.hasAttribute('checked')).to.be.false;
+  expect(component.checked).to.equal(false);
+
+  const input = component.shadowRoot?.querySelector('[data-test="input"]');
+  expect(input?.getAttribute('aria-checked')).to.equal('false');
+});

--- a/src/tooltip.stories.ts
+++ b/src/tooltip.stories.ts
@@ -32,7 +32,7 @@ const meta: Meta = {
           detail: '// The content of the tooltip',
         },
       },
-      type: { name: 'function', required: true },
+      type: { name: 'string', required: true },
     },
     'slot="target"': {
       table: {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- When filterable and an option is selected, Dropdown now sets the underlying `<input>`'s `value` instead of `placeholder` to match updated Design guidelines.
- Pressing `Meta` + `Backspace` when the insertion point is at the beginning of a filterable Dropdown now removes every non-overflowing, selected option.
- Dropdown now has a `click()` method.
- Dropdown no longer shows an empty menu when opened after all options have been filtered out.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

The primary change, and the one most worth testing, is that the `<input>`'s `value` is set when Dropdown is filterable:

1. Navigate to Dropdown's [Single Selection (Horizontal With Filtering)](https://glide-core.crowdstrike-ux.workers.dev/dropdown-filtering-enhancements?path=/story/dropdown--single-selection-horizontal-with-filtering) story.
2. Select an option.
3. Check that the `<input>`'s `value` was set to "One".
4. Now filter using some text other than "One".
5. Click outside of Dropdown or move focus elsewhere.
6. Check that `value` was changed back to "One".

## 📸 Images/Videos of Functionality

N/A
