### PR TITLE
Set, document, and type `name` and `value` consistently

### DIFF
--- a/.changeset/red-hats-drum.md
+++ b/.changeset/red-hats-drum.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Radio Group's `name` attribute is now reflected.
+- Checkbox, Checkbox Group, Dropdown, Input, and Textarea's `name` attribute is now an empty string by default to match native.

--- a/src/checkbox-group.stories.ts
+++ b/src/checkbox-group.stories.ts
@@ -97,6 +97,7 @@ const meta: Meta = {
     },
     name: {
       table: {
+        defaultValue: { summary: '""' },
         type: { summary: 'string' },
       },
     },

--- a/src/checkbox-group.test.basics.ts
+++ b/src/checkbox-group.test.basics.ts
@@ -22,16 +22,9 @@ it('has defaults', async () => {
     </glide-core-checkbox-group>`,
   );
 
-  expect(component.hasAttribute('disabled')).to.be.false;
   expect(component.disabled).to.be.false;
-
-  expect(component.hasAttribute('hide-label')).to.be.false;
   expect(component.hideLabel).to.be.false;
-
-  expect(component.getAttribute('name')).to.be.null;
-  expect(component.name).to.equal(undefined);
-
-  expect(component.hasAttribute('required')).to.be.false;
+  expect(component.name).to.be.empty.string;
   expect(component.required).to.be.false;
 
   // Not reflected, so no attribute assertion is necessary.

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -53,7 +53,7 @@ export default class GlideCoreCheckboxGroup extends LitElement {
   label?: string;
 
   @property({ reflect: true })
-  name?: string;
+  name = '';
 
   @property()
   privateSplit?: 'left' | 'middle';

--- a/src/checkbox.stories.ts
+++ b/src/checkbox.stories.ts
@@ -108,6 +108,7 @@ const meta: Meta = {
     },
     name: {
       table: {
+        defaultValue: { summary: '""' },
         type: { summary: 'string' },
       },
     },

--- a/src/checkbox.test.basics.ts
+++ b/src/checkbox.test.basics.ts
@@ -16,32 +16,15 @@ it('has defaults', async () => {
     html`<glide-core-checkbox label="Label"></glide-core-checkbox>`,
   );
 
-  expect(component.hasAttribute('checked')).to.be.false;
   expect(component.checked).to.be.false;
-
-  expect(component.hasAttribute('disabled')).to.be.false;
   expect(component.disabled).to.be.false;
-
-  expect(component.hasAttribute('hide-label')).to.be.false;
   expect(component.hideLabel).to.be.false;
-
-  expect(component.hasAttribute('indeterminate')).to.be.false;
   expect(component.indeterminate).to.be.false;
-
-  expect(component.getAttribute('name')).to.be.null;
-  expect(component.name).to.equal(undefined);
-
-  expect(component.getAttribute('orientation')).to.equal('horizontal');
+  expect(component.name).to.be.empty.string;
   expect(component.orientation).to.equal('horizontal');
-
-  expect(component.hasAttribute('required')).to.be.false;
   expect(component.required).to.be.false;
-
-  expect(component.getAttribute('summary')).to.be.null;
   expect(component.summary).to.equal(undefined);
-
-  expect(component.getAttribute('value')).to.equal('');
-  expect(component.value).to.equal('');
+  expect(component.value).to.be.empty.string;
 });
 
 it('is accessible', async () => {

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -85,7 +85,7 @@ export default class GlideCoreCheckbox extends LitElement {
   orientation: 'horizontal' | 'vertical' = 'horizontal';
 
   @property({ reflect: true })
-  name?: string;
+  name = '';
 
   @property({
     attribute: 'private-label-tooltip-offset',

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -132,6 +132,7 @@ const meta: Meta = {
     },
     name: {
       table: {
+        defaultValue: { summary: '""' },
         type: { summary: 'string' },
       },
     },
@@ -219,6 +220,7 @@ const meta: Meta = {
     },
     '<glide-core-dropdown-option>.value': {
       table: {
+        defaultValue: { summary: '""' },
         type: { summary: 'string' },
       },
       type: { name: 'string' },

--- a/src/dropdown.test.basics.ts
+++ b/src/dropdown.test.basics.ts
@@ -47,8 +47,8 @@ it('has defaults', async () => {
   expect(component.hasAttribute('filterable')).to.be.false;
   expect(component.filterable).to.be.false;
 
-  expect(component.getAttribute('name')).to.be.null;
-  expect(component.name).to.equal(undefined);
+  expect(component.getAttribute('name')).to.be.empty.string;
+  expect(component.name).to.be.empty.string;
 
   expect(component.hasAttribute('required')).to.be.false;
   expect(component.required).to.be.false;

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -68,7 +68,7 @@ export default class GlideCoreDropdown extends LitElement {
   label?: string;
 
   @property({ reflect: true })
-  name?: string;
+  name = '';
 
   @property({ reflect: true, type: Boolean })
   get open() {

--- a/src/input.stories.ts
+++ b/src/input.stories.ts
@@ -170,6 +170,12 @@ const meta: Meta = {
         type: { summary: 'number' },
       },
     },
+    name: {
+      table: {
+        defaultValue: { summary: '""' },
+        type: { summary: 'string' },
+      },
+    },
     orientation: {
       control: { type: 'radio' },
       options: ['horizontal', 'vertical'],

--- a/src/input.ts
+++ b/src/input.ts
@@ -59,7 +59,7 @@ export default class GlideCoreInput extends LitElement {
   type: SupportedTypes = 'text';
 
   @property({ reflect: true })
-  name?: string;
+  name = '';
 
   // `value` is intentionally not reflected here to match native
   @property()

--- a/src/radio-group.stories.ts
+++ b/src/radio-group.stories.ts
@@ -148,6 +148,7 @@ const meta: Meta = {
     },
     name: {
       table: {
+        defaultValue: { summary: '""' },
         type: { summary: 'string' },
       },
       type: { name: 'string' },
@@ -160,7 +161,7 @@ const meta: Meta = {
     },
     value: {
       table: {
-        defaultValue: { summary: '' },
+        defaultValue: { summary: '""' },
         type: { summary: 'string' },
       },
     },

--- a/src/radio-group.ts
+++ b/src/radio-group.ts
@@ -49,7 +49,7 @@ export default class GlideCoreRadioGroup extends LitElement {
   @property({ attribute: 'hide-label', type: Boolean })
   hideLabel = false;
 
-  @property()
+  @property({ reflect: true })
   name = '';
 
   @property()

--- a/src/textarea.stories.ts
+++ b/src/textarea.stories.ts
@@ -140,6 +140,7 @@ const meta: Meta = {
     },
     name: {
       table: {
+        defaultValue: { summary: '""' },
         type: { summary: 'string' },
       },
     },

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -71,7 +71,7 @@ export default class GlideCoreTextarea extends LitElement {
   maxlength?: number;
 
   @property({ reflect: true })
-  name?: string;
+  name = '';
 
   // It's typed by TypeScript as a boolean. But we treat it as a string throughout.
   @property({ type: Boolean })


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

We're inconsistent the default values of `name` and `value` as well as how we document them. Native sets both to an empty string by default. All of our components now do the same.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A