### PR TITLE
Conditionally add margin to Label's "description" slot

### DIFF
--- a/.changeset/popular-poems-judge.md
+++ b/.changeset/popular-poems-judge.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Form controls no longer have a small amount of extra whitespace below them when they lack a description.

--- a/src/label.styles.ts
+++ b/src/label.styles.ts
@@ -166,21 +166,20 @@ export default [
 
     .description {
       color: var(--glide-core-text-body-1);
-      display: none;
+      display: block;
       font-family: var(--glide-core-body-xs-font-family);
       font-size: var(--glide-core-body-xs-font-size);
       font-style: var(--glide-core-body-xs-font-style);
       font-weight: var(--glide-core-body-xs-font-weight);
       grid-column: 2;
       line-height: var(--glide-core-body-xs-line-height);
-      margin-block-start: var(--glide-core-spacing-xxs);
+
+      &.content {
+        margin-block-start: var(--glide-core-spacing-xxs);
+      }
 
       &.error {
         color: var(--glide-core-status-error);
-      }
-
-      &.visible {
-        display: block;
       }
     }
   `,


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Form controls no longer have a small amount of extra whitespace below them when they lack a description.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to a form control in Storybook.
2. Verify the "description" slot has no top margin.
3. Give the control a description.
4. Verify the description has a top margin.

## 📸 Images/Videos of Functionality

### Before

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/0f25a5ec-fffa-47e5-94e3-e7daaa37749f">

### After

<img width="1020" alt="image" src="https://github.com/user-attachments/assets/3d19bb6e-8ca3-4204-b475-4ff0903c3d5f">



<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed.  Before and After images are ideal when adjusting styling. -->
