### PR TITLE
Update dropdown's placeholder color

### DIFF
--- a/.changeset/brave-dolphins-search.md
+++ b/.changeset/brave-dolphins-search.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Updated Dropdown's placeholder color to align with Input and Textarea. This is improves Dark Mode support.

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -137,7 +137,12 @@ export default [
     }
 
     .placeholder {
-      color: var(--glide-core-text-placeholder);
+      /*
+        Using the browser's default placeholder color for now, as
+        '--glide-core-text-placeholder' has dark mode issues. Aligns
+        with Input and Textarea as suggested by design.
+      */
+      color: rgb(117 117 117);
 
       &.quiet {
         &:not(.disabled) {


### PR DESCRIPTION
## 🚀 Description

Updated Dropdown's placeholder color to align with Input and Textarea. This is improves Dark Mode support.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

- View [Dropdown's story](https://glide-core.crowdstrike-ux.workers.dev/dropdown-placeholder-fix?path=/docs/dropdown--overview)
- Verify the placeholder text color matches Input and Textarea in both Light and Dark modes

## 📸 Images/Videos of Functionality

| Before  | After |
| ------------- | ------------- |
| <img width="219" alt="Screenshot 2024-09-10 at 3 05 00 PM" src="https://github.com/user-attachments/assets/96b80deb-bf9b-4f96-8f54-f2ecceac0030">  | <img width="219" alt="Screenshot 2024-09-10 at 3 05 21 PM" src="https://github.com/user-attachments/assets/aea7be9e-2517-4cc6-9b3a-c5a64363f308">  |




