### PR TITLE
Handle multiselect Dropdown tag overflow automatically

### DIFF
--- a/.changeset/curvy-hornets-peel.md
+++ b/.changeset/curvy-hornets-peel.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Multiselect Dropdown previously moved selected option tags into an overflow menu when they exceeded 3.
+It now dynamically adds tags to the overflow menu based on available space.

--- a/src/dropdown.option.ts
+++ b/src/dropdown.option.ts
@@ -98,7 +98,7 @@ export default class GlideCoreDropdownOption extends LitElement {
   @state()
   private get isMultiple() {
     // The soonest Dropdown can set `this.privateMultiple` is in its `firstUpdated`.
-    // By then, however, this component has has already completed its first render. So
+    // By then, however, this component has has already completed its initial render. So
     // we fall sadly back to `this.closest('glide-core-dropdown')`. `this.privateMultiple`
     // is still useful for when Dropdown's `this.multiple` is change dynamically.
     return (

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -11,15 +11,24 @@ const meta: Meta = {
   title: 'Dropdown',
   tags: ['autodocs'],
   decorators: [
-    (story) =>
-      html`<form action="/" style="display: block; width: max-content;">
+    (story, context) => {
+      // `width: max-content` on the overview page so Dropdown is a little
+      // cleaner in appearance. Full width elsewhere so it's easy to play with
+      // tag overflow.
+      return html`<form
+        action="/"
+        style="display: block; ${context.viewMode === 'docs'
+          ? 'width: max-content'
+          : ''}"
+      >
         <script type="ignore">
           import '@crowdstrike/glide-core/dropdown.js';
           import '@crowdstrike/glide-core/dropdown.option.js';
         </script>
 
         ${story()}
-      </form>`,
+      </form>`;
+    },
   ],
   parameters: {
     docs: {

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -185,6 +185,7 @@ export default [
     }
 
     .tag-overflow-text {
+      align-content: center;
       color: var(--glide-core-text-link);
     }
 

--- a/src/dropdown.test.basics.multiple.ts
+++ b/src/dropdown.test.basics.multiple.ts
@@ -99,9 +99,14 @@ it('has a tag when an option is initially selected', async () => {
   expect(tag?.textContent?.trim()).to.equal('One');
 });
 
-it('only has so many tags when many options are initially selected', async () => {
+it('hides tags to prevent overflow', async () => {
   const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown label="Label" placeholder="Placeholder" multiple>
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      multiple
+      style="display: block; max-width: 20rem;"
+    >
       <glide-core-dropdown-option
         label="One"
         value="one"
@@ -128,13 +133,16 @@ it('only has so many tags when many options are initially selected', async () =>
     </glide-core-dropdown>`,
   );
 
+  // Wait for the Resize Observer to do its thing.
+  await aTimeout(0);
+
   const tagContainers = [
     ...(component.shadowRoot?.querySelectorAll<HTMLElement>(
       '[data-test="tag-container"]',
     ) ?? []),
   ].filter((element) => element.checkVisibility());
 
-  expect(tagContainers?.length).to.equal(3);
+  expect(tagContainers?.length).to.equal(2);
 });
 
 it('shows Select All', async () => {

--- a/src/dropdown.test.interactions.multiple.ts
+++ b/src/dropdown.test.interactions.multiple.ts
@@ -723,9 +723,14 @@ it('has no internal label when an option is newly selected', async () => {
   expect(label).to.not.exist;
 });
 
-it('only has so many tags when many options are selected', async () => {
+it('hides tags to prevent overflow', async () => {
   const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown label="Label" placeholder="Placeholder" multiple>
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      multiple
+      style="display: block; max-width: 20rem;"
+    >
       <glide-core-dropdown-option
         label="One"
         value="one"
@@ -755,7 +760,8 @@ it('only has so many tags when many options are selected', async () => {
   options[2].selected = true;
   options[3].selected = true;
 
-  await elementUpdated(component);
+  // Wait for the Resize Observer to do its thing.
+  await aTimeout(0);
 
   const tagContainers = [
     ...(component.shadowRoot?.querySelectorAll<HTMLElement>(
@@ -763,12 +769,17 @@ it('only has so many tags when many options are selected', async () => {
     ) ?? []),
   ].filter((element) => element.checkVisibility());
 
-  expect(tagContainers?.length).to.equal(3);
+  expect(tagContainers?.length).to.equal(2);
 });
 
-it('has overflow text when many options are selected', async () => {
+it('has overflow text when its tags are overflowing', async () => {
   const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown label="Label" placeholder="Placeholder" multiple>
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      multiple
+      style="display: block; max-width: 20rem;"
+    >
       <glide-core-dropdown-option
         label="One"
         value="one"
@@ -798,13 +809,14 @@ it('has overflow text when many options are selected', async () => {
   options[2].selected = true;
   options[3].selected = true;
 
-  await elementUpdated(component);
+  // Wait for the Resize Observer to do its thing.
+  await aTimeout(0);
 
   const tagOverflow = component.shadowRoot?.querySelector(
     '[data-test="tag-overflow-count"]',
   );
 
-  expect(tagOverflow?.textContent?.trim()).to.equal('1');
+  expect(tagOverflow?.textContent?.trim()).to.equal('2');
 });
 
 it('deselects the option when its tag is removed', async () => {

--- a/src/tag.styles.ts
+++ b/src/tag.styles.ts
@@ -19,6 +19,7 @@ export default [
       justify-content: center;
       line-height: 1;
       margin: 0;
+      max-inline-size: max-content;
       min-block-size: var(--glide-core-spacing-md);
       opacity: 1;
       overflow: hidden;


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- Handles multiselect Dropdown tag overflow automatically based on the available space.
- Tidies up the default slot handler slightly by [removing](https://github.com/CrowdStrike/glide-core/pull/421/files#diff-7431ab16692f7d7a7cfecdb04f55d6c62f87417591065650d88dc407a9b62f3bR847-R851) the Select All case and [setting](https://github.com/CrowdStrike/glide-core/pull/421/files#diff-7431ab16692f7d7a7cfecdb04f55d6c62f87417591065650d88dc407a9b62f3bR650-R651) Select All's attributes in line.
- Fixes an unpublished Tag bug.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to the multiselect [Dropdown](https://glide-core.crowdstrike-ux.workers.dev/handle-dropdown-tag-overflow-automatically?path=/story/dropdown--dropdown&args=multiple:!true) story.
2. Select all three options.
3. Resize the viewport down to a very small size and back.
4. Use DevTools to play with the size of Dropdown's `<form>`. Give it a smaller width and a larger one.
5. Verify that Dropdown's tags are moved to and from overflow and that the overflow text ("+ 2 more") is correct.

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

![2024-10-07_09-09-47 (2)](https://github.com/user-attachments/assets/8bce74c6-256e-453b-bce9-33cb2f7b3633)
