### PR TITLE
Rework Accordion

### DIFF
--- a/.changeset/friendly-dots-type.md
+++ b/.changeset/friendly-dots-type.md
@@ -1,0 +1,11 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Accordion respects the user's system preference for reduced motion.
+- Accordion waits to dispatch "toggle" on open until its animation is complete.
+- Accordion animates when `open` is set programmatically.
+- Accordion's "toggle" event bubbles.
+- Accordion's `open` property is set to `true` when Accordion is opened via click.
+- Accordion has a `click()` method.
+- Setting Accordion's `open` property to `false` closes Accordion.

--- a/.changeset/sixty-toes-share.md
+++ b/.changeset/sixty-toes-share.md
@@ -4,3 +4,5 @@
 
 - Button's "prefix" and "suffix" slots have been renamed to "prefix-icon" and "suffix-icon".
 - Button Group Button's "prefix" slot has been renamed to "icon".
+- Accordion's "prefix" and "suffix" slots have been renamed to "prefix-icon" and "suffix-icons".
+- Accordion no longer dispaches a custom event. Accordion's state, which was available via the custom event's `detail` property, can be accessed via the `open` property.

--- a/.github/workflows/on-pull-request-opened-and-synchronize.yml
+++ b/.github/workflows/on-pull-request-opened-and-synchronize.yml
@@ -54,7 +54,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     # It's possible our tests can hang and we don't want to blow through our
-    # GitHub Action minutes, so we'll timeout after 10 minutes to protect
+    # GitHub Action minutes, so we'll timeout after 10 minutes to prevent
     # that from happening.
     timeout-minutes: 10
     needs:

--- a/src/accordion.stories.ts
+++ b/src/accordion.stories.ts
@@ -1,9 +1,9 @@
-import './accordion.js';
 import './icons/storybook.js';
 import { STORY_ARGS_UPDATED } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import GlideCoreAccordion from './accordion.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
 const meta: Meta = {
@@ -31,14 +31,14 @@ const meta: Meta = {
     context.canvasElement
       .querySelector('glide-core-accordion')
       ?.addEventListener('toggle', (event) => {
-        if (event instanceof CustomEvent) {
+        if (event.target instanceof GlideCoreAccordion) {
           addons.getChannel().emit(STORY_ARGS_UPDATED, {
             storyId: context.id,
             args: {
               ...arguments_,
               // Our events are untyped at the moment. So `detail` is typed as `any`.
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              open: event.detail.newState === 'open',
+              open: event.target.open,
             },
           });
         }
@@ -63,8 +63,8 @@ const meta: Meta = {
     'click()': '',
     'focus(options)': '',
     open: false,
-    'slot="prefix"': '',
-    'slot="suffix"': '',
+    'slot="prefix-icon"': '',
+    'slot="suffix-icons"': '',
   },
   argTypes: {
     label: {
@@ -85,8 +85,7 @@ const meta: Meta = {
       table: {
         type: {
           summary: 'method',
-          detail:
-            '(event: "toggle", listener: (event: CustomEvent<{ newState: "open" | "closed", oldState: "open" | "closed" }>) => void) => void',
+          detail: '(event: "toggle", listener: (event: Event) => void) => void',
         },
       },
     },
@@ -114,21 +113,19 @@ const meta: Meta = {
         type: { summary: 'boolean' },
       },
     },
-    'slot="prefix"': {
+    'slot="prefix-icon"': {
       control: false,
       table: {
         type: {
           summary: 'Element',
-          detail: '// An optional icon before the label',
         },
       },
     },
-    'slot="suffix"': {
+    'slot="suffix-icons"': {
       control: false,
       table: {
         type: {
           summary: 'Element',
-          detail: '// Optional icons after the label',
         },
       },
     },
@@ -152,15 +149,15 @@ export const WithIcons: StoryObj = {
         ${unsafeHTML(arguments_['slot="default"'])}
 
         <glide-core-example-icon
-          slot="prefix"
+          slot="prefix-icon"
           name="share"
         ></glide-core-example-icon>
         <glide-core-example-icon
-          slot="suffix"
+          slot="suffix-icons"
           name="pencil"
         ></glide-core-example-icon>
         <glide-core-example-icon
-          slot="suffix"
+          slot="suffix-icons"
           name="settings"
         ></glide-core-example-icon>
       </glide-core-accordion>`;

--- a/src/accordion.styles.ts
+++ b/src/accordion.styles.ts
@@ -36,42 +36,24 @@ export default [
         display: none;
       }
 
-      .heading-box {
-        align-items: center;
-        display: flex;
-        flex: 1;
-        overflow: hidden;
-        white-space: nowrap;
-
-        &.heading-box-with-prefix {
-          gap: var(--glide-core-spacing-xs);
-        }
-
-        .prefix-slot-box {
-          display: flex;
-        }
-
-        .label {
-          display: block;
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
-      }
-
-      .suffix-slot-box {
-        align-items: center;
-        color: var(--glide-core-icon-primary);
-        display: flex;
-        gap: 0.625rem;
-
-        &.suffix-slot-box-with-content {
-          margin-inline-start: var(--glide-core-spacing-xs);
-        }
-      }
-
-      .component[open] & {
+      &.active {
         padding-block-end: var(--glide-core-spacing-xxs);
       }
+    }
+
+    .label-container {
+      align-items: center;
+      display: flex;
+      flex: 1;
+      gap: var(--glide-core-spacing-xs);
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
+    .label {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .chevron {
@@ -79,25 +61,41 @@ export default [
       display: flex;
       margin-inline-end: var(--glide-core-spacing-xxs);
       rotate: -90deg;
-      transition: 250ms rotate ease;
 
-      .component[open] & {
+      &.unrotated {
         rotate: 0deg;
+      }
+
+      @media (prefers-reduced-motion: no-preference) {
+        transition: 250ms rotate ease;
       }
     }
 
-    .content {
+    .default-slot {
       color: var(--glide-core-text-body-1);
+      display: block;
       font-size: var(--glide-core-body-sm-font-size);
       font-weight: var(--glide-core-body-xs-font-weight);
+      overflow: hidden;
       padding-block-end: var(--glide-core-spacing-sm);
 
       /* Hardcoded spacing here is intentional so that it better aligns with the Accordion label */
       padding-inline: 2rem var(--glide-core-spacing-sm);
+
+      &.indented {
+        padding-inline-start: 3.5rem;
+      }
     }
 
-    .content-with-prefix {
-      padding-inline-start: 3.5rem;
+    .suffix-icons-slot {
+      align-items: center;
+      color: var(--glide-core-icon-primary);
+      gap: 0.625rem;
+      margin-inline-start: var(--glide-core-spacing-xs);
+
+      &.icons {
+        display: flex;
+      }
     }
   `,
 ];

--- a/src/accordion.test.basics.ts
+++ b/src/accordion.test.basics.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 import './accordion.js';
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import GlideCoreAccordion from './accordion.js';
 
 GlideCoreAccordion.shadowRootOptions.mode = 'open';
@@ -14,155 +14,34 @@ it('registers', async () => {
 
 it('is accessible', async () => {
   const component = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="label">
-      Inner content
-    </glide-core-accordion>`,
+    html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
   );
 
   await expect(component).to.be.accessible();
 });
 
-it('is closed by default', async () => {
+it('has defaults', async () => {
   const component = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="label">
-      Inner content
+    html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
+  );
+
+  expect(component.open).to.be.false;
+});
+
+it('`#onPrefixIconSlotChange` coverage', async () => {
+  await fixture<GlideCoreAccordion>(
+    html`<glide-core-accordion label="Label">
+      Content
+      <div slot="prefix-icon"></div>
     </glide-core-accordion>`,
   );
-
-  const accordion =
-    component.shadowRoot?.querySelector<HTMLDetailsElement>('details');
-
-  expect(accordion).to.be.ok;
-  expect(accordion?.hasAttribute('open')).to.be.false;
 });
 
-it('defaults to "open" when provided with the attribute', async () => {
-  const component = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="label" open>
-      Inner content
+it('`#onSuffixIconsSlotChange` coverage', async () => {
+  await fixture<GlideCoreAccordion>(
+    html`<glide-core-accordion label="Label">
+      Content
+      <div slot="suffix-icons"></div>
     </glide-core-accordion>`,
   );
-
-  const accordion =
-    component.shadowRoot?.querySelector<HTMLDetailsElement>('details');
-
-  expect(accordion).to.be.ok;
-  expect(accordion?.hasAttribute('open')).to.be.true;
-});
-
-it('renders the provided "label"', async () => {
-  const component = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="Accordion Title">
-      Inner content
-    </glide-core-accordion>`,
-  );
-
-  const label = component.shadowRoot?.querySelector<HTMLSpanElement>(
-    '[data-test="label"]',
-  );
-
-  expect(label).to.be.ok;
-  expect(label?.textContent?.trim()).to.equal('Accordion Title');
-});
-
-it('renders the provided default slotted content', async () => {
-  const component = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="label"
-      ><p data-body>Inner content</p></glide-core-accordion
-    >`,
-  );
-
-  const body = component.querySelector<HTMLParagraphElement>('[data-body]');
-
-  expect(body).to.be.ok;
-});
-
-it('renders with a prefix slot and applies the appropriate classes', async () => {
-  const component = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="label">
-      Inner content
-      <span slot="prefix" data-prefix>prefix</span>
-    </glide-core-accordion>`,
-  );
-
-  expect(document.querySelector('[data-prefix]')).to.be.ok;
-
-  expect([
-    ...component.shadowRoot!.querySelector('[data-test="label"]')!.classList,
-  ]).to.deep.equal(['heading-box', 'heading-box-with-prefix']);
-
-  expect([
-    ...component.shadowRoot!.querySelector('[data-test="content"]')!.classList,
-  ]).to.deep.equal(['content', 'content-with-prefix']);
-});
-
-it('does not apply prefix classes when no prefix slot is provided', async () => {
-  const component = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="label">
-      Inner content
-    </glide-core-accordion>`,
-  );
-
-  expect([
-    ...component.shadowRoot!.querySelector('[data-test="label"]')!.classList,
-  ]).to.deep.equal(['heading-box']);
-
-  expect([
-    ...component.shadowRoot!.querySelector('[data-test="content"]')!.classList,
-  ]).to.deep.equal(['content']);
-});
-
-it('renders with a suffix slot and applies the appropriate class', async () => {
-  const component = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="label">
-      Inner content
-      <span slot="suffix" data-suffix>suffix</span>
-    </glide-core-accordion>`,
-  );
-
-  expect(component.querySelector('[data-suffix]')).to.be.ok;
-
-  expect([
-    ...component.shadowRoot!.querySelector('[data-test="suffix"]')!.classList,
-  ]).to.deep.equal(['suffix-slot-box', 'suffix-slot-box-with-content']);
-});
-
-it('does not apply the suffix class when no suffix slot is provided', async () => {
-  const component = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="label">
-      Inner content
-    </glide-core-accordion>`,
-  );
-
-  expect([
-    ...component.shadowRoot!.querySelector('[data-test="suffix"]')!.classList,
-  ]).to.deep.equal(['suffix-slot-box']);
-});
-
-it('renders without prefix and suffix classes after both are removed', async () => {
-  const component = await fixture<GlideCoreAccordion>(html`
-    <glide-core-accordion label="label">
-      Inner content
-      <span slot="prefix">prefix</span>
-      <span slot="suffix">suffix</span>
-    </glide-core-accordion>
-  `);
-
-  component.querySelector('[slot="prefix"]')?.remove();
-  component.querySelector('[slot="suffix"]')?.remove();
-  await elementUpdated(component);
-
-  // prefix
-  expect([
-    ...component.shadowRoot!.querySelector('[data-test="label"]')!.classList,
-  ]).to.deep.equal(['heading-box']);
-
-  expect([
-    ...component.shadowRoot!.querySelector('[data-test="content"]')!.classList,
-  ]).to.deep.equal(['content']);
-
-  // suffix
-  expect([
-    ...component.shadowRoot!.querySelector('[data-test="suffix"]')!.classList,
-  ]).to.deep.equal(['suffix-slot-box']);
 });

--- a/src/accordion.test.events.ts
+++ b/src/accordion.test.events.ts
@@ -1,75 +1,44 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 import './accordion.js';
-import {
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-  oneEvent,
-} from '@open-wc/testing';
+import { emulateMedia } from '@web/test-runner-commands';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import GlideCoreAccordion from './accordion.js';
 
 GlideCoreAccordion.shadowRootOptions.mode = 'open';
 
-it('dispatches a "toggle" event when the Accordion opens', async () => {
-  let hasToggleBeenCalled = false;
+it('dispatches a "toggle" event on open', async () => {
+  await emulateMedia({ reducedMotion: 'reduce' });
 
   const component = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="label">
-      Inner content
-    </glide-core-accordion>`,
+    html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
   );
 
-  component.addEventListener('toggle', () => (hasToggleBeenCalled = true));
+  setTimeout(() => {
+    component.click();
+  });
 
-  const summary = component.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="summary"]',
-  );
+  const event = await oneEvent(component, 'toggle');
 
-  expect(summary).to.be.ok;
-
-  summary?.click();
-
-  await oneEvent(component, 'toggle');
-
-  expect(hasToggleBeenCalled).to.be.true;
+  expect(event instanceof Event).to.be.true;
+  expect(event.bubbles).to.be.true;
 });
 
-it('dispatches a "toggle" event when the Accordion closes', async () => {
-  let hasToggleBeenCalled = false;
+it('dispatches a "toggle" event on close', async () => {
+  await emulateMedia({ reducedMotion: 'reduce' });
 
   const component = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="label" open>
-      Inner content
+    html`<glide-core-accordion label="Label" open>
+      Content
     </glide-core-accordion>`,
   );
 
-  component.addEventListener('toggle', () => (hasToggleBeenCalled = true));
+  setTimeout(() => {
+    component.click();
+  });
 
-  const summary = component.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="summary"]',
-  );
+  const event = await oneEvent(component, 'toggle');
 
-  expect(summary).to.be.ok;
-
-  summary?.click();
-
-  // Force the animations to complete with javascript
-  // and by triggering a `finish` event ourselves.
-  component.shadowRoot
-    ?.querySelector('[data-test="content"]')
-    ?.getAnimations()
-    ?.at(0)
-    ?.finish();
-
-  component.shadowRoot
-    ?.querySelector('[data-test="content"]')
-    ?.dispatchEvent(new AnimationEvent('finish'));
-
-  await elementUpdated(component);
-
-  await oneEvent(component, 'toggle');
-
-  expect(hasToggleBeenCalled).to.be.true;
+  expect(event instanceof Event).to.be.true;
+  expect(event.bubbles).to.be.true;
 });

--- a/src/accordion.test.focus.ts
+++ b/src/accordion.test.focus.ts
@@ -6,15 +6,13 @@ import GlideCoreAccordion from './accordion.js';
 
 GlideCoreAccordion.shadowRootOptions.mode = 'open';
 
-it('focuses its label when `focus()` is called', async () => {
+it('focuses itself when `focus()` is called', async () => {
   const component = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="label">
-      Inner content
-    </glide-core-accordion>`,
+    html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
   );
 
   component.focus();
 
   const summary = component?.shadowRoot?.querySelector('[data-test="summary"]');
-  expect(component?.shadowRoot?.activeElement).to.be.equal(summary);
+  expect(component?.shadowRoot?.activeElement).to.equal(summary);
 });

--- a/src/accordion.test.interactions.ts
+++ b/src/accordion.test.interactions.ts
@@ -1,0 +1,123 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+import './accordion.js';
+import { emulateMedia } from '@web/test-runner-commands';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
+import GlideCoreAccordion from './accordion.js';
+
+GlideCoreAccordion.shadowRootOptions.mode = 'open';
+
+it('can be opened via click', async () => {
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  const component = await fixture<GlideCoreAccordion>(
+    html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
+  );
+
+  component.click();
+
+  expect(component.open).to.be.true;
+});
+
+it('can be opened via click when animated', async () => {
+  await emulateMedia({ reducedMotion: 'no-preference' });
+
+  const component = await fixture<GlideCoreAccordion>(
+    html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
+  );
+
+  component.click();
+
+  let animation: Animation | undefined;
+  let isAnimationFinished = false;
+
+  await waitUntil(() => {
+    animation = component.shadowRoot
+      ?.querySelector('[data-test="default-slot"]')
+      ?.getAnimations()
+      ?.at(0);
+
+    return animation;
+  });
+
+  animation?.addEventListener('finish', () => {
+    isAnimationFinished = true;
+  });
+
+  await waitUntil(() => isAnimationFinished);
+
+  expect(component.open).to.be.true;
+});
+
+it('can be opened via Space', async () => {
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  const component = await fixture<GlideCoreAccordion>(
+    html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
+  );
+
+  component.focus();
+  await sendKeys({ press: ' ' });
+
+  expect(component.open).to.be.true;
+});
+
+it('can be opened via Enter', async () => {
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  const component = await fixture<GlideCoreAccordion>(
+    html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
+  );
+
+  component.focus();
+  await sendKeys({ press: 'Enter' });
+
+  expect(component.open).to.be.true;
+});
+
+it('can be closed via click', async () => {
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  const component = await fixture<GlideCoreAccordion>(
+    html`<glide-core-accordion label="Label" open>
+      Content
+    </glide-core-accordion>`,
+  );
+
+  component.click();
+
+  expect(component.open).to.be.false;
+});
+
+it('can be closed via click when animated', async () => {
+  await emulateMedia({ reducedMotion: 'no-preference' });
+
+  const component = await fixture<GlideCoreAccordion>(
+    html`<glide-core-accordion label="Label" open>
+      Content
+    </glide-core-accordion>`,
+  );
+
+  component.click();
+
+  let animation: Animation | undefined;
+  let isAnimationFinished = false;
+
+  await waitUntil(() => {
+    animation = component.shadowRoot
+      ?.querySelector('[data-test="default-slot"]')
+      ?.getAnimations()
+      ?.at(0);
+
+    return animation;
+  });
+
+  animation?.addEventListener('finish', () => {
+    isAnimationFinished = true;
+  });
+
+  await waitUntil(() => isAnimationFinished);
+
+  expect(component.open).to.be.false;
+});


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- Accordion respects the user's system preference for reduced motion.
- Accordion waits to dispatch "toggle" on open until its animation is complete.
- Accordion animates when `open` is set programmatically.
- Accordion's "toggle" event bubbles.
- Accordion's `open` property is set to `true` when Accordion is opened via click.
- Accordion has a `click()` method.
- Setting Accordion's `open` property to `false` closes Accordion.
- Accordion's "prefix" and "suffix" slots have been renamed to "prefix-icon" and "suffix-icons".
- Accordion no longer dispaches a custom event.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

A full regression, including the fixes above, is probably in order.

## 📸 Images/Videos of Functionality

N/A
