### PR TITLE
fix(tab-group): Consolidate active tab indicator logic

### DIFF
--- a/.changeset/friendly-foxes-train.md
+++ b/.changeset/friendly-foxes-train.md
@@ -1,5 +1,0 @@
----
-'@crowdstrike/glide-core': patch
----
-
-Consolidation of `glide-core-tab-group` active tab indicator calculations


### PR DESCRIPTION
- Consolidates duplicated logic and removes `setupActiveTabIndicator`

Storybook: https://glide-core.crowdstrike-ux.workers.dev/tabs-active-tab-changes?path=/docs/tabs--overview