### PR TITLE
Toast story buttons shouldn't be full width

### DIFF
--- a/src/toasts.stories.ts
+++ b/src/toasts.stories.ts
@@ -37,7 +37,7 @@ const meta: Meta = {
 -->
       <glide-core-toasts></glide-core-toasts>
 
-      <div style="display:flex; flex-direction: column; gap: 0.25rem;">
+      <div style="display: inline-flex; flex-direction: column; gap: 0.25rem;">
         <glide-core-button data-informational>
           Informational
         </glide-core-button>


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

The buttons in Toast's story are full width and so the empty space to the right of each button creates a toast when clicked. This is because the story's containing `<div>` has `display: flex` instead of `display: inline-flex`.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

1. Navigate to the Toasts story.
2. Click the empty space to the right of one of the buttons.
3. Verify that a toast isn't shown.

## 📸 Images/Videos of Functionality

## Before 

<img width="1040" alt="image" src="https://github.com/user-attachments/assets/ef4f26de-a115-4781-aec7-1adf6c4efb4b">


## After

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/336372f5-e8a5-4346-9e27-6c6dcf547fd2">
