### PR TITLE
Remove focus back to `document.body` after `reportValidity()` in stories

### DIFF
--- a/src/checkbox-group.stories.ts
+++ b/src/checkbox-group.stories.ts
@@ -130,6 +130,12 @@ const meta: Meta = {
       // `reportValidity` scrolls the element into view, which means the "autodocs"
       // story upon load will be scrolled to the first error story. No good.
       document.documentElement.scrollTop = 0;
+
+      if (document.activeElement instanceof HTMLElement) {
+        // Calling `reportValidity()` focuses the element. Focus is expected to be
+        // on `document.body` on page load.
+        document.activeElement.blur();
+      }
     }
   },
   render(arguments_) {

--- a/src/checkbox.stories.ts
+++ b/src/checkbox.stories.ts
@@ -170,6 +170,12 @@ const meta: Meta = {
       // `reportValidity` scrolls the element into view, which means the "autodocs"
       // story upon load will be scrolled to the first error story. No good.
       document.documentElement.scrollTop = 0;
+
+      if (document.activeElement instanceof HTMLElement) {
+        // Calling `reportValidity()` focuses the element. Focus is expected to be
+        // on `document.body` on page load.
+        document.activeElement.blur();
+      }
     }
 
     // eslint-disable-next-line no-underscore-dangle

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -251,6 +251,12 @@ const meta: Meta = {
       // `reportValidity` scrolls the element into view, which means the "autodocs"
       // story upon load will be scrolled to the first error story. No good.
       document.documentElement.scrollTop = 0;
+
+      if (document.activeElement instanceof HTMLElement) {
+        // Calling `reportValidity()` focuses the element. Focus is expected to be
+        // on `document.body` on page load.
+        document.activeElement.blur();
+      }
     }
 
     // eslint-disable-next-line no-underscore-dangle

--- a/src/input.stories.ts
+++ b/src/input.stories.ts
@@ -48,6 +48,12 @@ const meta: Meta = {
       // `reportValidity` scrolls the element into view, which means the "autodocs"
       // story upon load will be scrolled to the first error story. No good.
       document.documentElement.scrollTop = 0;
+
+      if (document.activeElement instanceof HTMLElement) {
+        // Calling `reportValidity()` focuses the element. Focus is expected to be
+        // on `document.body` on page load.
+        document.activeElement.blur();
+      }
     }
   },
   render(arguments_) {

--- a/src/radio-group.stories.ts
+++ b/src/radio-group.stories.ts
@@ -29,6 +29,12 @@ const meta: Meta = {
       // `reportValidity` scrolls the element into view, which means the "autodocs"
       // story upon load will be scrolled to the first error story. No good.
       document.documentElement.scrollTop = 0;
+
+      if (document.activeElement instanceof HTMLElement) {
+        // Calling `reportValidity()` focuses the element. Focus is expected to be
+        // on `document.body` on page load.
+        document.activeElement.blur();
+      }
     }
   },
   render(arguments_) {

--- a/src/textarea.stories.ts
+++ b/src/textarea.stories.ts
@@ -20,9 +20,16 @@ const meta: Meta = {
       textarea instanceof GlideCoreTextarea
     ) {
       textarea.reportValidity();
+
       // `reportValidity` scrolls the element into view, which means the "autodocs"
       // story upon load will be scrolled to the first error story. No good.
       document.documentElement.scrollTop = 0;
+
+      if (document.activeElement instanceof HTMLElement) {
+        // Calling `reportValidity()` focuses the element. Focus is expected to be
+        // on `document.body` on page load.
+        document.activeElement.blur();
+      }
     }
   },
   args: {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

We call `reportValidity()` in our form control stories to show off their error state. Doing so, however, moves focus from `document.body` to the control, which isn't where focus should be on page load.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

A quick Storybook spotcheck should do.

## 📸 Images/Videos of Functionality

## Before

<img width="1046" alt="image" src="https://github.com/user-attachments/assets/ba68993a-4603-42c5-b69e-d4a716a7a3bf">


## After

<img width="780" alt="image" src="https://github.com/user-attachments/assets/2197ef8e-fee1-49c9-92e4-79c02ab77c1d">

