### PR TITLE
Reduce the weight Dropdown's button font when `variant="quiet"`

### DIFF
--- a/.changeset/chatty-suits-yawn.md
+++ b/.changeset/chatty-suits-yawn.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+The weight of Dropdown's button font is no longer bold when `variant="quiet"`.

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -50,9 +50,6 @@ export default [
         block-size: 1.5rem;
         border-color: transparent;
         border-radius: var(--glide-core-border-radius-round);
-        font-size: var(--glide-core-heading-xxxs-font-size);
-        font-style: var(--glide-core-heading-xxxs-font-style);
-        font-weight: var(--glide-core-heading-xxxs-font-weight);
         gap: var(--glide-core-spacing-xxs);
         min-inline-size: 3.75rem;
         padding-block: 0;


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

You know what to do!

## 📸 Images/Videos of Functionality

## Before

<img width="189" alt="image" src="https://github.com/user-attachments/assets/895086d7-91f9-41cc-a0db-463c4beef360">


## After

<img width="181" alt="image" src="https://github.com/user-attachments/assets/37c19ed0-be77-4223-be85-8f2e9cd9382f">

