### PR TITLE
Button and native button parity

### DIFF
--- a/.changeset/twelve-parrots-check.md
+++ b/.changeset/twelve-parrots-check.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Button's `type` attribute is now reflected.
+- Button now supports the full set of native `<button>` attributes such as `formenctype`, `name`, `popovertarget`, and others.

--- a/src/button.stories.ts
+++ b/src/button.stories.ts
@@ -13,39 +13,157 @@ const meta: Meta = {
       },
     },
   },
-  render: (arguments_) => html`
-    <script type="ignore">
-      import '@crowdstrike/glide-core/button.js';
-    </script>
+  render: (arguments_) => {
+    /* eslint-disable unicorn/explicit-length-check */
+    return html`
+      <script type="ignore">
+        import '@crowdstrike/glide-core/button.js';
+      </script>
 
-    <glide-core-button
-      size=${arguments_.size}
-      type=${arguments_.type}
-      variant=${arguments_.variant}
-      ?disabled=${arguments_.disabled || nothing}
-      >${arguments_['slot="default"']}</glide-core-button
-    >
-  `,
+      <form>
+        <glide-core-button
+          formaction=${arguments_.formaction || nothing}
+          formenctype=${arguments_.formenctype || nothing}
+          formmethod=${arguments_.formmethod || nothing}
+          formtarget=${arguments_.formtarget || nothing}
+          name=${arguments_.name || nothing}
+          popovertarget=${arguments_.popovertarget || nothing}
+          popovertargetaction=${arguments_.popovertargetaction || nothing}
+          size=${arguments_.size || nothing}
+          type=${arguments_.type || nothing}
+          value=${arguments_.value || nothing}
+          variant=${arguments_.variant || nothing}
+          ?autofocus=${arguments_.autofocus}
+          ?disabled=${arguments_.disabled || nothing}
+          ?formnovalidate=${arguments_.formnovalidate}
+          >${arguments_['slot="default"']}</glide-core-button
+        >
+      </form>
+    `;
+  },
   args: {
     'slot="default"': 'Button',
+    autofocus: false,
     disabled: false,
+    form: '',
+    formaction: '',
+    formenctype: 'application/x-www-form-urlencoded',
+    formmethod: 'get',
+    formnovalidate: false,
+    formtarget: '_self',
+    name: '',
+    popovertarget: '',
+    popovertargetaction: 'toggle',
     size: 'large',
     type: 'button',
+    value: '',
     variant: 'primary',
   },
   argTypes: {
-    variant: {
-      control: { type: 'radio' },
-      options: ['primary', 'secondary', 'tertiary'],
+    'slot="default"': {
+      control: { type: 'text' },
+      table: {
+        type: { summary: 'Element | string' },
+      },
+      type: { name: 'string', required: true },
+    },
+    autofocus: {
       table: {
         defaultValue: {
-          summary: '"primary"',
+          summary: 'false',
         },
-        type: { summary: '"primary" | "secondary" | "tertiary"' },
       },
     },
     disabled: {
-      control: 'boolean',
+      table: {
+        defaultValue: {
+          summary: 'false',
+        },
+      },
+    },
+    form: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: 'null',
+        },
+        type: { summary: 'readonly HTMLFormElement | readonly null' },
+      },
+    },
+    formaction: {
+      table: {
+        defaultValue: {
+          summary: '""',
+        },
+      },
+    },
+    formenctype: {
+      control: { type: 'select' },
+      options: [
+        '',
+        'application/x-www-form-urlencoded',
+        'multipart/form-data',
+        'text/plain',
+      ],
+      table: {
+        defaultValue: {
+          summary: '"application/x-www-form-urlencoded"',
+        },
+        type: {
+          summary:
+            '"application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain"',
+        },
+      },
+    },
+    formmethod: {
+      control: { type: 'select' },
+      options: ['', 'dialog', 'get', 'post'],
+      table: {
+        defaultValue: {
+          summary: '"get"',
+        },
+        type: {
+          summary: '"dialog" | "get" | "post"',
+        },
+      },
+    },
+    formnovalidate: {
+      table: {
+        defaultValue: {
+          summary: 'false',
+        },
+      },
+    },
+    formtarget: {
+      control: { type: 'select' },
+      options: ['', '_blank', '_parent', '_self', '_top'],
+      table: {
+        defaultValue: {
+          summary: '"_self"',
+        },
+        type: {
+          summary: '"_blank" | "_parent" | "_self" | "_top"',
+        },
+      },
+    },
+    name: {
+      table: {
+        defaultValue: {
+          summary: '""',
+        },
+      },
+    },
+    popovertargetaction: {
+      control: { type: 'select' },
+      options: ['', 'hide', 'show', 'toggle'],
+      table: {
+        defaultValue: {
+          summary: '"toggle"',
+        },
+        type: {
+          summary: '"hide" | "show" | "toggle"',
+        },
+      },
     },
     size: {
       control: { type: 'radio' },
@@ -57,13 +175,6 @@ const meta: Meta = {
         type: { summary: '"large" | "small"' },
       },
     },
-    'slot="default"': {
-      control: { type: 'text' },
-      table: {
-        type: { summary: 'Element | string' },
-      },
-      type: { name: 'string', required: true },
-    },
     type: {
       control: { type: 'select' },
       options: ['button', 'reset', 'submit'],
@@ -72,6 +183,25 @@ const meta: Meta = {
           summary: '"button"',
         },
         type: { summary: '"button" | "reset" | "submit"' },
+      },
+    },
+    value: {
+      control: { type: 'text' },
+      table: {
+        defaultValue: {
+          summary: '""',
+        },
+        type: { summary: 'string' },
+      },
+    },
+    variant: {
+      control: { type: 'radio' },
+      options: ['primary', 'secondary', 'tertiary'],
+      table: {
+        defaultValue: {
+          summary: '"primary"',
+        },
+        type: { summary: '"primary" | "secondary" | "tertiary"' },
       },
     },
   },
@@ -96,10 +226,20 @@ export const PrimaryWithPrefixIcon: StoryObj = {
     </script>
 
     <glide-core-button
-      size=${arguments_.size}
-      type=${arguments_.type}
-      variant=${arguments_.variant}
+      formaction=${arguments_.formaction || nothing}
+      formenctype=${arguments_.formenctype || nothing}
+      formmethod=${arguments_.formmethod || nothing}
+      formtarget=${arguments_.formtarget || nothing}
+      name=${arguments_.name || nothing}
+      popovertarget=${arguments_.popovertarget || nothing}
+      popovertargetaction=${arguments_.popovertargetaction || nothing}
+      size=${arguments_.size || nothing}
+      type=${arguments_.type || nothing}
+      value=${arguments_.value || nothing}
+      variant=${arguments_.variant || nothing}
+      ?autofocus=${arguments_.autofocus}
       ?disabled=${arguments_.disabled}
+      ?formnovalidate=${arguments_.formnovalidate}
     >
       ${arguments_['slot="default"']}
 
@@ -119,10 +259,20 @@ export const PrimaryWithSuffixIcon: StoryObj = {
     </script>
 
     <glide-core-button
-      size=${arguments_.size}
-      type=${arguments_.type}
+      formaction=${arguments_.formaction || nothing}
+      formenctype=${arguments_.formenctype || nothing}
+      formmethod=${arguments_.formmethod || nothing}
+      formtarget=${arguments_.formtarget || nothing}
+      name=${arguments_.name || nothing}
+      popovertarget=${arguments_.popovertarget || nothing}
+      popovertargetaction=${arguments_.popovertargetaction || nothing}
+      size=${arguments_.size || nothing}
+      type=${arguments_.type || nothing}
+      value=${arguments_.value || nothing}
       variant=${arguments_.variant}
+      ?autofocus=${arguments_.autofocus}
       ?disabled=${arguments_.disabled}
+      ?formnovalidate=${arguments_.formnovalidate}
     >
       ${arguments_['slot="default"']}
 
@@ -142,10 +292,20 @@ export const PrimaryWithPrefixAndSuffixIcons: StoryObj = {
     </script>
 
     <glide-core-button
-      size=${arguments_.size}
-      type=${arguments_.type}
+      formaction=${arguments_.formaction || nothing}
+      formenctype=${arguments_.formenctype || nothing}
+      formmethod=${arguments_.formmethod || nothing}
+      formtarget=${arguments_.formtarget || nothing}
+      name=${arguments_.name || nothing}
+      popovertarget=${arguments_.popovertarget || nothing}
+      popovertargetaction=${arguments_.popovertargetaction || nothing}
+      size=${arguments_.size || nothing}
+      type=${arguments_.type || nothing}
+      value=${arguments_.value || nothing}
       variant=${arguments_.variant}
+      ?autofocus=${arguments_.autofocus}
       ?disabled=${arguments_.disabled}
+      ?formnovalidate=${arguments_.formnovalidate}
     >
       ${arguments_['slot="default"']}
 
@@ -178,10 +338,20 @@ export const SecondaryWithPrefixIcon: StoryObj = {
     </script>
 
     <glide-core-button
-      size=${arguments_.size}
-      type=${arguments_.type}
+      formaction=${arguments_.formaction || nothing}
+      formenctype=${arguments_.formenctype || nothing}
+      formmethod=${arguments_.formmethod || nothing}
+      formtarget=${arguments_.formtarget || nothing}
+      name=${arguments_.name || nothing}
+      popovertarget=${arguments_.popovertarget || nothing}
+      popovertargetaction=${arguments_.popovertargetaction || nothing}
+      size=${arguments_.size || nothing}
+      type=${arguments_.type || nothing}
+      value=${arguments_.value || nothing}
       variant=${arguments_.variant}
+      ?autofocus=${arguments_.autofocus}
       ?disabled=${arguments_.disabled}
+      ?formnovalidate=${arguments_.formnovalidate}
     >
       ${arguments_['slot="default"']}
 
@@ -204,10 +374,20 @@ export const SecondaryWithSuffixIcon: StoryObj = {
     </script>
 
     <glide-core-button
-      size=${arguments_.size}
-      type=${arguments_.type}
-      variant=${arguments_.variant}
+      formaction=${arguments_.formaction || nothing}
+      formenctype=${arguments_.formenctype || nothing}
+      formmethod=${arguments_.formmethod || nothing}
+      formtarget=${arguments_.formtarget || nothing}
+      name=${arguments_.name || nothing}
+      popovertarget=${arguments_.popovertarget || nothing}
+      popovertargetaction=${arguments_.popovertargetaction || nothing}
+      size=${arguments_.size || nothing}
+      type=${arguments_.type || nothing}
+      value=${arguments_.value || nothing}
+      variant=${arguments_.variant || nothing}
+      ?autofocus=${arguments_.autofocus}
       ?disabled=${arguments_.disabled}
+      ?formnovalidate=${arguments_.formnovalidate}
     >
       ${arguments_['slot="default"']}
 
@@ -230,10 +410,20 @@ export const SecondaryWithPrefixAndSuffixIcons: StoryObj = {
     </script>
 
     <glide-core-button
-      size=${arguments_.size}
-      type=${arguments_.type}
-      variant=${arguments_.variant}
+      formaction=${arguments_.formaction || nothing}
+      formenctype=${arguments_.formenctype || nothing}
+      formmethod=${arguments_.formmethod || nothing}
+      formtarget=${arguments_.formtarget || nothing}
+      name=${arguments_.name || nothing}
+      popovertarget=${arguments_.popovertarget || nothing}
+      popovertargetaction=${arguments_.popovertargetaction || nothing}
+      size=${arguments_.size || nothing}
+      type=${arguments_.type || nothing}
+      value=${arguments_.value || nothing}
+      variant=${arguments_.variant || nothing}
+      ?autofocus=${arguments_.autofocus}
       ?disabled=${arguments_.disabled}
+      ?formnovalidate=${arguments_.formnovalidate}
     >
       ${arguments_['slot="default"']}
 
@@ -266,10 +456,20 @@ export const TertiaryWithPrefixIcon: StoryObj = {
     </script>
 
     <glide-core-button
-      size=${arguments_.size}
-      type=${arguments_.type}
-      variant=${arguments_.variant}
+      formaction=${arguments_.formaction || nothing}
+      formenctype=${arguments_.formenctype || nothing}
+      formmethod=${arguments_.formmethod || nothing}
+      formtarget=${arguments_.formtarget || nothing}
+      name=${arguments_.name || nothing}
+      popovertarget=${arguments_.popovertarget || nothing}
+      popovertargetaction=${arguments_.popovertargetaction || nothing}
+      size=${arguments_.size || nothing}
+      type=${arguments_.type || nothing}
+      value=${arguments_.value || nothing}
+      variant=${arguments_.variant || nothing}
+      ?autofocus=${arguments_.autofocus}
       ?disabled=${arguments_.disabled}
+      ?formnovalidate=${arguments_.formnovalidate}
     >
       ${arguments_['slot="default"']}
 
@@ -292,10 +492,20 @@ export const TertiaryWithSuffixIcon: StoryObj = {
     </script>
 
     <glide-core-button
-      size=${arguments_.size}
-      type=${arguments_.type}
-      variant=${arguments_.variant}
+      formaction=${arguments_.formaction || nothing}
+      formenctype=${arguments_.formenctype || nothing}
+      formmethod=${arguments_.formmethod || nothing}
+      formtarget=${arguments_.formtarget || nothing}
+      name=${arguments_.name || nothing}
+      popovertarget=${arguments_.popovertarget || nothing}
+      popovertargetaction=${arguments_.popovertargetaction || nothing}
+      size=${arguments_.size || nothing}
+      type=${arguments_.type || nothing}
+      value=${arguments_.value || nothing}
+      variant=${arguments_.variant || nothing}
+      ?autofocus=${arguments_.autofocus}
       ?disabled=${arguments_.disabled}
+      ?formnovalidate=${arguments_.formnovalidate}
     >
       ${arguments_['slot="default"']}
 
@@ -318,10 +528,19 @@ export const TertiaryWithPrefixAndSuffixIcons: StoryObj = {
     </script>
 
     <glide-core-button
-      size=${arguments_.size}
-      type=${arguments_.type}
+      formaction=${arguments_.formaction || nothing}
+      formenctype=${arguments_.formenctype || nothing}
+      formmethod=${arguments_.formmethod || nothing}
+      name=${arguments_.name || nothing}
+      popovertarget=${arguments_.popovertarget || nothing}
+      popovertargetaction=${arguments_.popovertargetaction || nothing}
+      size=${arguments_.size || nothing}
+      type=${arguments_.type || nothing}
+      value=${arguments_.value || nothing}
       variant=${arguments_.variant}
+      ?autofocus=${arguments_.autofocus}
       ?disabled=${arguments_.disabled}
+      ?formnovalidate=${arguments_.formnovalidate}
     >
       ${arguments_['slot="default"']}
 

--- a/src/button.test.basics.ts
+++ b/src/button.test.basics.ts
@@ -2,7 +2,7 @@
 
 import './button.js';
 import { ArgumentError } from 'ow';
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import GlideCoreButton from './button.js';
 import sinon from 'sinon';
 
@@ -27,26 +27,42 @@ it('has defaults', async () => {
     <glide-core-button>Button</glide-core-button>
   `);
 
+  expect(component.ariaControls).to.be.null;
+  expect(component.ariaExpanded).to.be.null;
+  expect(component.ariaHasPopup).to.be.null;
+  expect(component.autofocus).to.be.false;
+  expect(component.disabled).to.be.false;
+  expect(component.formAction).to.be.empty.string;
+  expect(component.formEncType).to.be.empty.string;
+  expect(component.formMethod).to.be.empty.string;
+  expect(component.formNoValidate).to.be.false;
+  expect(component.name).to.be.empty.string;
+  expect(component.popoverTarget).to.be.undefined;
+  expect(component.popoverTargetAction).to.be.empty.string;
+  expect(component.value).to.be.empty.string;
   expect(component.type).to.equal('button');
-  expect(component.disabled).to.equal(false);
-  expect(component.textContent).to.equal('Button');
-  expect(component?.ariaHasPopup).to.equal(null);
-  expect(component?.ariaExpanded).to.equal(null);
-  expect(component?.ariaControls).to.equal(null);
+
+  expect(component.hasAttribute('autofocus')).to.be.false;
+  expect(component.getAttribute('aria-controls')).to.be.null;
+  expect(component.getAttribute('aria-expanded')).to.be.null;
+  expect(component.getAttribute('aria-haspopup')).to.be.null;
+  expect(component.hasAttribute('disabled')).to.be.false;
+  expect(component.getAttribute('formaction')).to.be.empty.string;
+  expect(component.getAttribute('formenctype')).to.be.empty.string;
+  expect(component.getAttribute('formmethod')).to.be.empty.string;
+  expect(component.hasAttribute('formnovalidate')).to.be.false;
+  expect(component.getAttribute('name')).to.be.empty.string;
+  expect(component.getAttribute('popovertarget')).to.be.null;
+  expect(component.getAttribute('popovertargetaction')).to.be.empty.string;
+  expect(component.getAttribute('type')).to.equal('button');
+  expect(component.getAttribute('value')).to.be.empty.string;
 
   const button = component.shadowRoot?.querySelector('button');
 
-  expect(button?.getAttribute('type')).to.equal('button');
-  expect(button?.getAttribute('aria-controls')).to.equal(null);
-  expect(button?.ariaExpanded).to.equal(null);
-  expect(button?.ariaHasPopup).to.equal(null);
+  expect(button?.getAttribute('aria-controls')).to.be.null;
+  expect(button?.ariaExpanded).to.be.null;
+  expect(button?.ariaHasPopup).to.be.null;
   expect(button?.disabled).to.equal(false);
-
-  expect([...button!.classList]).to.deep.equal([
-    'component',
-    'primary',
-    'large',
-  ]);
 });
 
 it('delegates focus', async () => {
@@ -59,202 +75,6 @@ it('delegates focus', async () => {
   expect(component.shadowRoot?.activeElement).to.equal(
     component.shadowRoot?.querySelector('button'),
   );
-});
-
-it('renders a secondary variant', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button variant="secondary">Button</glide-core-button>
-  `);
-
-  expect([
-    ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal(['component', 'secondary', 'large']);
-});
-
-it('renders a tertiary variant', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button variant="tertiary">Button</glide-core-button>
-  `);
-
-  expect([
-    ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal(['component', 'tertiary', 'large']);
-});
-
-it('sets the size to "large" by default', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button>Button</glide-core-button>
-  `);
-
-  expect(component.size).to.equal('large');
-
-  expect([
-    ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal(['component', 'primary', 'large']);
-});
-
-it('sets the size attribute to "large"', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button size="large">Button</glide-core-button>
-  `);
-
-  expect(component.size).to.equal('large');
-
-  expect([
-    ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal(['component', 'primary', 'large']);
-});
-
-it('sets the size attribute to "small"', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button size="small">Button</glide-core-button>
-  `);
-
-  expect(component.size).to.equal('small');
-
-  expect([
-    ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal(['component', 'primary', 'small']);
-});
-
-it('sets the disabled attribute', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button disabled>Button</glide-core-button>
-  `);
-
-  expect(component.disabled).to.equal(true);
-
-  expect(component.shadowRoot!.querySelector('button')?.disabled).to.equal(
-    true,
-  );
-});
-
-it('sets the type attribute to "submit"', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button type="submit">Button</glide-core-button>
-  `);
-
-  expect(component.type).to.equal('submit');
-
-  expect(
-    component.shadowRoot!.querySelector('button')?.getAttribute('type'),
-  ).to.equal('submit');
-});
-
-it('sets the type attribute to "reset"', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button type="reset">Button</glide-core-button>
-  `);
-
-  expect(component.type).to.equal('reset');
-
-  expect(
-    component.shadowRoot?.querySelector('button')?.getAttribute('type'),
-  ).to.equal('reset');
-});
-
-it('renders with a prefix slot', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button>
-      <span slot="prefix" data-prefix>prefix</span>
-      Button
-    </glide-core-button>
-  `);
-
-  expect([
-    ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal(['component', 'primary', 'large', 'has-prefix']);
-
-  expect(document.querySelector('[data-prefix]')).to.be.ok;
-});
-
-it('renders with a suffix slot', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button>
-      Button
-      <span slot="suffix" data-suffix>suffix</span>
-    </glide-core-button>
-  `);
-
-  expect([
-    ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal(['component', 'primary', 'large', 'has-suffix']);
-
-  expect(document.querySelector('[data-suffix]')).to.be.ok;
-});
-
-it('renders with a prefix and suffix slot when both are present initially', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button>
-      <span slot="prefix" data-prefix>prefix</span>
-      Button
-      <span slot="suffix" data-suffix>suffix</span>
-    </glide-core-button>
-  `);
-
-  expect([
-    ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal([
-    'component',
-    'primary',
-    'large',
-    'has-prefix',
-    'has-suffix',
-  ]);
-
-  expect(document.querySelector('[data-prefix]')).to.be.ok;
-  expect(document.querySelector('[data-suffix]')).to.be.ok;
-});
-
-it('renders with prefix and suffix classes when both are dynamically added', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button>Button</glide-core-button>
-  `);
-
-  const prefix = document.createElement('span');
-  prefix.setAttribute('slot', 'prefix');
-  prefix.dataset.prefix = undefined;
-  prefix.textContent = 'prefix';
-  component.append(prefix);
-
-  const suffix = document.createElement('span');
-  suffix.setAttribute('slot', 'suffix');
-  prefix.dataset.suffix = undefined;
-  suffix.textContent = 'suffix';
-  component.append(suffix);
-
-  await elementUpdated(component);
-
-  expect([
-    ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal([
-    'component',
-    'primary',
-    'large',
-    'has-prefix',
-    'has-suffix',
-  ]);
-
-  expect(document.querySelector('[data-prefix]')).to.be.ok;
-  expect(document.querySelector('[data-suffix]')).to.be.ok;
-});
-
-it('renders without prefix and suffix classes after both are removed', async () => {
-  const component = await fixture<GlideCoreButton>(html`
-    <glide-core-button>
-      <span slot="prefix">prefix</span>
-      Button
-      <span slot="suffix">suffix</span>
-    </glide-core-button>
-  `);
-
-  component.querySelector('[slot="prefix"]')?.remove();
-  component.querySelector('[slot="suffix"]')?.remove();
-  await elementUpdated(component);
-
-  expect([
-    ...component.shadowRoot!.querySelector('button')!.classList,
-  ]).to.deep.equal(['component', 'primary', 'large']);
 });
 
 it('throws if it does not have a default slot', async () => {
@@ -271,4 +91,22 @@ it('throws if it does not have a default slot', async () => {
   }
 
   expect(spy.callCount).to.equal(1);
+});
+
+it('`#onPrefixSlotChange` coverage', async () => {
+  await fixture<GlideCoreButton>(html`
+    <glide-core-button>
+      <span slot="prefix">Prefix</span>
+      Button
+    </glide-core-button>
+  `);
+});
+
+it('`#onSuffixSlotChange` coverage', async () => {
+  await fixture<GlideCoreButton>(html`
+    <glide-core-button>
+      Button
+      <span slot="suffix">Suffix</span>
+    </glide-core-button>
+  `);
 });

--- a/src/button.ts
+++ b/src/button.ts
@@ -49,15 +49,51 @@ export default class GlideCoreButton extends LitElement {
   @property({ attribute: 'aria-controls', reflect: true })
   ariaControls: string | null = null;
 
+  @property({ type: Boolean, reflect: true }) override autofocus = false;
+
   @property({ type: Boolean, reflect: true }) disabled = false;
 
-  @property() type: 'button' | 'submit' | 'reset' = 'button';
+  @property({ attribute: 'formaction', reflect: true }) formAction = '';
 
-  @property({ reflect: true })
-  variant: 'primary' | 'secondary' | 'tertiary' = 'primary';
+  @property({ attribute: 'formenctype', reflect: true }) formEncType:
+    | ''
+    | 'application/x-www-form-urlencoded'
+    | 'multipart/form-data'
+    | 'text/plain' = '';
+
+  @property({ attribute: 'formmethod', reflect: true }) formMethod:
+    | ''
+    | 'dialog'
+    | 'get'
+    | 'post' = '';
+
+  @property({ attribute: 'formnovalidate', type: Boolean, reflect: true })
+  formNoValidate = false;
+
+  @property({ attribute: 'formtarget', reflect: true }) formTarget:
+    | ''
+    | '_blank'
+    | '_parent'
+    | '_self'
+    | '_top' = '';
+
+  @property({ reflect: true }) name = '';
+
+  @property({ attribute: 'popovertarget', reflect: true })
+  popoverTarget?: string;
+
+  @property({ attribute: 'popovertargetaction', reflect: true })
+  popoverTargetAction: '' | 'hide' | 'show' | 'toggle' = '';
 
   @property({ reflect: true })
   size: 'large' | 'small' = 'large';
+
+  @property({ reflect: true }) type: 'button' | 'submit' | 'reset' = 'button';
+
+  @property({ reflect: true }) value = '';
+
+  @property({ reflect: true })
+  variant: 'primary' | 'secondary' | 'tertiary' = 'primary';
 
   get form() {
     return this.#internals.form;
@@ -76,6 +112,7 @@ export default class GlideCoreButton extends LitElement {
       aria-controls=${ifDefined(this.ariaControls ?? undefined)}
       aria-expanded=${ifDefined(this.ariaExpanded ?? undefined)}
       aria-haspopup=${ifDefined(this.ariaHasPopup ?? undefined)}
+      ?autofocus=${this.autofocus}
       class=${classMap({
         component: true,
         primary: this.variant === 'primary',
@@ -86,7 +123,6 @@ export default class GlideCoreButton extends LitElement {
         'has-prefix': this.hasPrefixSlot,
         'has-suffix': this.hasSuffixSlot,
       })}
-      type=${this.type}
       ?disabled=${this.disabled}
       @click=${this.#onClick}
       ${ref(this.#buttonElementRef)}
@@ -149,15 +185,11 @@ export default class GlideCoreButton extends LitElement {
 
   #onPrefixSlotChange() {
     const assignedNodes = this.#prefixSlotElementRef.value?.assignedNodes();
-
-    this.hasPrefixSlot =
-      assignedNodes && assignedNodes.length > 0 ? true : false;
+    this.hasPrefixSlot = Boolean(assignedNodes && assignedNodes.length > 0);
   }
 
   #onSuffixSlotChange() {
     const assignedNodes = this.#suffixSlotElementRef.value?.assignedNodes();
-
-    this.hasSuffixSlot =
-      assignedNodes && assignedNodes.length > 0 ? true : false;
+    this.hasSuffixSlot = Boolean(assignedNodes && assignedNodes.length > 0);
   }
 }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- Button now supports the full set of native `<button>` attributes such as `formenctype`, `name`, and `popovertarget`.
- Button's `type` attribute is now reflected.
- Cleaned up a bunch of tests.

The first change will need to be brought to every form control. It's tedious work. But there's no rush. So I'll take it one component at a time as time permits. Feel free to help!

<hr>

As an aside—we normally don't expose attributes we don't know are needed. But we have a conflicting value in wanting to align with native. 

As with `this.form` and `this.willValidate` and similar, which likewise no consumer has presented a case for, we've established (consciously or not) that when these two values conflict, we defer to the latter value and add and expose attributes and properties to match native. At least that's my rationale for adding these attributes.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

Just have a poke around Storybook and make sure everything I added to Button is covered and typed correctly, and that the story's controls look good.

## 📸 Images/Videos of Functionality

N/A
