### PR TITLE
Fixed an issue with Tooltip content not wrapping

### DIFF
--- a/.changeset/eleven-years-live.md
+++ b/.changeset/eleven-years-live.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Tooltip now inserts line breaks into long strings to allow wrapping and prevent overflow.

--- a/src/tooltip.styles.ts
+++ b/src/tooltip.styles.ts
@@ -126,7 +126,7 @@ export default [
       inline-size: max-content;
       inset-block-start: 50%;
       max-inline-size: 11.25rem;
-      overflow-wrap: break-word;
+      overflow-wrap: anywhere;
       padding: var(--glide-core-spacing-xs) var(--glide-core-spacing-sm);
     }
   `,


### PR DESCRIPTION
## 🚀 Description

Fixed an issue with Tooltip content not wrapping.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

- Go to [Tooltip's story](https://glide-core.crowdstrike-ux.workers.dev/tooltip-wrap-fix)
- Set the text to `TooltipTooltipTooltipTooltipTooltipTooltipTooltip` or something really long
- Verify the word break kicks in and it wraps

## 📸 Images/Videos of Functionality

| Before  | After |
| ------------- | ------------- |
| <img width="533" alt="Screenshot 2024-09-13 at 9 56 11 AM" src="https://github.com/user-attachments/assets/3c5411db-f32e-4a15-82eb-3d886a09d5e6">  | <img width="344" alt="Screenshot 2024-09-13 at 9 56 58 AM" src="https://github.com/user-attachments/assets/89a0771f-b3de-46a4-b13d-e5dd528aad38">  |




