### PR TITLE
Use `emulateMedia` in Drawer tests

### DIFF
--- a/src/drawer.test.closing.ts
+++ b/src/drawer.test.closing.ts
@@ -8,6 +8,7 @@ import {
   html,
   oneEvent,
 } from '@open-wc/testing';
+import { emulateMedia } from '@web/test-runner-commands';
 import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreDrawer from './drawer.js';
 
@@ -17,6 +18,8 @@ GlideCoreDrawer.shadowRootOptions.mode = 'open';
 // to manually dispatch the `transitionend` event in tests.
 
 it('closes when the "Escape" key is pressed', async () => {
+  await emulateMedia({ reducedMotion: 'no-preference' });
+
   const component = await fixture<GlideCoreDrawer>(
     html`<glide-core-drawer>Drawer content</glide-core-drawer>`,
   );
@@ -47,6 +50,8 @@ it('closes when the "Escape" key is pressed', async () => {
 });
 
 it('does not close when a key other than "Escape" is pressed', async () => {
+  await emulateMedia({ reducedMotion: 'no-preference' });
+
   const component = await fixture<GlideCoreDrawer>(
     html`<glide-core-drawer>Drawer content</glide-core-drawer>`,
   );


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

These tests have been intermittently failing for me (and only me, apparently) for months. My assumption is that it's because I always have reduced motion turned on System Settings. 

Either way, it's probably good for us to get in the habit of using `emulateMedia` in tests when animations are involved so local system preferences are overridden.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A