### PR TITLE
Use `attributesFilter` when observing attribute changes

### DIFF
--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -261,26 +261,23 @@ const meta: Meta = {
       arguments_ = event.args as typeof context.args;
     });
 
-    const observer = new MutationObserver((entries) => {
-      const hasOpenChanged = entries.some(
-        ({ attributeName }) => attributeName === 'open',
-      );
-
-      if (hasOpenChanged) {
-        addons.getChannel().emit(STORY_ARGS_UPDATED, {
-          storyId: context.id,
-          args: {
-            ...arguments_,
-            open: context.canvasElement.querySelector<GlideCoreDropdown>(
-              'glide-core-dropdown',
-            )?.open,
-          },
-        });
-      }
+    const observer = new MutationObserver(() => {
+      addons.getChannel().emit(STORY_ARGS_UPDATED, {
+        storyId: context.id,
+        args: {
+          ...arguments_,
+          open: context.canvasElement.querySelector<GlideCoreDropdown>(
+            'glide-core-dropdown',
+          )?.open,
+        },
+      });
     });
 
     if (dropdown) {
-      observer.observe(dropdown, { attributes: true });
+      observer.observe(dropdown, {
+        attributes: true,
+        attributeFilter: ['open'],
+      });
     }
   },
   render(arguments_) {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -441,24 +441,18 @@ export default class GlideCoreMenu extends LitElement {
     ow(this.#targetElement, ow.object.instanceOf(Element));
     ow(this.#optionsElement, ow.object.instanceOf(GlideCoreMenuOptions));
 
-    const observer = new MutationObserver((records) => {
-      const isDisabledMutated = records.some((record) => {
-        return (
-          record.attributeName === 'disabled' ||
-          record.attributeName === 'aria-disabled'
-        );
-      });
-
-      if (isDisabledMutated) {
-        if (this.open && !this.isTargetDisabled) {
-          this.#show();
-        } else {
-          this.#hide();
-        }
+    const observer = new MutationObserver(() => {
+      if (this.open && !this.isTargetDisabled) {
+        this.#show();
+      } else {
+        this.#hide();
       }
     });
 
-    observer.observe(this.#targetElement, { attributes: true });
+    observer.observe(this.#targetElement, {
+      attributes: true,
+      attributeFilter: ['aria-disabled', 'disabled'],
+    });
 
     this.#targetElement.ariaHasPopup = 'true';
     this.#targetElement.id = nanoid();

--- a/src/split-button-container.stories.ts
+++ b/src/split-button-container.stories.ts
@@ -32,27 +32,24 @@ const meta: Meta = {
       'glide-core-split-button-container',
     );
 
-    const observer = new MutationObserver((entries) => {
-      const hasOpenChanged = entries.some(
-        ({ attributeName }) => attributeName === 'menu-open',
-      );
-
-      if (hasOpenChanged) {
-        addons.getChannel().emit(STORY_ARGS_UPDATED, {
-          storyId: context.id,
-          args: {
-            ...arguments_,
-            ['menu-open']:
-              context.canvasElement.querySelector<GlideCoreSplitButtonContainer>(
-                'glide-core-split-button-container',
-              )?.menuOpen,
-          },
-        });
-      }
+    const observer = new MutationObserver(() => {
+      addons.getChannel().emit(STORY_ARGS_UPDATED, {
+        storyId: context.id,
+        args: {
+          ...arguments_,
+          ['menu-open']:
+            context.canvasElement.querySelector<GlideCoreSplitButtonContainer>(
+              'glide-core-split-button-container',
+            )?.menuOpen,
+        },
+      });
     });
 
     if (splitButtonContainer) {
-      observer.observe(splitButtonContainer, { attributes: true });
+      observer.observe(splitButtonContainer, {
+        attributes: true,
+        attributeFilter: ['menu-open'],
+      });
     }
   },
   render(arguments_) {

--- a/src/split-button-container.ts
+++ b/src/split-button-container.ts
@@ -109,18 +109,18 @@ export default class GlideCoreSplitButtonContainer extends LitElement {
     //
     // Thus an observer. Which only assumes that `open` is reflected and doesn't
     // depend on knowledge of Menu's internals.
-    const observer = new MutationObserver((entries) => {
-      const hasOpenChanged = entries.some(
-        ({ attributeName }) => attributeName === 'open',
-      );
-
-      if (hasOpenChanged && this.#menuElementRef.value) {
+    const observer = new MutationObserver(() => {
+      if (this.#menuElementRef.value) {
         this.menuOpen = this.#menuElementRef.value.open;
       }
     });
 
     ow(this.#menuElementRef.value, ow.object.instanceOf(GlideCoreMenu));
-    observer.observe(this.#menuElementRef.value, { attributes: true });
+
+    observer.observe(this.#menuElementRef.value, {
+      attributes: true,
+      attributeFilter: ['open'],
+    });
   }
 
   override focus(


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

We observe attribute changes in a few places using Mutation Observer. We can use `attributeFilter` instead of a conditional that checks if the attribute we're interested in has changed. It's a bit cleaner.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A
