### PR TITLE
Enable eqeqeq lint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -109,6 +109,8 @@ export default [
         { exceptAfterSingleLine: false },
       ],
 
+      eqeqeq: 'error',
+
       // We work with the DOM enough that this rule also became tiresome.
       'unicorn/no-null': 'off',
 


### PR DESCRIPTION
## 🚀 Description

Another softball ESLint rule.  We're already using strict equality checks with `===`, so enabling [eqeqeq](https://eslint.org/docs/latest/rules/eqeqeq) seems like a no brainer to me.  There's also a [smart](https://eslint.org/docs/latest/rules/eqeqeq#smart) option, but I don't know that I see any real value of using it; however, no strong opinions.  What do y'all think?

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

```bash
glide-core/src/button-group.ts
  71:40  error  Expected '!==' and instead saw '!='  eqeqeq
```

```bash
glide-core/src/button-group.ts
  71:40  error  Expected '===' and instead saw '=='  eqeqeq
```
