### PR TITLE
Add subtle transitions to components

### DIFF
--- a/.changeset/tame-students-complain.md
+++ b/.changeset/tame-students-complain.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Subtle hover transitions were added to Dropdown, Dropdown Option, Menu Button, Menu Link, and Tree components.

--- a/src/dropdown.option.styles.ts
+++ b/src/dropdown.option.styles.ts
@@ -7,6 +7,7 @@ export default [
       block-size: var(--private-option-height);
       border-radius: var(--glide-core-spacing-sm);
       max-inline-size: 21.875rem;
+      transition: background-color 100ms ease-in-out;
       user-select: none;
 
       &.active {

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -43,6 +43,9 @@ export default [
       min-inline-size: var(--min-inline-size);
       padding-inline: var(--glide-core-spacing-sm);
       text-align: start;
+      transition:
+        background-color 200ms ease-in-out,
+        border-color 200ms ease-in-out;
       user-select: none;
       white-space: nowrap;
 

--- a/src/menu.button.styles.ts
+++ b/src/menu.button.styles.ts
@@ -14,6 +14,7 @@ export default [
       inline-size: 100%;
       padding-block: var(--padding-block);
       padding-inline: var(--padding-inline);
+      transition: background-color 100ms ease-in-out;
       user-select: none;
 
       &.active {

--- a/src/menu.link.styles.ts
+++ b/src/menu.link.styles.ts
@@ -16,6 +16,7 @@ export default [
       padding-block: var(--padding-block);
       padding-inline: var(--padding-inline);
       text-decoration: none;
+      transition: background-color 100ms ease-in-out;
       user-select: none;
 
       &.active {

--- a/src/tree.item.styles.ts
+++ b/src/tree.item.styles.ts
@@ -57,6 +57,7 @@ export default [
       font-size: var(--glide-core-body-sm-font-size);
       padding-block: var(--glide-core-spacing-xxs);
       padding-inline: var(--glide-core-spacing-xs);
+      transition: background-color 150ms ease-in-out;
 
       &:hover {
         background-color: var(--glide-core-surface-hover);


### PR DESCRIPTION
## 🚀 Description

Subtle hover transitions were added to Dropdown, Dropdown Option, Menu Button, Menu Link, and Tree components.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

### Dropdown

- Visit https://glide-core.crowdstrike-ux.workers.dev/add-transitions?path=/docs/dropdown--overview
- Verify nothing broke with Dropdown

### Menu

- Visit https://glide-core.crowdstrike-ux.workers.dev/add-transitions?path=/docs/menu--overview
- Verify nothing broke with Menu

### Tree

- Visit https://glide-core.crowdstrike-ux.workers.dev/add-transitions?path=/docs/tree--overview
- Verify nothing broke with Tree

## 📸 Images/Videos of Functionality

N/A
