### PR TITLE
Set resize: none on Textarea when readonly

### DIFF
--- a/.changeset/hip-pumas-yell.md
+++ b/.changeset/hip-pumas-yell.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Textarea's resize handle was removed when the component is in the readonly state to align with the latest designs.

--- a/src/textarea.styles.ts
+++ b/src/textarea.styles.ts
@@ -71,6 +71,7 @@ export default [
       &[readonly] {
         border-color: transparent;
         outline: none;
+        resize: none;
         transition: none;
       }
 


### PR DESCRIPTION
## 🚀 Description

Textarea's resize handle was removed when the component is in the readonly state to align with the latest designs.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

- Go to https://glide-core.crowdstrike-ux.workers.dev/textarea-readonly-resize-none?path=/docs/textarea--overview
- Set the Textarea to `readonly`
- Make sure it looks like the picture below

## 📸 Images/Videos of Functionality

### Before

<img width="1002" alt="Screenshot 2024-09-03 at 7 49 03 PM" src="https://github.com/user-attachments/assets/0c3a826e-7245-4847-aca5-816700a88f03">

### After

<img width="1001" alt="Screenshot 2024-09-03 at 7 48 39 PM" src="https://github.com/user-attachments/assets/b5dfebdb-bcb5-47bb-9f22-ebc1d8a6444d">

