### PR TITLE
Add link slot to Tree Item

### DIFF
--- a/.changeset/sour-stingrays-develop.md
+++ b/.changeset/sour-stingrays-develop.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+An optional link slot has been added to Tree Item, allowing users to provide their own <a> tag or custom link component.

--- a/src/tree.item.styles.ts
+++ b/src/tree.item.styles.ts
@@ -100,6 +100,17 @@ export default [
       &.prefix-icon .label {
         padding-inline-start: var(--glide-core-spacing-xs);
       }
+
+      &.has-link {
+        /* If they have a link, the area outside that link slot isn't clickable */
+        cursor: default;
+      }
+    }
+
+    ::slotted([slot='link']) {
+      color: inherit;
+      inline-size: 100%;
+      text-decoration: none;
     }
 
     ::slotted([slot='menu']) {

--- a/src/tree.stories.ts
+++ b/src/tree.stories.ts
@@ -70,6 +70,8 @@ const meta: Meta = {
             <glide-core-example-icon name="settings"></glide-core-example-icon>
           </glide-core-tree-item-icon-button>
 
+          <a href="/" slot="link">Link slot</a>
+
           <glide-core-tree-item-menu
             slot="menu"
             placement=${arguments_['<glide-core-tree-item-menu>.placement']}

--- a/src/tree.test.focus.ts
+++ b/src/tree.test.focus.ts
@@ -9,6 +9,7 @@ import GlideCoreTreeItemIconButton from './tree.item.icon-button.js';
 import GlideCoreTreeItemMenu from './tree.item.menu.js';
 
 GlideCoreTree.shadowRootOptions.mode = 'open';
+GlideCoreTreeItem.shadowRootOptions.mode = 'open';
 
 it('focuses the first tree item when tree is focused, if there are no selected items', async () => {
   const component = await fixture<GlideCoreTree>(html`
@@ -496,4 +497,70 @@ it('does not select a tree item if Enter is pressed while its tree item icon but
   await sendKeys({ press: 'Enter' });
 
   expect(childItems[0].hasAttribute('selected')).to.be.false;
+});
+
+it("can click on a link in a Tree Item's link slot", async () => {
+  let clicked = false;
+
+  const component = await fixture<GlideCoreTree>(html`
+    <glide-core-tree>
+      <glide-core-tree-item>
+        <a
+          href="/"
+          data-test="link"
+          slot="link"
+          @click=${(event: Event) => {
+            clicked = true;
+            event?.preventDefault();
+          }}
+          >Link slot</a
+        >
+      </glide-core-tree-item>
+    </glide-core-tree>
+  `);
+
+  const treeItem = component.querySelector('glide-core-tree-item');
+  assert(treeItem);
+  const notLink = treeItem.shadowRoot?.querySelector('.label-container');
+
+  assert(notLink instanceof HTMLElement);
+
+  notLink.click();
+
+  expect(clicked).to.be.false;
+  expect(treeItem?.selected).to.be.false;
+
+  const link = component.querySelector('[data-test="link"]');
+  assert(link instanceof HTMLAnchorElement);
+  link.click();
+  expect(clicked).to.be.true;
+  expect(treeItem?.selected).to.be.true;
+});
+
+it("can click on a link in a Tree Item's link slot with the keyboard", async () => {
+  let clicked = false;
+
+  const component = await fixture<GlideCoreTree>(html`
+    <glide-core-tree>
+      <glide-core-tree-item>
+        <a
+          href="/"
+          data-test="link"
+          slot="link"
+          @click=${(event: Event) => {
+            clicked = true;
+            event?.preventDefault();
+          }}
+          >Link slot</a
+        >
+      </glide-core-tree-item>
+    </glide-core-tree>
+  `);
+
+  const treeItem = component.querySelector('glide-core-tree-item');
+  treeItem?.focus();
+  await sendKeys({ press: 'Enter' });
+
+  expect(clicked).to.be.true;
+  expect(treeItem?.selected).to.be.true;
 });


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Adds a link slot to Tree Item, allowing users to provide their own `<a>` tag or custom link component.

```
<glide-core-tree-item>
  <a href="/" slot="link">Link slot</a>
</glide-core-tree-item>
```

This element will be rendered as a child element of Tree Item (It would be great to instead have the link element be the entirety of the Tree Item, but I don't see how that would be possible while still supporting icon button and menu slots within the same Tree Item):

<img width="292" alt="image" src="https://github.com/user-attachments/assets/3df64544-b492-4feb-9042-6e4896c63f0e">

This allows native link capability like opening the link in a new tab.  

Clicking on the link will select the Tree Item, and hitting Enter when the Tree Item is focuses will trigger a click on the link.


## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

An example has been added in [Storybook](https://glide-core.crowdstrike-ux.workers.dev/tree-item-links?path=/docs/tree--overview):

![image](https://github.com/user-attachments/assets/c71b71f0-05eb-4f94-8263-ca794d5c726c)


## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed. Before and after images are ideal when adjusting styling.

Use a markdown table to display changes side-by-side for easier comparison.

| Before  | After |
| ------- | ----- |
|  Image  | Image |

-->
