### PR TITLE
Call `click()` on Menu's active option instead of dispatching "click"

### DIFF
--- a/.changeset/spotty-dodos-pull.md
+++ b/.changeset/spotty-dodos-pull.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Menu Link now navigates when selected via Space or Enter.

--- a/src/menu.link.ts
+++ b/src/menu.link.ts
@@ -1,5 +1,6 @@
 import { LitElement, html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
+import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { nanoid } from 'nanoid';
@@ -35,6 +36,10 @@ export default class GlideCoreMenuLink extends LitElement {
   // A link is considered active when it's interacted with via keyboard or hovered.
   privateActive = false;
 
+  override click() {
+    this.#anchorElementRef.value?.click();
+  }
+
   override connectedCallback() {
     super.connectedCallback();
 
@@ -61,11 +66,14 @@ export default class GlideCoreMenuLink extends LitElement {
       })}
       data-test="component"
       href=${ifDefined(this.url)}
+      ${ref(this.#anchorElementRef)}
     >
       <slot name="icon"></slot>
       ${this.label}
     </a>`;
   }
+
+  #anchorElementRef = createRef<HTMLAnchorElement>();
 
   // Established here instead of in `connectedCallback` so the ID remains
   // constant even if this component is removed and re-added to the DOM.

--- a/src/menu.stories.ts
+++ b/src/menu.stories.ts
@@ -83,15 +83,6 @@ const meta: Meta = {
     },
   },
   play(context) {
-    const links = context.canvasElement.querySelectorAll(
-      'glide-core-menu-link',
-    );
-
-    for (const link of links) {
-      // Prevent navigation. The URLs don't go anywhere.
-      link.addEventListener('click', (event) => event.preventDefault());
-    }
-
     // eslint-disable-next-line no-underscore-dangle
     let arguments_: Meta['args'] = context.args;
 
@@ -130,10 +121,8 @@ const meta: Meta = {
           <glide-core-button slot="target"> Target </glide-core-button>
 
           <glide-core-menu-options>
-            <glide-core-menu-link label="One" url="/one">
-            </glide-core-menu-link>
-            <glide-core-menu-link label="Two" url="/two">
-            </glide-core-menu-link>
+            <glide-core-menu-link label="One" url="/"> </glide-core-menu-link>
+            <glide-core-menu-link label="Two" url="/"> </glide-core-menu-link>
             <glide-core-menu-button label="Three"> </glide-core-menu-button>
           </glide-core-menu-options>
         </glide-core-menu>
@@ -181,28 +170,28 @@ export const WithIcons: StoryObj = {
           ?open=${arguments_.open}
         >
           <glide-core-menu-options>
-            <glide-core-menu-link label="Edit" url="/edit">
+            <glide-core-menu-link label="Edit" url="/">
               <glide-core-example-icon
                 slot="icon"
                 name="pencil"
               ></glide-core-example-icon>
             </glide-core-menu-link>
 
-            <glide-core-menu-link label="Move" url="/move">
+            <glide-core-menu-link label="Move" url="/">
               <glide-core-example-icon
                 slot="icon"
                 name="move"
               ></glide-core-example-icon>
             </glide-core-menu-link>
 
-            <glide-core-menu-link label="Share" url="/share">
+            <glide-core-menu-link label="Share" url="/">
               <glide-core-example-icon
                 slot="icon"
                 name="share"
               ></glide-core-example-icon>
             </glide-core-menu-link>
 
-            <glide-core-menu-link label="Settings" url="/settings">
+            <glide-core-menu-link label="Settings" url="/">
               <glide-core-example-icon
                 slot="icon"
                 name="settings"

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -177,7 +177,7 @@ export default class GlideCoreMenu extends LitElement {
 
   #cleanUpFloatingUi?: ReturnType<typeof autoUpdate>;
 
-  #componentElementRef = createRef<HTMLDivElement>();
+  #componentElementRef = createRef<HTMLElement>();
 
   #defaultSlotElementRef = createRef<HTMLSlotElement>();
 
@@ -316,9 +316,7 @@ export default class GlideCoreMenu extends LitElement {
       // now that Menu is closed.
       this.focus();
 
-      this.#activeOption?.dispatchEvent(
-        new PointerEvent('click', { bubbles: true }),
-      );
+      this.#activeOption?.click();
 
       // `#onTargetSlotClick` is called on click, and it opens or closes Menu.
       // Space and Enter produce "click" events. This property gives `#onTargetSlotClick`


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

I noticed while [working](https://github.com/CrowdStrike/glide-core/pull/361) on Split Button Container that Menu Links don't navigate on Space or Enter—only when clicked. This PR fixes that.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Menu in Storybook.
2. Open Menu.
3. Use Space or Enter to select a Menu Link.
4. Verify the link navigates.

## 📸 Images/Videos of Functionality

N/A
