### PR TITLE
Visual improvements to Dropdown when "quiet"

### DIFF
--- a/.changeset/violet-scissors-hope.md
+++ b/.changeset/violet-scissors-hope.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- The height of Dropdown when `variant="quiet"` has been greatly reduced.
+- Dropdown no longer has a focus outline on focus. Its border color changes instead.

--- a/src/button.stories.ts
+++ b/src/button.stories.ts
@@ -45,7 +45,7 @@ const meta: Meta = {
       },
     },
     disabled: {
-      control: { type: 'boolean' },
+      control: 'boolean',
     },
     size: {
       control: { type: 'radio' },
@@ -89,7 +89,6 @@ export const PrimaryWithPrefixIcon: StoryObj = {
   args: {
     variant: 'primary',
   },
-
   name: 'Primary (With Prefix Icon)',
   render: (arguments_) => html`
     <script type="ignore">

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -1,13 +1,9 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
 import menuOpeningAnimation from './styles/menu-opening-animation.js';
 import visuallyHidden from './styles/visually-hidden.js';
 
 export default [
   css`
-    ${focusOutline(
-      '.dropdown:has(.button:focus-visible, .input:focus-visible)',
-    )}
     ${menuOpeningAnimation('.options:popover-open')}
     ${visuallyHidden('.selected-option-labels')}
   `,
@@ -48,7 +44,9 @@ export default [
 
       &.quiet:not(.multiple) {
         background-color: transparent;
-        border: unset;
+        block-size: 1.5rem;
+        border-color: transparent;
+        border-radius: var(--glide-core-border-radius-round);
         font-size: var(--glide-core-heading-xxxs-font-size);
         font-style: var(--glide-core-heading-xxxs-font-style);
         font-weight: var(--glide-core-heading-xxxs-font-weight);
@@ -74,12 +72,31 @@ export default [
         padding-inline-start: 0;
       }
 
-      &:hover:not(&.error, &.disabled, &.readonly) {
+      &.quiet {
+        &:is(:hover, :has(.button:focus-visible, .input:focus-visible)):not(
+            &.error,
+            &.disabled,
+            &.multiple,
+            &.readonly
+          ) {
+          background-color: var(--glide-core-surface-hover);
+          color: var(--glide-core-text-body-1);
+        }
+      }
+
+      &:is(:hover, :has(.button:focus-visible, .input:focus-visible)):not(
+          &.disabled,
+          &.error,
+          &.quiet,
+          &.readonly
+        ) {
         border-color: var(--glide-core-border-focus);
       }
 
-      &.quiet:hover:not(&.error, &.disabled, &.multiple, &.readonly) {
-        background-color: var(--glide-core-surface-hover);
+      &:has(.button:focus-visible, .input:focus-visible) {
+        &.quiet {
+          border-color: var(--glide-core-border-focus);
+        }
       }
     }
 
@@ -121,6 +138,16 @@ export default [
 
     .placeholder {
       color: var(--glide-core-text-placeholder);
+
+      &.quiet {
+        &:not(.disabled) {
+          color: var(--glide-core-text-body-1);
+        }
+      }
+
+      &.disabled {
+        color: var(--glide-core-text-tertiary-disabled);
+      }
     }
 
     .tags {
@@ -179,13 +206,6 @@ export default [
 
       &::placeholder {
         font-family: var(--glide-core-font-sans);
-      }
-    }
-
-    .caret-icon {
-      &.disabled,
-      &.readonly {
-        color: var(--glide-core-surface-selected-disabled);
       }
     }
   `,

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -230,7 +230,14 @@ export default class GlideCoreDropdown extends LitElement {
 
   private get internalLabel() {
     return !this.isFilterable && this.selectedOptions.length === 0
-      ? html`<span class="placeholder">${this.placeholder}</span>`
+      ? html`<span
+          class=${classMap({
+            placeholder: true,
+            disabled: this.disabled,
+            quiet: this.variant === 'quiet',
+          })}
+          >${this.placeholder}</span
+        >`
       : !this.multiple &&
           !this.isFilterable &&
           this.selectedOptions.at(-1)?.label
@@ -545,11 +552,6 @@ export default class GlideCoreDropdown extends LitElement {
                   () => {
                     return html`<svg
                       aria-label=${this.#localize.term('open')}
-                      class=${classMap({
-                        'caret-icon': true,
-                        disabled: this.disabled,
-                        readonly: this.readonly,
-                      })}
                       width="16"
                       height="16"
                       viewBox="0 0 24 24"


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- The height of Dropdown when `variant="quiet"` has been greatly reduced.
- Dropdown no longer has an outline on focus. Its border color changes instead.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to Dropdown in Storybook.
2. Tab to Dropdown.
3. Verify that its focus outline is gone and that its border color changes.

<br>

1. Navigate to Dropdown in Storybook.
2. Change to the "quiet" variant.
3. Hover Dropdown.
5. Verify that Dropdown is a lot shorter.

## 📸 Images/Videos of Functionality

## `variant=""` when focused

### Before

<img width="231" alt="image" src="https://github.com/user-attachments/assets/9144cd3b-9e09-4cd6-a7fd-df633e711384">




### After

<img width="225" alt="image" src="https://github.com/user-attachments/assets/8b9c00fb-ca80-4ae4-a7ab-353a4036ded7">




## `variant="quiet"` on hover

### Before

<img width="180" alt="image" src="https://github.com/user-attachments/assets/e059daf5-f414-4710-96e1-db319fd10efd">



### After

<img width="189" alt="image" src="https://github.com/user-attachments/assets/9478f038-67fa-4365-8d2f-c91ef264507d">

## `variant="quiet"` when focused

### Before

<img width="186" alt="image" src="https://github.com/user-attachments/assets/b5d761ea-1665-4c89-9af3-34426ec29af8">



### After

<img width="186" alt="image" src="https://github.com/user-attachments/assets/fd9c12fc-ba40-45ed-8b55-7aff6fe07d18">


