### PR TITLE
Use `emulateMedia` directly in tests instead of globally

### DIFF
--- a/src/tab.group.test.interactions.ts
+++ b/src/tab.group.test.interactions.ts
@@ -3,6 +3,7 @@
 import './tab.group.js';
 import './tab.js';
 import './tab.panel.js';
+import { emulateMedia } from '@web/test-runner-commands';
 import { expect, fixture, html, waitUntil } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreTabGroup from './tab.group.js';
@@ -207,6 +208,8 @@ it('renders a disabled end-overflow button when there is only overflow at the st
 });
 
 it('scrolls tabs when overflow buttons are clicked', async () => {
+  await emulateMedia({ reducedMotion: 'reduce' });
+
   const spy = sinon.spy();
 
   const component = await fixture(html`
@@ -286,6 +289,8 @@ it('scrolls tabs when overflow buttons are clicked', async () => {
   expect(spy.callCount).to.equal(1);
   expect(startOverflowButton?.disabled).to.be.true;
   expect(endOverflowButton?.disabled).to.be.false;
+
+  await emulateMedia({ reducedMotion: 'no-preference' });
 });
 
 it('removes overflow buttons when the component is resized and there is no overflow', async () => {

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -64,34 +64,6 @@ export default {
       // https://github.com/lit/lit/issues/3807#issuecomment-1513369439
       tsconfig: fileURLToPath(new URL('tsconfig.json', import.meta.url)),
     }),
-    {
-      // In the test environment, we set `prefers-reduced-motion: reduce`
-      // as tests shouldn't need to rely on animations to finish before
-      // interacting with a component. Doing so leads to hardcoded
-      // waits, which extends testing time and doesn't actually provide
-      // any value.
-      //
-      // https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
-      name: 'prefers-reduced-motion-plugin',
-      transform(context) {
-        if (context.path.includes('.test.')) {
-          const emulateMediaScript = `
-            import { emulateMedia } from '@web/test-runner-commands';
-
-            before(async () => {
-              await emulateMedia({ reducedMotion: 'reduce' });
-            });
-          `;
-
-          return {
-            body: `${emulateMediaScript}\n${context.body}`,
-            map: context.map,
-          };
-        }
-
-        return context.body;
-      },
-    },
   ],
   reporters:
     process.env.NODE_ENV === 'production'


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

I'm reworking Accordion to, among other things, add reduced motion support to its [JavaScript animation](https://github.com/CrowdStrike/glide-core/blob/main/src/accordion.ts#L165C17-L165C25). 

To do that, I'll add a conditional to Accordion with two branches: one with the animation and one without. And both branches need to be tested so our thresholds are met. 

To test the branch with the animation, I would need to use `emulateMedia({ reducedMotion: 'no-preference' })` to override the `emulateMedia({ reducedMotion: 'reduce' })` that's [added](https://github.com/CrowdStrike/glide-core/pull/389/files#diff-24d782e02f46a1eb18aed719d1c73354c23a5702d6e324a6163f6d90a6965cadL81-L83) to every test. 

But I can't import `emulateMedia` in an individual test because it's [already](https://github.com/CrowdStrike/glide-core/pull/389/files#diff-24d782e02f46a1eb18aed719d1c73354c23a5702d6e324a6163f6d90a6965cadL79) been imported by Web Test Runner.

So, sad as it is, I think we have to say goodbye to that piece of our Web Test Runner configuration. It's also, incidentally, a bit magical in practice and would have likely led to some confusion down the road.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A