### PR TITLE
Update Dropdown and Menu animations to align with Tooltip

### DIFF
--- a/.changeset/hot-wasps-thank.md
+++ b/.changeset/hot-wasps-thank.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Updated Dropdown and Menu open animations to align with Tooltip.

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -1,10 +1,10 @@
 import { css } from 'lit';
-import menuOpeningAnimation from './styles/menu-opening-animation.js';
+import opacityAndScaleAnimation from './styles/opacity-and-scale-animation.js';
 import visuallyHidden from './styles/visually-hidden.js';
 
 export default [
   css`
-    ${menuOpeningAnimation('.options:popover-open')}
+    ${opacityAndScaleAnimation('.options:popover-open')}
     ${visuallyHidden('.selected-option-labels')}
   `,
   css`

--- a/src/menu.styles.ts
+++ b/src/menu.styles.ts
@@ -1,9 +1,9 @@
 import { css } from 'lit';
-import menuOpeningAnimation from './styles/menu-opening-animation.js';
+import opacityAndScaleAnimation from './styles/opacity-and-scale-animation.js';
 
 export default [
   css`
-    ${menuOpeningAnimation('.default-slot:popover-open')}
+    ${opacityAndScaleAnimation('.default-slot:popover-open')}
   `,
   css`
     :host {

--- a/src/styles/opacity-and-scale-animation.ts
+++ b/src/styles/opacity-and-scale-animation.ts
@@ -3,22 +3,20 @@ import { css, unsafeCSS } from 'lit';
 export default (selector: string) => {
   return css`
     /* stylelint-disable selector-type-case, selector-type-no-unknown */
-    @keyframes menu-opening {
+    @keyframes opacity-and-scale {
       from {
         opacity: 0;
-        transform: scaleY(0);
-        transform-origin: 0% 0%;
+        transform: scale(0.95);
       }
 
       to {
         opacity: 1;
-        transform: scaleY(1);
-        transform-origin: 0% 0%;
+        transform: scale(1);
       }
     }
 
     ${unsafeCSS(selector)} {
-      animation: menu-opening 150ms cubic-bezier(0.25, 0, 0.3, 1);
+      animation: opacity-and-scale 250ms cubic-bezier(0.25, 0, 0.3, 1);
     }
 
     @media (prefers-reduced-motion: reduce) {

--- a/src/tooltip.styles.ts
+++ b/src/tooltip.styles.ts
@@ -1,29 +1,13 @@
 import { css } from 'lit';
 import focusOutline from './styles/focus-outline.js';
+import opacityAndScaleAnimation from './styles/opacity-and-scale-animation.js';
 
 export default [
   css`
+    ${opacityAndScaleAnimation('.tooltip:popover-open')}
     ${focusOutline('.target:focus-visible')}
   `,
   css`
-    @keyframes opacity-and-scale {
-      from {
-        opacity: 0;
-        transform: scale(0.95);
-      }
-
-      to {
-        opacity: 1;
-        transform: scale(1);
-      }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      .tooltip:popover-open {
-        animation: none !important;
-      }
-    }
-
     :host {
       display: inline-block;
     }
@@ -77,7 +61,6 @@ export default [
       }
 
       &:popover-open {
-        animation: opacity-and-scale 250ms cubic-bezier(0.25, 0, 0.3, 1);
         display: flex;
 
         /*


### PR DESCRIPTION
## 🚀 Description

Dropdown and Menu animations are busted when the popover is at the top rather than the bottom. This makes the animation the same as Tooltip, as approved by design

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have read and followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have created or updated stories in Storybook to document the new functionality.
- I have included a changeset with this Pull Request if it adds/updates/removes functionality for consumers.
- I have scheduled a Design Review for these changes, if one is required.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) and/or met with the Accessibility Team to ensure this functionality is accessible.

## 🔬 How to Test

### Menu

- Go to https://glide-core.crowdstrike-ux.workers.dev/dropdown-and-menu-animation-fix?path=/docs/menu--overview
- Verify the menu animation plays.
- Verify switching the placement to `top-end` or anywhere else isn't busted.

### Dropdown

- Go to https://glide-core.crowdstrike-ux.workers.dev/dropdown-and-menu-animation-fix?path=/docs/dropdown--overview
- Verify the dropdown animation plays.
- Resize the browser window so that the popover appears on the top of the dropdown rather than the bottom, and verify it doesn't look terrible.

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
