### PR TITLE
Fix filterable Dropdown insertion point bug

### DIFF
--- a/.changeset/polite-yaks-drive.md
+++ b/.changeset/polite-yaks-drive.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown no longer prevents the user from setting the insertion point inside the input field.

--- a/src/dropdown.option.styles.ts
+++ b/src/dropdown.option.styles.ts
@@ -43,9 +43,20 @@ export default [
     }
 
     glide-core-checkbox {
+      &.large {
+        &::part(private-label-and-input-and-checkbox) {
+          padding-inline: var(--glide-core-spacing-sm);
+        }
+      }
+
+      &.small {
+        &::part(private-label-and-input-and-checkbox) {
+          padding-inline: var(--glide-core-spacing-xs);
+        }
+      }
+
       &::part(private-label-and-input-and-checkbox) {
-        block-size: var(--height);
-        padding-inline: var(--padding-inline);
+        block-size: var(--private-option-height);
       }
     }
 

--- a/src/dropdown.test.focus.filterable.ts
+++ b/src/dropdown.test.focus.filterable.ts
@@ -213,8 +213,6 @@ it('does not focus the input when `checkValidity` is called', async () => {
 });
 
 it('sets the `value` of the `<input>` to the selected option when focus is lost', async () => {
-  document.body.tabIndex = -1;
-
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
       ${defaultSlot}
@@ -234,11 +232,27 @@ it('sets the `value` of the `<input>` to the selected option when focus is lost'
   component.focus();
   await sendKeys({ type: 'o' });
 
-  document.body.focus();
+  component.blur();
 
   const input = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
   expect(input?.value).to.equal('One');
+});
+
+it('selects the filter text on focus', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder">
+      ${defaultSlot}
+    </glide-core-dropdown>`,
+  );
+
+  component.focus();
+  await sendKeys({ type: 'one' });
+
+  component.blur();
+  component.focus();
+
+  expect(window.getSelection()?.toString()).to.equal('one');
 });

--- a/src/dropdown.test.focus.ts
+++ b/src/dropdown.test.focus.ts
@@ -46,9 +46,7 @@ it('closes and reports validity when it loses focus', async () => {
   await sendKeys({ up: 'Shift' });
 
   expect(component.open).to.be.false;
-
   expect(component.shadowRoot?.activeElement).to.equal(null);
-
   expect(component.validity.valid).to.be.false;
 
   expect(component.shadowRoot?.querySelector('glide-core-private-label')?.error)

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -898,53 +898,6 @@ it('selects the filter text when `click()` is called', async () => {
   expect(window.getSelection()?.toString()).to.equal('one');
 });
 
-it('selects the filter text when the `<input>` is clicked', async () => {
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown label="Label" placeholder="Placeholder">
-      ${defaultSlot}
-    </glide-core-dropdown>`,
-  );
-
-  component.focus();
-  await sendKeys({ type: 'one' });
-
-  // Calling `click()` would be sweet. The problem is it sets `event.detail` to `0`,
-  // which puts us in a guard in the event handler. `Event` has no `detail` property
-  // and would work. `CustomEvent` is used for completeness and to get us as close as
-  // possible to a real click. See the comment in the handler for more information.
-  component.shadowRoot
-    ?.querySelector('[data-test="input"]')
-    ?.dispatchEvent(new CustomEvent('click', { bubbles: true, detail: 1 }));
-
-  expect(window.getSelection()?.toString()).to.equal('one');
-});
-
-it('selects the filter text when closed and the button is clicked', async () => {
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown label="Label" placeholder="Placeholder">
-      ${defaultSlot}
-    </glide-core-dropdown>`,
-  );
-
-  component.focus();
-  await sendKeys({ type: 'one' });
-
-  component.open = false;
-  await elementUpdated(component);
-
-  // Calling `click()` would be sweet. The problem is it sets `event.detail` to `0`,
-  // which puts us in a guard in the event handler. `Event` has no `detail` property
-  // and would work. `CustomEvent` is used for completeness and to get us as close as
-  // possible to a real click. See the comment in the handler for more information.
-  component.shadowRoot
-    ?.querySelector('[data-test="button"]')
-    ?.dispatchEvent(new CustomEvent('click', { bubbles: true, detail: 1 }));
-
-  await elementUpdated(component);
-
-  expect(window.getSelection()?.toString()).to.equal('one');
-});
-
 it('clicks the `<input>` when `click()` is called', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder">

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -499,6 +499,7 @@ export default class GlideCoreDropdown extends LitElement {
                 tabindex=${this.disabled ? '-1' : '0'}
                 ?disabled=${this.disabled}
                 ?readonly=${this.readonly}
+                @focusin=${this.#onInputFocusin}
                 @input=${this.#onInputInput}
                 @keydown=${this.#onInputKeydown}
                 ${ref(this.#inputElementRef)}
@@ -1139,7 +1140,6 @@ export default class GlideCoreDropdown extends LitElement {
       // Thus we return, with or without a form for consistency.
     } else if (event.detail !== 0) {
       this.open = true;
-      this.#inputElementRef.value?.select();
     }
   }
 
@@ -1152,15 +1152,23 @@ export default class GlideCoreDropdown extends LitElement {
     // label or padding shouldn't cause the input to lose focus. The trouble is we
     // don't know it if was the tag's removal button that was clicked because it's
     // in a shadow DOM.
-
     const isFilterable = this.filterable || this.isFilterable;
+    const isGlideCoreTag = event.target instanceof GlideCoreTag;
 
-    if (!(event.target instanceof GlideCoreTag) && isFilterable) {
-      event.preventDefault();
-      this.focus();
-    } else if (!(event.target instanceof GlideCoreTag)) {
+    if (isFilterable && !isGlideCoreTag) {
+      // If the `<input>` was clicked, canceling the event would prevent the insertion
+      // point from moving inside the input.
+      if (event.target !== this.#inputElementRef.value) {
+        event.preventDefault();
+        this.focus();
+      }
+    } else if (!isGlideCoreTag) {
       event.preventDefault();
     }
+  }
+
+  #onInputFocusin() {
+    this.#inputElementRef.value?.select();
   }
 
   #onInputInput(event: Event) {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Dropdown no longer prevents the user from setting the insertion point inside the input field. Thanks for telling me about this issue, @danwenzel.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Dropdown in Storybook.
2. Set `filterable` to `true`.
3. Add some text to the `<input>`.
4. Click outside of Dropdown.
5. Now click Dropdown.
6. Verify the text you entered is selected.
7. Click inside the text you entered.
8. Verify the insertion point moved inside the text.

## 📸 Images/Videos of Functionality

N/A
