### PR TITLE
Dropdown Option styling fix 

### DIFF
--- a/.changeset/flat-lemons-flash.md
+++ b/.changeset/flat-lemons-flash.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown Option's label is now vertically centered and shorter when Dropdown's `size` is `"small"`.

--- a/src/dropdown.option.styles.ts
+++ b/src/dropdown.option.styles.ts
@@ -13,39 +13,33 @@ export default [
       &.active {
         background-color: var(--glide-core-surface-hover);
       }
+    }
+
+    .option {
+      align-items: center;
+      block-size: 100%;
+      display: flex;
+      user-select: none;
 
       &.large {
-        --height: 1.75rem;
-        --gap: var(--glide-core-spacing-sm);
-        --padding-inline: var(--glide-core-spacing-sm);
-
+        column-gap: var(--glide-core-spacing-sm);
         font-family: var(--glide-core-body-sm-font-family);
         font-size: var(--glide-core-body-sm-font-size);
         font-style: var(--glide-core-body-sm-font-style);
         font-weight: var(--glide-core-body-sm-font-weight);
         line-height: var(--glide-core-body-sm-line-height);
+        padding-inline: var(--glide-core-spacing-sm);
       }
 
       &.small {
-        --height: 1.25rem;
-        --gap: var(--glide-core-spacing-xs);
-        --padding-inline: var(--glide-core-spacing-xs);
-
+        column-gap: var(--glide-core-spacing-xs);
         font-family: var(--glide-core-body-xs-font-family);
         font-size: var(--glide-core-body-xs-font-size);
         font-style: var(--glide-core-body-xs-font-style);
         font-weight: var(--glide-core-body-xs-font-weight);
         line-height: var(--glide-core-body-xs-line-height);
+        padding-inline: var(--glide-core-spacing-xs);
       }
-    }
-
-    .option {
-      align-items: center;
-      block-size: var(--height);
-      display: flex;
-      gap: var(--gap);
-      padding-inline: var(--padding-inline);
-      user-select: none;
     }
 
     glide-core-checkbox {

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -103,7 +103,6 @@ export default [
     .options {
       --border-width: 1px;
       --padding: var(--glide-core-spacing-xxxs);
-      --private-option-height: 1.75rem;
 
       background-color: var(--glide-core-surface-modal);
       border: var(--border-width) solid var(--glide-core-surface-modal);
@@ -123,6 +122,14 @@ export default [
 
       &.hidden {
         display: none;
+      }
+
+      &.large {
+        --private-option-height: 1.75rem;
+      }
+
+      &.small {
+        --private-option-height: 1.25rem;
       }
     }
 

--- a/src/dropdown.test.basics.ts
+++ b/src/dropdown.test.basics.ts
@@ -41,19 +41,10 @@ it('has defaults', async () => {
     </glide-core-dropdown>`,
   );
 
-  expect(component.hasAttribute('disabled')).to.be.false;
   expect(component.disabled).to.be.false;
-
-  expect(component.hasAttribute('filterable')).to.be.false;
   expect(component.filterable).to.be.false;
-
-  expect(component.getAttribute('name')).to.be.empty.string;
   expect(component.name).to.be.empty.string;
-
-  expect(component.hasAttribute('required')).to.be.false;
   expect(component.required).to.be.false;
-
-  expect(component.getAttribute('size')).to.equal('large');
   expect(component.size).to.equal('large');
 
   // Not reflected, so no attribute assertion is necessary.

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -581,6 +581,7 @@ export default class GlideCoreDropdown extends LitElement {
             class=${classMap({
               options: true,
               hidden: this.isOptionsHidden,
+              [this.size]: true,
             })}
             data-test="options"
             id="options"


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Dropdown Option's label is now vertically centered and shorter when Dropdown's `size` is `"small"`.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Dropdown in Storybook.
2. Set `size` to `"small"`. 
3. Verify Dropdown's options are short and that their labels vertically centered.
4. Set `size` to `"large"`.
5. Verify Dropdown's options are unchanged compared to production.

## 📸 Images/Videos of Functionality

| Before  | After |
| ------------- | ------------- |
| <img width="226" alt="image" src="https://github.com/user-attachments/assets/3c4cf9d3-6bce-4b50-b889-c8b0775a1a8f">  | <img width="225" alt="image" src="https://github.com/user-attachments/assets/7bb543f2-b15e-4a6c-b55d-00fe1b91335b">  |




