### PR TITLE
Added no-space-press lint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,7 @@ export default [
       '@crowdstrike/glide-core/no-redundant-property-attribute': 'error',
       '@crowdstrike/glide-core/no-redundant-property-string-type': 'error',
       '@crowdstrike/glide-core/no-skip-tests': 'error',
+      '@crowdstrike/glide-core/no-space-press': 'error',
       '@crowdstrike/glide-core/no-to-have-attribute': 'error',
       '@crowdstrike/glide-core/prefer-closed-shadow-root': 'error',
       '@crowdstrike/glide-core/prefixed-lit-element-class-declaration': 'error',

--- a/src/button-group.test.events.ts
+++ b/src/button-group.test.events.ts
@@ -212,7 +212,7 @@ it('emits a "change" event when a button is selected via Space', async () => {
   const buttons = document.querySelectorAll('glide-core-button-group-button');
   buttons[1]?.focus();
 
-  sendKeys({ press: 'Space' });
+  sendKeys({ press: ' ' });
   const event = await oneEvent(component, 'input');
 
   expect(event instanceof Event).to.be.true;
@@ -265,7 +265,7 @@ it('does not emit a "change" event when an already selected button is selected v
   const spy = sinon.spy();
   component.addEventListener('change', spy);
 
-  sendKeys({ press: 'Space' });
+  sendKeys({ press: ' ' });
   expect(spy.callCount).to.equal(0);
 });
 

--- a/src/button-group.test.interactions.ts
+++ b/src/button-group.test.interactions.ts
@@ -89,7 +89,7 @@ it('selects a button on Space', async () => {
   const buttons = document.querySelectorAll('glide-core-button-group-button');
   buttons[1]?.focus();
 
-  await sendKeys({ press: 'Space' });
+  await sendKeys({ press: ' ' });
 
   expect(buttons[0].selected).to.be.false;
   expect(buttons[1].selected).to.be.true;

--- a/src/eslint/plugin.ts
+++ b/src/eslint/plugin.ts
@@ -5,6 +5,7 @@ import { noPrefixedEventName } from './rules/no-glide-core-prefixed-event-name.j
 import { noRedudantPropertyAttribute } from './rules/no-redundant-property-attribute.js';
 import { noRedudantPropertyStringType } from './rules/no-redundant-property-string-type.js';
 import { noSkipTests } from './rules/no-skip-tests.js';
+import { noSpacePress } from './rules/no-space-press.js';
 import { noToHaveAttribute } from './rules/no-to-have-attribute.js';
 import { preferClosedShadowRoot } from './rules/prefer-closed-shadow-root.js';
 import { prefixedClassDeclaration } from './rules/prefixed-lit-element-class-declaration.js';
@@ -18,6 +19,7 @@ const rules = {
   'no-redundant-property-attribute': noRedudantPropertyAttribute,
   'no-redundant-property-string-type': noRedudantPropertyStringType,
   'no-skip-tests': noSkipTests,
+  'no-space-press': noSpacePress,
   'no-to-have-attribute': noToHaveAttribute,
   'prefer-closed-shadow-root': preferClosedShadowRoot,
   'prefixed-lit-element-class-declaration': prefixedClassDeclaration,

--- a/src/eslint/rules/no-space-press.test.ts
+++ b/src/eslint/rules/no-space-press.test.ts
@@ -1,0 +1,66 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noSpacePress } from './no-space-press.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-space-press', noSpacePress, {
+  valid: [
+    {
+      code: "await sendKeys({ down: 'Shift' })",
+    },
+    {
+      code: "await sendKeys({ press: 'Shift' })",
+    },
+    {
+      code: "await sendKeys({ up: 'Shift' })",
+    },
+    {
+      code: "some.nested.key.thing === 'Space'",
+    },
+    {
+      code: "some.nested.key.thing === ' '",
+    },
+  ],
+  invalid: [
+    {
+      code: "sendKeys({ down: 'Space' });",
+      output: "sendKeys({ down: ' ' });",
+      errors: [{ messageId: 'preferWhitespace' }],
+    },
+    {
+      code: "await sendKeys({ down: 'Space' });",
+      output: "await sendKeys({ down: ' ' });",
+      errors: [{ messageId: 'preferWhitespace' }],
+    },
+    {
+      code: "sendKeys({ press: 'Space' });",
+      output: "sendKeys({ press: ' ' });",
+      errors: [{ messageId: 'preferWhitespace' }],
+    },
+    {
+      code: "await sendKeys({ press: 'Space' });",
+      output: "await sendKeys({ press: ' ' });",
+      errors: [{ messageId: 'preferWhitespace' }],
+    },
+    {
+      code: "sendKeys({ up: 'Space' });",
+      output: "sendKeys({ up: ' ' });",
+      errors: [{ messageId: 'preferWhitespace' }],
+    },
+    {
+      code: "await sendKeys({ up: 'Space' });",
+      output: "await sendKeys({ up: ' ' });",
+      errors: [{ messageId: 'preferWhitespace' }],
+    },
+    {
+      code: "event.key === 'Space'",
+      output: "event.key === ' '",
+      errors: [{ messageId: 'preferWhitespace' }],
+    },
+    {
+      code: "event.key !== 'Space'",
+      output: "event.key !== ' '",
+      errors: [{ messageId: 'preferWhitespace' }],
+    },
+  ],
+});

--- a/src/eslint/rules/no-space-press.ts
+++ b/src/eslint/rules/no-space-press.ts
@@ -1,0 +1,82 @@
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+
+// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
+const createRule = ESLintUtils.RuleCreator<{
+  recommended: boolean;
+}>(
+  (name) =>
+    `https://github.com/CrowdStrike/glide-core/blob/main/packages/eslint-plugin/src/rules/${name}.ts`,
+);
+
+export const noSpacePress = createRule({
+  name: 'no-space-press',
+  meta: {
+    docs: {
+      description:
+        'Prefer using " " over "Space" when checking keys to align with the native key value. In application code, checking `event.key === "Space"` is incorrect, as " " is what key will be in this case. https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#whitespace_keys',
+      recommended: true,
+    },
+    type: 'suggestion',
+    messages: {
+      preferWhitespace: 'Prefer using " " for the Space Bar key.',
+    },
+    schema: [],
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create: (context) => {
+    return {
+      BinaryExpression(node) {
+        if (
+          (node.operator === '===' || node.operator === '!==') &&
+          node.left.type === AST_NODE_TYPES.MemberExpression &&
+          node.left.object.type === AST_NODE_TYPES.Identifier &&
+          node.left.property.type === AST_NODE_TYPES.Identifier &&
+          node.left.property.name === 'key' &&
+          node.right.type === AST_NODE_TYPES.Literal &&
+          node.right.value === 'Space'
+        ) {
+          context.report({
+            node,
+            messageId: 'preferWhitespace',
+            fix: function (fixer) {
+              return fixer.replaceText(node.right, "' '");
+            },
+          });
+        }
+      },
+      CallExpression(node) {
+        if (
+          node.callee &&
+          node.callee.type === AST_NODE_TYPES.Identifier &&
+          node.callee.name === 'sendKeys' &&
+          node.arguments.length === 1
+        ) {
+          const argument = node.arguments.at(0);
+
+          if (argument?.type === AST_NODE_TYPES.ObjectExpression) {
+            for (const property of argument.properties) {
+              if (
+                property.type === AST_NODE_TYPES.Property &&
+                property.key.type === AST_NODE_TYPES.Identifier &&
+                (property.key.name === 'press' ||
+                  property.key.name === 'down' ||
+                  property.key.name === 'up') &&
+                property.value.type === AST_NODE_TYPES.Literal &&
+                property.value.value === 'Space'
+              ) {
+                context.report({
+                  node: property,
+                  messageId: 'preferWhitespace',
+                  fix: function (fixer) {
+                    return fixer.replaceText(property.value, "' '");
+                  },
+                });
+              }
+            }
+          }
+        }
+      },
+    };
+  },
+});

--- a/src/menu.test.events.ts
+++ b/src/menu.test.events.ts
@@ -80,7 +80,7 @@ it('dispatches one link "click" event when a link is selected via Space', async 
 
   link.addEventListener('click', spy);
   component.focus();
-  sendKeys({ press: 'Space' });
+  sendKeys({ press: ' ' });
 
   const event = await oneEvent(link, 'click');
 
@@ -108,7 +108,7 @@ it('dispatches one button "click" event when a button is selected via Space', as
 
   button.addEventListener('click', spy);
   component.focus();
-  sendKeys({ press: 'Space' });
+  sendKeys({ press: ' ' });
 
   const event = await oneEvent(button, 'click');
 


### PR DESCRIPTION
## 🚀 Description

Initially wanted to use `Space` instead, but after realizing `event.key === 'Space'` is not the same as `event.key === ' '` (https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#whitespace_keys), it makes sense to go the opposite direction and be less explicit, but matching closer to native / what we'd write in code directly.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

```bash
glide-core/src/button-group.test.events.ts
  215:14  error  Prefer using " " for the Space Bar key  @crowdstrike/glide-core/prefer-whitespace-key
  268:14  error  Prefer using " " for the Space Bar key  @crowdstrike/glide-core/prefer-whitespace-key
```
