### PR TITLE
Fix indentation from programmatically-added tree items

### DIFF
--- a/.changeset/funny-feet-act.md
+++ b/.changeset/funny-feet-act.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Fixes a bug where programmatically-added tree items weren't correctly indented

--- a/src/tree.item.test.basics.ts
+++ b/src/tree.item.test.basics.ts
@@ -131,6 +131,23 @@ it('renders child and grandchild tree items', async () => {
   expect(grandchildItems?.[0].level).to.equal(3, 'Grandchildren are level 3');
 });
 
+it('sets the level for tree items programmatically added later', async () => {
+  const component = await fixture<TreeItem>(html`
+    <glide-core-tree-item expanded label="Item"></glide-core-tree-item>
+  `);
+
+  const newItem = Object.assign(
+    document.createElement('glide-core-tree-item'),
+    {
+      label: 'Child',
+    },
+  );
+
+  component.append(newItem);
+  await component.updateComplete;
+  expect(newItem.level).to.equal(2);
+});
+
 it('can select child and grandchild items', async () => {
   const component = await fixture<TreeItem>(html`
     <glide-core-tree-item expanded label="Item">

--- a/src/tree.item.ts
+++ b/src/tree.item.ts
@@ -58,10 +58,6 @@ export default class GlideCoreTreeItem extends LitElement {
   @queryAssignedElements({ slot: 'suffix' })
   suffixSlotAssignedElements!: HTMLElement[];
 
-  override firstUpdated() {
-    this.#setupChildren();
-  }
-
   override focus(options?: FocusOptions) {
     this.#labelContainerElementRef.value?.focus(options);
     this.#setTabIndexes(0);
@@ -151,7 +147,10 @@ export default class GlideCoreTreeItem extends LitElement {
         </div>
       </div>
       <div class="child-items" role="group">
-        <slot></slot>
+        <slot
+          @slotchange=${this.#onDefaultSlotChange}
+          ${ref(this.#defaultSlotElementRef)}
+        ></slot>
       </div>
     </div>`;
   }
@@ -190,6 +189,8 @@ export default class GlideCoreTreeItem extends LitElement {
 
   @state()
   private childTreeItems: GlideCoreTreeItem[] = [];
+
+  #defaultSlotElementRef = createRef<HTMLSlotElement>();
 
   #labelContainerElementRef = createRef<HTMLInputElement>();
 
@@ -240,6 +241,10 @@ export default class GlideCoreTreeItem extends LitElement {
       !(target instanceof GlideCoreTreeItem) &&
       this.contains(target)
     );
+  }
+
+  #onDefaultSlotChange() {
+    this.#setupChildren();
   }
 
   #onMenuSlotChange() {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Previously, for a `Tree Item` that was added to another `Tree Item` programmatically, that new `Tree Item` would not have the proper indentation `level`

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
