### PR TITLE
Take option icons into account when handling option clicks

### DIFF
--- a/.changeset/shy-llamas-work.md
+++ b/.changeset/shy-llamas-work.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Clicking a Dropdown option's icon now selects the option.

--- a/src/dropdown.option.ts
+++ b/src/dropdown.option.ts
@@ -243,7 +243,7 @@ export default class GlideCoreDropdownOption extends LitElement {
                 ${checkedIcon}
               </div>
 
-              <slot name="icon"></slot>
+              <slot data-test="icon-slot" name="icon"></slot>
 
               <glide-core-tooltip class="tooltip" offset=${10} ?disabled=${!this
                 .isLabelOverflow} ?open=${this.privateActive}>

--- a/src/dropdown.test.interactions.single.ts
+++ b/src/dropdown.test.interactions.single.ts
@@ -144,6 +144,42 @@ it('selects an option on Space', async () => {
   expect(option?.selected).to.be.true;
 });
 
+it('selects an option when its icon is clicked', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
+      <glide-core-dropdown-option label="One" value="one">
+        <svg
+          slot="icon"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          style="height: 1rem; width: 1rem;"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15"
+          />
+        </svg>
+      </glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for it to open.
+  await aTimeout(0);
+
+  const option = component.querySelector('glide-core-dropdown-option');
+
+  option?.shadowRoot
+    ?.querySelector<HTMLSlotElement>('[data-test="icon-slot"]')
+    ?.assignedElements()
+    ?.at(0)
+    ?.dispatchEvent(new Event('click', { bubbles: true }));
+
+  expect(option?.selected).to.be.true;
+});
+
 it('does not deselect options on Space', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -1163,19 +1163,20 @@ export default class GlideCoreDropdown extends LitElement {
   }
 
   #onOptionsClick(event: PointerEvent) {
-    if (
-      event.target instanceof GlideCoreDropdownOption &&
-      !event.target.selected
-    ) {
-      event.target.selected = true;
-      this.#unfilter();
+    if (event.target instanceof Element) {
+      const option = event.target.closest('glide-core-dropdown-option');
 
-      if (!this.multiple) {
-        this.#hide();
+      if (option instanceof GlideCoreDropdownOption && !option.selected) {
+        option.selected = true;
+        this.#unfilter();
+
+        if (!this.multiple) {
+          this.#hide();
+        }
+
+        this.dispatchEvent(new Event('change', { bubbles: true }));
+        this.dispatchEvent(new Event('input', { bubbles: true }));
       }
-
-      this.dispatchEvent(new Event('change', { bubbles: true }));
-      this.dispatchEvent(new Event('input', { bubbles: true }));
     }
   }
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Easy one. Clicking a Dropdown option's icon now selects the option.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to Dropdown's [Single Selection (Horizontal With Icon)](https://glide-core.crowdstrike-ux.workers.dev/dropdown-icon-click?path=/story/dropdown--single-selection-horizontal-with-icon) story.
2. Open Dropdown and click an option's icon.
3. The option should be selected.

## 📸 Images/Videos of Functionality

N/A