### PR TITLE
`display: contents` Modal's tertiary slotted content

### DIFF
--- a/.changeset/shy-rules-chew.md
+++ b/.changeset/shy-rules-chew.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Tertiary slotted content in a Modal now properly vertically center-aligns itself.

--- a/src/modal.styles.ts
+++ b/src/modal.styles.ts
@@ -69,6 +69,7 @@ export default [
       ::slotted([slot='tertiary']) {
         --size: 1rem;
 
+        display: contents;
         size: 1rem;
       }
     }


### PR DESCRIPTION
## 🚀 Description

Fixes a layout issue with the tertiary slotted content. A fun read: https://ishadeed.com/article/display-contents/

In this case, I think we're at https://ishadeed.com/article/display-contents/#remove-a-container due to the container being a web component.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

- Go to https://glide-core.crowdstrike-ux.workers.dev/fix-modal-icon-layout?path=/docs/modal--overview
- Verify the tertiary slot isn't busted.

## 📸 Images/Videos of Functionality

| Before  | After |
| ------------- | ------------- |
| <img width="618" alt="Screenshot 2024-09-25 at 10 38 17 AM" src="https://github.com/user-attachments/assets/5d29785b-645f-42ca-8a05-199e5be6de4c">  | <img width="637" alt="Screenshot 2024-09-25 at 10 37 42 AM" src="https://github.com/user-attachments/assets/72737cc7-97e1-4ddf-ac4f-6174e1b50a6a">  |

