### PR TITLE
Add newly-translated Japanese and French strings

### DIFF
--- a/.changeset/purple-guests-crash.md
+++ b/.changeset/purple-guests-crash.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Add newly-translated Japanese and French strings

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -12,8 +12,8 @@ const translation: Translation = {
   open: 'Open',
   selectAll: 'Select all',
   moreInformation: 'More information',
-  nextTab: 'Next tab',
   notifications: 'Notifications',
+  nextTab: 'Next tab',
   previousTab: 'Previous tab',
 
   announcedCharacterCount: (current: number, maximum: number) =>

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -5,5 +5,11 @@
   "selectAll": "Tout sélectionner",
   "moreInformation": "Plus d’informations",
   "notifications": "Notifications",
-  "removeTag": "Supprimer la balise : {label}"
+  "nextTab": "Onglet suivant",
+  "previousTab": "Onglet précédent",
+  "announcedCharacterCount": "Nombre de caractères {current} de {maximum}",
+  "displayedCharacterCount": "{current}/{maximum}",
+  "clearEntry": "Effacer l'entrée {label}",
+  "removeTag": "Supprimer la balise : {label}",
+  "actionsFor": "Actions pour {label}"
 }

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1,13 +1,6 @@
 import type { Translation } from '../library/localize.js';
 
-export const PENDING_STRINGS = [
-  'nextTab',
-  'previousTab',
-  'announcedCharacterCount',
-  'displayedCharacterCount',
-  'clearEntry',
-  'actionsFor',
-] as const;
+export const PENDING_STRINGS = [] as const;
 
 type PendingTranslation = (typeof PENDING_STRINGS)[number];
 
@@ -23,8 +16,16 @@ const translation: Omit<Translation, PendingTranslation> = {
   selectAll: 'Tout sélectionner',
   moreInformation: 'Plus d’informations',
   notifications: 'Notifications',
+  nextTab: 'Onglet suivant',
+  previousTab: 'Onglet précédent',
 
+  announcedCharacterCount: (current: number, maximum: number) =>
+    `Nombre de caractères ${current} de ${maximum}`,
+  displayedCharacterCount: (current: number, maximum: number) =>
+    `${current}/${maximum}`,
+  clearEntry: (label: string) => `Effacer l'entrée ${label}`,
   removeTag: (label: string) => `Supprimer la balise : ${label}`,
+  actionsFor: (label: string) => `Actions pour ${label}`,
 };
 
 export default translation;

--- a/src/translations/ja.json
+++ b/src/translations/ja.json
@@ -5,5 +5,11 @@
   "selectAll": "すべて選択",
   "moreInformation": "詳細情報",
   "notifications": "通知",
-  "removeTag": "タグを削除: {label}"
+  "nextTab": "次のタブ",
+  "previousTab": "前のタブ",
+  "announcedCharacterCount": "{maximum} 文字数の{current}",
+  "displayedCharacterCount": "{current}/{maximum}",
+  "clearEntry": "{label}エントリのクリア",
+  "removeTag": "タグを削除: {label}",
+  "actionsFor": "{label}のアクション"
 }

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -1,13 +1,6 @@
 import type { Translation } from '../library/localize.js';
 
-export const PENDING_STRINGS = [
-  'nextTab',
-  'previousTab',
-  'announcedCharacterCount',
-  'displayedCharacterCount',
-  'clearEntry',
-  'actionsFor',
-] as const;
+export const PENDING_STRINGS = [] as const;
 
 type PendingTranslation = (typeof PENDING_STRINGS)[number];
 
@@ -23,8 +16,16 @@ const translation: Omit<Translation, PendingTranslation> = {
   selectAll: 'すべて選択',
   moreInformation: '詳細情報',
   notifications: '通知',
+  nextTab: 'Onglet suivant',
+  previousTab: 'Onglet précédent',
 
+  announcedCharacterCount: (current: number, maximum: number) =>
+    `${maximum} 文字数の${current}`,
+  displayedCharacterCount: (current: number, maximum: number) =>
+    `${current}/${maximum}`,
+  clearEntry: (label: string) => `${label}エントリのクリア`,
   removeTag: (label: string) => `タグを削除: ${label}`,
+  actionsFor: (label: string) => `${label}のアクション`,
 };
 
 export default translation;


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Adds the new translation strings to the Japanese and French JSON files, and then copies the string values into their corresponding TS files

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

Change the lang attribute of Storybook's html element to test the other locales, and then validate the new strings:

![image](https://github.com/user-attachments/assets/3275ef15-0d75-4792-8805-acd8272ec08f)


## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
