### PR TITLE
Rename icon slots

### DIFF
--- a/.changeset/sixty-toes-share.md
+++ b/.changeset/sixty-toes-share.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+- Button's "prefix" and "suffix" slots have been renamed to "prefix-icon" and "suffix-icon".
+- Button Group Button's "prefix" slot has been renamed to "icon".

--- a/src/button-group.button.styles.ts
+++ b/src/button-group.button.styles.ts
@@ -76,7 +76,7 @@ export default [
       &.vertical {
         border-block-end: 1px solid var(--glide-core-border-base-lighter);
 
-        &.prefix {
+        &.icon {
           &:not(.icon-only) {
             justify-content: flex-start;
           }

--- a/src/button-group.button.test.basics.ts
+++ b/src/button-group.button.test.basics.ts
@@ -51,20 +51,6 @@ it('can have a label', async () => {
   expect(component.shadowRoot?.textContent?.trim()).to.equal('Button');
 });
 
-it('can have a "prefix" slot', async () => {
-  const component = await fixture(
-    html`<glide-core-button-group-button label="Button">
-      <span slot="prefix">Prefix</span>
-    </glide-core-button-group-button>`,
-  );
-
-  const assignedElements = component.shadowRoot
-    ?.querySelector<HTMLSlotElement>('slot[name="prefix"]')
-    ?.assignedElements();
-
-  expect(assignedElements?.at(0)?.textContent).to.equal('Prefix');
-});
-
 it('sets `aria-checked` when selected', async () => {
   const component = await fixture(
     html`<glide-core-button-group-button
@@ -134,7 +120,7 @@ it('is not tabbable when not selected', async () => {
   expect(radio?.getAttribute('tabindex')).to.equal('-1');
 });
 
-it('throws when icon-only and no "prefix" slot', async () => {
+it('throws when icon-only and no "icon" slot', async () => {
   const spy = sinon.spy();
 
   try {

--- a/src/button-group.button.ts
+++ b/src/button-group.button.ts
@@ -13,7 +13,7 @@ declare global {
 
 /**
  * @slot - A label.
- * @slot prefix - An optional icon before the label.
+ * @slot icon - An optional icon before the label.
  */
 @customElement('glide-core-button-group-button')
 export default class GlideCoreButtonGroupButton extends LitElement {
@@ -57,7 +57,7 @@ export default class GlideCoreButtonGroupButton extends LitElement {
 
   override firstUpdated() {
     if (this.privateVariant === 'icon-only') {
-      owSlot(this.#prefixSlotElementRef.value);
+      owSlot(this.#iconSlotElementRef.value);
     }
   }
 
@@ -74,7 +74,7 @@ export default class GlideCoreButtonGroupButton extends LitElement {
         selected: this.selected,
         disabled: this.disabled,
         [this.privateOrientation]: true,
-        prefix: this.hasPrefixSlot,
+        icon: this.hasIcon,
         'icon-only': this.privateVariant === 'icon-only',
       })}
       role="radio"
@@ -82,9 +82,9 @@ export default class GlideCoreButtonGroupButton extends LitElement {
       ${ref(this.#componentElementRef)}
     >
       <slot
-        name="prefix"
-        @slotchange=${this.#onPrefixSlotChange}
-        ${ref(this.#prefixSlotElementRef)}
+        name="icon"
+        @slotchange=${this.#onIconSlotChange}
+        ${ref(this.#iconSlotElementRef)}
       ></slot>
 
       <div
@@ -99,18 +99,17 @@ export default class GlideCoreButtonGroupButton extends LitElement {
   }
 
   @state()
-  private hasPrefixSlot = false;
+  private hasIcon = false;
 
   #componentElementRef = createRef<HTMLElement>();
 
+  #iconSlotElementRef = createRef<HTMLSlotElement>();
+
   #isSelected = false;
 
-  #prefixSlotElementRef = createRef<HTMLSlotElement>();
+  #onIconSlotChange() {
+    ow(this.#iconSlotElementRef.value, ow.object.instanceOf(HTMLElement));
 
-  #onPrefixSlotChange() {
-    ow(this.#prefixSlotElementRef.value, ow.object.instanceOf(HTMLElement));
-
-    this.hasPrefixSlot =
-      this.#prefixSlotElementRef.value?.assignedNodes().length > 0;
+    this.hasIcon = this.#iconSlotElementRef.value?.assignedNodes().length > 0;
   }
 }

--- a/src/button-group.stories.ts
+++ b/src/button-group.stories.ts
@@ -36,21 +36,21 @@ const meta: Meta = {
                 ]}
               >
                 <glide-core-example-icon
-                  slot="prefix"
+                  slot="icon"
                   name="info"
                 ></glide-core-example-icon>
               </glide-core-button-group-button>
 
               <glide-core-button-group-button label="Two">
                 <glide-core-example-icon
-                  slot="prefix"
+                  slot="icon"
                   name="info"
                 ></glide-core-example-icon>
               </glide-core-button-group-button>
 
               <glide-core-button-group-button label="Three">
                 <glide-core-example-icon
-                  slot="prefix"
+                  slot="icon"
                   name="info"
                 ></glide-core-example-icon>
               </glide-core-button-group-button>`;
@@ -91,6 +91,7 @@ const meta: Meta = {
     variant: '',
     '<glide-core-button-group-button>.disabled': false,
     '<glide-core-button-group-button>.selected': true,
+    '<glide-core-button-group-button>[slot="icon"]': '',
     '<glide-core-button-group-button>.value': '',
   },
   argTypes: {
@@ -140,6 +141,12 @@ const meta: Meta = {
     '<glide-core-button-group-button>.selected': {
       defaultValue: { summary: 'false' },
     },
+    '<glide-core-button-group-button>[slot="icon"]': {
+      control: false,
+      table: {
+        type: { summary: 'Element' },
+      },
+    },
     '<glide-core-button-group-button>.value': {
       table: {
         type: {
@@ -178,21 +185,21 @@ export const WithIcons: StoryObj = {
           ?selected=${arguments_['<glide-core-button-group-button>.selected']}
         >
           <glide-core-example-icon
-            slot="prefix"
+            slot="icon"
             name="info"
           ></glide-core-example-icon>
         </glide-core-button-group-button>
 
         <glide-core-button-group-button label="Two">
           <glide-core-example-icon
-            slot="prefix"
+            slot="icon"
             name="pencil"
           ></glide-core-example-icon>
         </glide-core-button-group-button>
 
         <glide-core-button-group-button label="Three">
           <glide-core-example-icon
-            slot="prefix"
+            slot="icon"
             name="calendar"
           ></glide-core-example-icon>
         </glide-core-button-group-button>

--- a/src/button-group.test.basics.ts
+++ b/src/button-group.test.basics.ts
@@ -36,7 +36,7 @@ it('has defaults', async () => {
 
 it('is accessible', async () => {
   const component = await fixture(
-    html`<glide-core-button-group label="label">
+    html`<glide-core-button-group label="Label">
       <glide-core-button-group-button
         label="One"
       ></glide-core-button-group-button>
@@ -57,7 +57,7 @@ it('is accessible', async () => {
 
 it('can have a label', async () => {
   const component = await fixture(
-    html`<glide-core-button-group label="label">
+    html`<glide-core-button-group label="Label">
       <glide-core-button-group-button
         label="One"
       ></glide-core-button-group-button>
@@ -71,7 +71,7 @@ it('can have a label', async () => {
   const label = component.shadowRoot?.querySelector('[data-test="label"]');
   const radioGroup = component.shadowRoot?.querySelector('[role="radiogroup"]');
 
-  expect(label?.textContent).to.equal('label');
+  expect(label?.textContent).to.equal('Label');
   expect(radioGroup?.getAttribute('aria-labelledby')).to.equal(label?.id);
 });
 
@@ -115,13 +115,13 @@ it('sets the orientation of each button when vertical', async () => {
 
 it('sets `privateVariant` on each button', async () => {
   await fixture(
-    html`<glide-core-button-group label="label" variant="icon-only">
+    html`<glide-core-button-group label="Label" variant="icon-only">
       <glide-core-button-group-button label="One">
-        <div slot="prefix">Prefix</div>
+        <div slot="icon">Icon</div>
       </glide-core-button-group-button>
 
       <glide-core-button-group-button label="Two">
-        <div slot="prefix">Prefix</div>
+        <div slot="icon">Icon</div>
       </glide-core-button-group-button>
     </glide-core-button-group>`,
   );
@@ -135,7 +135,7 @@ it('sets `privateVariant` on each button', async () => {
 it('throws when its default slot is the wrong type', async () => {
   await expectArgumentError(() => {
     return fixture(html`
-      <glide-core-button-group label="label">
+      <glide-core-button-group label="Label">
         <div></div>
       </glide-core-button-group>
     `);
@@ -143,7 +143,7 @@ it('throws when its default slot is the wrong type', async () => {
 
   await expectArgumentError(() => {
     return fixture(
-      html`<glide-core-button-group label="label"> </glide-core-button-group>`,
+      html`<glide-core-button-group label="Label"> </glide-core-button-group>`,
     );
   });
 });

--- a/src/button.stories.ts
+++ b/src/button.stories.ts
@@ -52,8 +52,8 @@ const meta: Meta = {
     popovertarget: '',
     popovertargetaction: 'toggle',
     size: 'large',
-    'slot="prefix"': '',
-    'slot="suffix"': '',
+    'slot="prefix-icon"': '',
+    'slot="suffix-icon"': '',
     type: 'button',
     value: '',
     variant: 'primary',
@@ -191,13 +191,13 @@ const meta: Meta = {
         type: { summary: '"large" | "small"' },
       },
     },
-    'slot="prefix"': {
+    'slot="prefix-icon"': {
       control: false,
       table: {
         type: { summary: 'Element' },
       },
     },
-    'slot="suffix"': {
+    'slot="suffix-icon"': {
       control: false,
       table: {
         type: { summary: 'Element' },
@@ -266,11 +266,11 @@ export const WithIcons: StoryObj = {
         ${arguments_['slot="default"']}
 
         <glide-core-example-icon
-          slot="prefix"
+          slot="prefix-icon"
           name="calendar"
         ></glide-core-example-icon>
         <glide-core-example-icon
-          slot="suffix"
+          slot="suffix-icon"
           name="pencil"
         ></glide-core-example-icon>
       </glide-core-button>

--- a/src/button.styles.ts
+++ b/src/button.styles.ts
@@ -41,13 +41,13 @@ export default [
       }
 
       /* We remove spacing using negative margin when an icon is present to help with empty space balancing */
-      &.has-prefix,
-      ::slotted([slot='prefix']) {
+      &.prefix-icon,
+      ::slotted([slot='prefix-icon']) {
         margin-inline-start: -0.125rem;
       }
 
-      &.has-suffix,
-      ::slotted([slot='suffix']) {
+      &.suffix-icon,
+      ::slotted([slot='suffix-icon']) {
         margin-inline-end: -0.125rem;
       }
 

--- a/src/button.test.basics.ts
+++ b/src/button.test.basics.ts
@@ -96,17 +96,17 @@ it('throws if it does not have a default slot', async () => {
 it('`#onPrefixSlotChange` coverage', async () => {
   await fixture<GlideCoreButton>(html`
     <glide-core-button>
-      <span slot="prefix">Prefix</span>
+      <span slot="prefix-icon">Prefix</span>
       Button
     </glide-core-button>
   `);
 });
 
-it('`#onSuffixSlotChange` coverage', async () => {
+it('`#onSuffixIconSlotChange` coverage', async () => {
   await fixture<GlideCoreButton>(html`
     <glide-core-button>
       Button
-      <span slot="suffix">Suffix</span>
+      <span slot="suffix-icon">Suffix</span>
     </glide-core-button>
   `);
 });

--- a/src/button.ts
+++ b/src/button.ts
@@ -14,8 +14,8 @@ declare global {
 
 /**
  * @slot - A label.
- * @slot prefix - An optional icon before the label.
- * @slot suffix - An optional icon after the label.
+ * @slot prefix-icon - An optional icon before the label.
+ * @slot suffix-icon - An optional icon after the label.
  */
 @customElement('glide-core-button')
 export default class GlideCoreButton extends LitElement {
@@ -117,17 +117,17 @@ export default class GlideCoreButton extends LitElement {
         tertiary: this.variant === 'tertiary',
         large: this.size === 'large',
         small: this.size === 'small',
-        'has-prefix': this.hasPrefixSlot,
-        'has-suffix': this.hasSuffixSlot,
+        'prefix-icon': this.hasPrefixIcon,
+        'suffix-icon': this.hasSuffixIcon,
       })}
       ?disabled=${this.disabled}
       @click=${this.#onClick}
       ${ref(this.#buttonElementRef)}
     >
       <slot
-        name="prefix"
-        @slotchange=${this.#onPrefixSlotChange}
-        ${ref(this.#prefixSlotElementRef)}
+        name="prefix-icon"
+        @slotchange=${this.#onPrefixIconSlotChange}
+        ${ref(this.#prefixIconSlotElementRef)}
       ></slot>
 
       <slot
@@ -136,9 +136,9 @@ export default class GlideCoreButton extends LitElement {
       ></slot>
 
       <slot
-        name="suffix"
-        @slotchange=${this.#onSuffixSlotChange}
-        ${ref(this.#suffixSlotElementRef)}
+        name="suffix-icon"
+        @slotchange=${this.#onSuffixIconSlotChange}
+        ${ref(this.#suffixIconSlotElementRef)}
       ></slot>
     </button>`;
   }
@@ -149,10 +149,10 @@ export default class GlideCoreButton extends LitElement {
   }
 
   @state()
-  private hasPrefixSlot = false;
+  private hasPrefixIcon = false;
 
   @state()
-  private hasSuffixSlot = false;
+  private hasSuffixIcon = false;
 
   #buttonElementRef = createRef<HTMLButtonElement>();
 
@@ -160,9 +160,9 @@ export default class GlideCoreButton extends LitElement {
 
   #internals: ElementInternals;
 
-  #prefixSlotElementRef = createRef<HTMLSlotElement>();
+  #prefixIconSlotElementRef = createRef<HTMLSlotElement>();
 
-  #suffixSlotElementRef = createRef<HTMLSlotElement>();
+  #suffixIconSlotElementRef = createRef<HTMLSlotElement>();
 
   #onClick() {
     if (this.type === 'submit') {
@@ -180,13 +180,13 @@ export default class GlideCoreButton extends LitElement {
     owSlot(this.#defaultSlotElementRef.value);
   }
 
-  #onPrefixSlotChange() {
-    const assignedNodes = this.#prefixSlotElementRef.value?.assignedNodes();
-    this.hasPrefixSlot = Boolean(assignedNodes && assignedNodes.length > 0);
+  #onPrefixIconSlotChange() {
+    const assignedNodes = this.#prefixIconSlotElementRef.value?.assignedNodes();
+    this.hasPrefixIcon = Boolean(assignedNodes && assignedNodes.length > 0);
   }
 
-  #onSuffixSlotChange() {
-    const assignedNodes = this.#suffixSlotElementRef.value?.assignedNodes();
-    this.hasSuffixSlot = Boolean(assignedNodes && assignedNodes.length > 0);
+  #onSuffixIconSlotChange() {
+    const assignedNodes = this.#suffixIconSlotElementRef.value?.assignedNodes();
+    this.hasSuffixIcon = Boolean(assignedNodes && assignedNodes.length > 0);
   }
 }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- Renamed Button and Button Group's icon slots to include "icon" in their names for clarity.
- Adding a missing Storybook control for Button Group Button's icon slot.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Button and Button Group in Storybook.
2. Verify the icon stories.
3. Verify the icon slots each component's controls table.

## 📸 Images/Videos of Functionality

N/A
