### PR TITLE
Fix Checkbox Group edge cases

### DIFF
--- a/src/checkbox-group.stories.ts
+++ b/src/checkbox-group.stories.ts
@@ -7,6 +7,9 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 const meta: Meta = {
   title: 'Checkbox Group',
   tags: ['autodocs'],
+  decorators: [
+    (story) => html`<div style="width: max-content;">${story()}</div>`,
+  ],
   parameters: {
     docs: {
       story: {

--- a/src/checkbox-group.test.interactions.ts
+++ b/src/checkbox-group.test.interactions.ts
@@ -16,10 +16,11 @@ it('checks and unchecks Checkboxes when `value` is changed programmatically', as
   const component = await fixture<GlideCoreCheckboxGroup>(
     html`<glide-core-checkbox-group label="Checkbox Group">
       <glide-core-checkbox label="One" value="one"></glide-core-checkbox>
+      <glide-core-checkbox label="Two" checked></glide-core-checkbox>
 
       <glide-core-checkbox
-        label="Two"
-        value="two"
+        label="Three"
+        value="three"
         checked
       ></glide-core-checkbox>
     </glide-core-checkbox-group>`,
@@ -30,7 +31,8 @@ it('checks and unchecks Checkboxes when `value` is changed programmatically', as
   const checkboxes = component.querySelectorAll('glide-core-checkbox');
 
   expect(checkboxes[0].checked).to.be.true;
-  expect(checkboxes[1].checked).to.be.false;
+  expect(checkboxes[1].checked).to.be.true;
+  expect(checkboxes[2].checked).to.be.false;
 });
 
 it('updates `value` when the `value` of a checked Checkbox is changed programmatically', async () => {
@@ -85,4 +87,27 @@ it('updates `value` when the `value` of a checked Checkbox is emptied programmat
 
   expect(component.value).to.deep.equal(['two']);
   expect(component.getAttribute('value')).to.equal('["two"]');
+});
+
+it('enables disabled Checkboxes when `value` is set programmatically', async () => {
+  const component = await fixture<GlideCoreCheckboxGroup>(
+    html`<glide-core-checkbox-group label="Checkbox Group">
+      <glide-core-checkbox
+        label="One"
+        value="one"
+        disabled
+      ></glide-core-checkbox>
+
+      <glide-core-checkbox
+        label="Two"
+        value="two"
+        checked
+      ></glide-core-checkbox>
+    </glide-core-checkbox-group>`,
+  );
+
+  component.value = ['one', 'two'];
+
+  const checkbox = component.querySelector('glide-core-checkbox');
+  expect(checkbox?.disabled).to.be.false;
 });

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -96,9 +96,36 @@ export default class GlideCoreCheckboxGroup extends LitElement {
     this.#value = value;
 
     for (const checkbox of this.#checkboxes) {
-      checkbox.checked = value.some(
+      const isChecked = value.some(
         (value) => value && value === checkbox.value,
       );
+
+      // It would be simpler if we just checked and unchecked every Checkbox
+      // based on whether its value is in `value`. But doing so would uncheck
+      // Checkboxes that don't have a value but have nonetheless been checked
+      // by the user. Doing it this way ensures we change as little state as
+      // possible that isn't ours to change.
+      if (isChecked) {
+        checkbox.checked = true;
+      } else if (checkbox.value) {
+        checkbox.checked = false;
+      }
+
+      // We have a few options if `value` is set programmatically to include
+      // the value of a disabled Checkbox. We can throw, remove the value
+      // from `value`, or enable the Checkbox.
+      //
+      // Throwing is attractive because the inclusion of a disabled Checkbox
+      // in `value` is likely a mistake, either due to bad data or developer
+      // error.
+      //
+      // But we only throw in development. So the form will be submitted with
+      // the new `value` in production regardless if it was by mistake. By enabling
+      // the Checkbox, we at least ensure the user is aware of the fact that it'll
+      // be included in the submission.
+      if (checkbox.checked && checkbox.disabled) {
+        checkbox.disabled = false;
+      }
     }
   }
 
@@ -134,7 +161,6 @@ export default class GlideCoreCheckboxGroup extends LitElement {
 
     for (const checkbox of this.#checkboxes) {
       checkbox.privateVariant = 'minimal';
-
       checkbox.addEventListener('blur', this.#onCheckboxBlur.bind(this));
     }
   }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- When `value` is set programmatically, Checkbox Group no longer unchecks Checkboxes that don't have a `value` but were nonetheless checked by the user.
- When `value` is set programmatically, Checkbox Group now enables disabled Checkboxes whose `value` is included in Checkbox Group's `value`.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

#### When `value` is set programmatically, Checkbox Group no longer unchecks Checkboxes that don't have a `value` but were nonetheless checked by the user

1. Navigate to Checkbox Group in Storybook.
2. Give the first Checkbox a `value` using DevTools: `$0.value = 'one'`
3. Check the second checkbox.
4. Set Checkbox Group's `value` programmatically: `$0.value = ['one']`.
5. Verify that the second Checkbox is checked.

#### When `value` is set programmatically, Checkbox Group now enables disabled Checkboxes whose `value` is included in Checkbox Group's `value`

1. Navigate to Checkbox Group in Storybook.
2. Give the first Checkbox a `value` using DevTools: `$0.value = 'one'`
3. Disable the first Checkbox using DevTools or the Storybook control.
4. Set Checkbox Group's `value` programmatically: `$0.value = ['one']`.
5. Verify that the first Checkbox is enabled.

## 📸 Images/Videos of Functionality

N/A
