### PR TITLE
Storybook controls removal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
 - [Best practices](#best-practices)
   - [Proceed with caution when upgrading Storybook](#proceed-with-caution-when-upgrading-storybook)
   - [Prefer controls over stories](#prefer-controls-over-stories)
+  - [Don't add Storybook controls for properties and methods inherited from `HTMLElement` or `Element`](#dont-add-storybook-controls-for-properties-and-methods-inherited-from-htmlelement-or-element)
   - [Only set required attributes in stories](#only-set-required-attributes-in-stories)
   - [Prefer encapsulation](#prefer-encapsulation)
     - [Avoid styling `:host`](#avoid-styling-host)
@@ -75,6 +76,22 @@ only write stories for component states that can't reasonably be changed via a c
 
 A story showing the use of an optional slot that requires specific markup is one example.
 A story showing an error state triggered by a form submission is another.
+
+### Don't add Storybook controls for properties and methods inherited from `HTMLElement` or `Element`
+
+Our components extend `LitElement`, which extends `HTMLElement`—which extends `Element`.
+So our components can be assumed to implement properties and methods inherited from those classes.
+Ideally, we'd document everything.
+But Storybook's controls table would quickly become cluttered.
+And adding and maintaining controls isn't free.
+
+The exception is `addEventListener()`.
+It is inherited.
+But which events it supports isn't obvious.
+Document `addEventListener()` if your component dispatches events that aren't universal—like `"change"`, `"input"`, or `"toggle"`.
+
+If you're unsure where a property or method comes from, TypeScript's [Playground](https://www.typescriptlang.org/play) can help.
+So can your editor and [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes).
 
 ### Only set required attributes in stories
 

--- a/src/accordion.stories.ts
+++ b/src/accordion.stories.ts
@@ -63,8 +63,6 @@ const meta: Meta = {
     label: 'Label',
     'slot="default"': 'Content',
     'addEventListener(event, listener)': '',
-    'click()': '',
-    'focus(options)': '',
     open: false,
     'slot="prefix-icon"': '',
     'slot="suffix-icons"': '',
@@ -89,24 +87,6 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail: '(event: "toggle", listener: (event: Event) => void) => void',
-        },
-      },
-    },
-    'click()': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '() => void',
-        },
-      },
-    },
-    'focus(options)': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
         },
       },
     },

--- a/src/button-group.stories.ts
+++ b/src/button-group.stories.ts
@@ -49,14 +49,14 @@ const meta: Meta = {
               <glide-core-button-group-button label="Two">
                 <glide-core-example-icon
                   slot="icon"
-                  name="info"
+                  name="edit"
                 ></glide-core-example-icon>
               </glide-core-button-group-button>
 
               <glide-core-button-group-button label="Three">
                 <glide-core-example-icon
                   slot="icon"
-                  name="info"
+                  name="calendar"
                 ></glide-core-example-icon>
               </glide-core-button-group-button>`;
           },

--- a/src/button.stories.ts
+++ b/src/button.stories.ts
@@ -22,22 +22,16 @@ const meta: Meta = {
     /* eslint-disable @typescript-eslint/no-unsafe-argument, unicorn/explicit-length-check */
     return html`
       <glide-core-button
-        aria-controls=${arguments_['aria-controls'] || nothing}
-        aria-expanded=${arguments_['aria-expanded'] || nothing}
-        aria-haspopup=${arguments_['aria-haspopup'] || nothing}
         formaction=${arguments_.formaction || nothing}
         formenctype=${arguments_.formenctype || nothing}
         formmethod=${arguments_.formmethod || nothing}
         formtarget=${arguments_.formtarget || nothing}
         label=${arguments_.label || nothing}
         name=${arguments_.name || nothing}
-        popovertarget=${arguments_.popovertarget || nothing}
-        popovertargetaction=${arguments_.popovertargetaction || nothing}
         size=${arguments_.size || nothing}
         type=${arguments_.type || nothing}
         value=${arguments_.value || nothing}
         variant=${arguments_.variant || nothing}
-        ?autofocus=${arguments_.autofocus}
         ?disabled=${arguments_.disabled || nothing}
         ?formnovalidate=${arguments_.formnovalidate}
       >
@@ -47,13 +41,7 @@ const meta: Meta = {
   },
   args: {
     label: 'Label',
-    'aria-controls': '',
-    'aria-expanded': '',
-    'aria-haspopup': '',
-    autofocus: false,
-    'click()': '',
     disabled: false,
-    'focus(options)': '',
     form: '',
     formaction: '',
     formenctype: 'application/x-www-form-urlencoded',
@@ -61,8 +49,6 @@ const meta: Meta = {
     formnovalidate: false,
     formtarget: '_self',
     name: '',
-    popovertarget: '',
-    popovertargetaction: 'toggle',
     size: 'large',
     'slot="prefix-icon"': '',
     'slot="suffix-icon"': '',
@@ -77,76 +63,10 @@ const meta: Meta = {
       },
       type: { name: 'string', required: true },
     },
-    'aria-controls': {
-      table: {
-        defaultValue: {
-          summary: 'null',
-        },
-      },
-    },
-    'aria-expanded': {
-      control: { type: 'select' },
-      table: {
-        defaultValue: {
-          summary: 'null',
-        },
-        type: {
-          summary: '"true" | "false"',
-        },
-      },
-      options: ['', 'true', 'false'],
-    },
-    'aria-haspopup': {
-      control: { type: 'select' },
-      table: {
-        defaultValue: {
-          summary: 'null',
-        },
-        type: {
-          summary:
-            '"true" | "false" | "menu" | "listbox" | "tree" | "grid" | "dialog"',
-        },
-      },
-      options: [
-        '',
-        'true',
-        'false',
-        'menu',
-        'listbox',
-        'tree',
-        'grid',
-        'dialog',
-      ],
-    },
-    autofocus: {
-      table: {
-        defaultValue: {
-          summary: 'false',
-        },
-      },
-    },
-    'click()': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '() => void',
-        },
-      },
-    },
     disabled: {
       table: {
         defaultValue: {
           summary: 'false',
-        },
-      },
-    },
-    'focus(options)': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
         },
       },
     },
@@ -222,18 +142,6 @@ const meta: Meta = {
         },
       },
     },
-    popovertargetaction: {
-      control: { type: 'select' },
-      options: ['', 'hide', 'show', 'toggle'],
-      table: {
-        defaultValue: {
-          summary: '"toggle"',
-        },
-        type: {
-          summary: '"hide" | "show" | "toggle"',
-        },
-      },
-    },
     size: {
       control: { type: 'radio' },
       options: ['large', 'small'],
@@ -297,22 +205,16 @@ export const WithIcons: StoryObj = {
   render(arguments_) {
     return html`
       <glide-core-button
-        aria-controls=${arguments_['aria-controls'] || nothing}
-        aria-expanded=${arguments_['aria-expanded'] || nothing}
-        aria-haspopup=${arguments_['aria-haspopup'] || nothing}
         formaction=${arguments_.formaction || nothing}
         formenctype=${arguments_.formenctype || nothing}
         formmethod=${arguments_.formmethod || nothing}
         formtarget=${arguments_.formtarget || nothing}
         label=${arguments_.label || nothing}
         name=${arguments_.name || nothing}
-        popovertarget=${arguments_.popovertarget || nothing}
-        popovertargetaction=${arguments_.popovertargetaction || nothing}
         size=${arguments_.size || nothing}
         type=${arguments_.type || nothing}
         value=${arguments_.value || nothing}
         variant=${arguments_.variant || nothing}
-        ?autofocus=${arguments_.autofocus}
         ?disabled=${arguments_.disabled}
         ?formnovalidate=${arguments_.formnovalidate}
       >

--- a/src/checkbox.stories.ts
+++ b/src/checkbox.stories.ts
@@ -30,9 +30,7 @@ const meta: Meta = {
     'addEventListener(event, listener)': '',
     checked: false,
     'checkValidity()': '',
-    'click()': '',
     disabled: false,
-    'focus(options)': '',
     'hide-label': false,
     indeterminate: false,
     name: '',
@@ -70,28 +68,10 @@ const meta: Meta = {
         type: { summary: 'boolean' },
       },
     },
-    'click()': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '() => void',
-        },
-      },
-    },
     disabled: {
       table: {
         defaultValue: { summary: 'false' },
         type: { summary: 'boolean' },
-      },
-    },
-    'focus(options)': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
-        },
       },
     },
     'hide-label': {

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -43,9 +43,7 @@ const meta: Meta = {
     'slot="default"': '',
     'addEventListener(event, listener)': '',
     'checkValidity()': '',
-    'click()': '',
     disabled: false,
-    'focus(options)': '',
     filterable: false,
     'hide-label': false,
     multiple: false,
@@ -93,15 +91,6 @@ const meta: Meta = {
         },
       },
     },
-    'click()': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '() => void',
-        },
-      },
-    },
     disabled: {
       table: {
         defaultValue: { summary: 'false' },
@@ -115,15 +104,6 @@ const meta: Meta = {
           summary: 'boolean',
           detail:
             '// Dropdown will be filterable regardless of this attribute when there are more than 10 options',
-        },
-      },
-    },
-    'focus(options)': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
         },
       },
     },

--- a/src/icon-button.stories.ts
+++ b/src/icon-button.stories.ts
@@ -30,9 +30,7 @@ const meta: Meta = {
   args: {
     label: 'Label',
     'slot="default"': '',
-    'click()': '',
     disabled: false,
-    'focus(options)': '',
     variant: 'primary',
   },
   argTypes: {
@@ -48,30 +46,12 @@ const meta: Meta = {
       },
       type: { name: 'function', required: true },
     },
-    'click()': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '() => void',
-        },
-      },
-    },
     disabled: {
       table: {
         defaultValue: {
           summary: 'false',
         },
         type: { summary: 'boolean' },
-      },
-    },
-    'focus(options)': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
-        },
       },
     },
     variant: {

--- a/src/input.stories.ts
+++ b/src/input.stories.ts
@@ -32,9 +32,7 @@ const meta: Meta = {
     autocomplete: 'on',
     'checkValidity()': '',
     clearable: false,
-    'click()': '',
     disabled: false,
-    'focus(options)': '',
     'hide-label': false,
     maxlength: '',
     name: '',
@@ -153,15 +151,6 @@ const meta: Meta = {
         },
       },
     },
-    'click()': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '() => void',
-        },
-      },
-    },
     clearable: {
       table: {
         defaultValue: { summary: 'false' },
@@ -172,15 +161,6 @@ const meta: Meta = {
       table: {
         defaultValue: { summary: 'false' },
         type: { summary: 'boolean' },
-      },
-    },
-    'focus(options)': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
-        },
       },
     },
     'hide-label': {

--- a/src/menu.stories.ts
+++ b/src/menu.stories.ts
@@ -33,8 +33,6 @@ const meta: Meta = {
   args: {
     'slot="default"': '',
     'slot="target"': '',
-    'click()': '',
-    'focus(options)': '',
     open: false,
     placement: 'bottom-start',
     size: 'large',
@@ -54,15 +52,6 @@ const meta: Meta = {
         type: { summary: 'Element', detail: 'Any focusable element.' },
       },
       type: { name: 'function', required: true },
-    },
-    'focus(options)': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
-        },
-      },
     },
     open: {
       table: {

--- a/src/split-button.stories.ts
+++ b/src/split-button.stories.ts
@@ -112,23 +112,17 @@ const meta: Meta = {
     size: 'large',
     variant: 'primary',
     '<glide-core-split-button-primary-button>.label': 'Label',
-    '<glide-core-split-button-primary-button>.click()': '',
     '<glide-core-split-button-primary-button>.disabled': false,
-    '<glide-core-split-button-primary-button>.focus(options)': '',
     '<glide-core-split-button-primary-button>[slot="icon"]': '',
     '<glide-core-split-button-primary-link>.label': 'Label',
     '<glide-core-split-button-primary-link>.url': '/',
-    '<glide-core-split-button-primary-link>.click()': '',
     '<glide-core-split-button-primary-link>.disabled': false,
-    '<glide-core-split-button-primary-link>.focus(options)': '',
     '<glide-core-split-button-primary-link>[slot="icon"]': '',
     '<glide-core-split-button-secondary-button>.label': 'Label',
-    '<glide-core-split-button-secondary-button>.click()': '',
+    '<glide-core-split-button-secondary-button>[slot="default"]': '',
     '<glide-core-split-button-secondary-button>.disabled': false,
-    '<glide-core-split-button-secondary-button>.focus(options)': '',
     '<glide-core-split-button-secondary-button>.menu-open': false,
     '<glide-core-split-button-secondary-button>.menu-placement': 'bottom-end',
-    '<glide-core-split-button-secondary-button>[slot="default"]': '',
   },
   argTypes: {
     'slot="default"': {
@@ -176,34 +170,12 @@ const meta: Meta = {
         type: { summary: 'string' },
       },
     },
-    '<glide-core-split-button-primary-button>.click()': {
-      name: 'click()',
-      control: false,
-      table: {
-        category: 'Split Button Primary Button',
-        type: {
-          summary: 'method',
-          detail: '() => void',
-        },
-      },
-    },
     '<glide-core-split-button-primary-button>.disabled': {
       name: 'disabled',
       table: {
         category: 'Split Button Primary Button',
         defaultValue: { summary: 'false' },
         type: { summary: 'boolean' },
-      },
-    },
-    '<glide-core-split-button-primary-button>.focus(options)': {
-      name: 'focus(options)',
-      control: false,
-      table: {
-        category: 'Split Button Primary Button',
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
-        },
       },
     },
     '<glide-core-split-button-primary-button>[slot="icon"]': {
@@ -230,34 +202,12 @@ const meta: Meta = {
         type: { summary: 'string' },
       },
     },
-    '<glide-core-split-button-primary-link>.click()': {
-      name: 'click()',
-      control: false,
-      table: {
-        category: 'Split Button Primary Link',
-        type: {
-          summary: 'method',
-          detail: '() => void',
-        },
-      },
-    },
     '<glide-core-split-button-primary-link>.disabled': {
       name: 'disabled',
       table: {
         category: 'Split Button Primary Link',
         defaultValue: { summary: 'false' },
         type: { summary: 'boolean' },
-      },
-    },
-    '<glide-core-split-button-primary-link>.focus(options)': {
-      name: 'focus(options)',
-      control: false,
-      table: {
-        category: 'Split Button Primary Link',
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
-        },
       },
     },
     '<glide-core-split-button-primary-link>[slot="icon"]': {
@@ -286,34 +236,12 @@ const meta: Meta = {
       },
       type: { name: 'function', required: true },
     },
-    '<glide-core-split-button-secondary-button>.click()': {
-      name: 'click()',
-      control: false,
-      table: {
-        category: 'Split Button Secondary Button',
-        type: {
-          summary: 'method',
-          detail: '() => void',
-        },
-      },
-    },
     '<glide-core-split-button-secondary-button>.disabled': {
       name: 'disabled',
       table: {
         category: 'Split Button Secondary Button',
         defaultValue: { summary: 'false' },
         type: { summary: 'boolean' },
-      },
-    },
-    '<glide-core-split-button-secondary-button>.focus(options)': {
-      name: 'focus(options)',
-      control: false,
-      table: {
-        category: 'Split Button Secondary Button',
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
-        },
       },
     },
     '<glide-core-split-button-secondary-button>.menu-open': {

--- a/src/tag.stories.ts
+++ b/src/tag.stories.ts
@@ -29,8 +29,6 @@ const meta: Meta = {
   args: {
     label: 'Label',
     'addEventListener(event, listener)': '',
-    'click()': '',
-    'focus(options)': '',
     removable: false,
     size: 'medium',
     'slot="icon"': '',
@@ -47,24 +45,6 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail: '(event: "remove", listener: (event: Event) => void) => void',
-        },
-      },
-    },
-    'click()': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '() => void',
-        },
-      },
-    },
-    'focus(options)': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
         },
       },
     },

--- a/src/textarea.stories.ts
+++ b/src/textarea.stories.ts
@@ -48,9 +48,7 @@ const meta: Meta = {
     autocapitalize: 'on',
     autocomplete: 'on',
     'checkValidity()': '',
-    'click()': '',
     disabled: false,
-    'focus(options)': '',
     'hide-label': false,
     maxlength: '',
     name: '',
@@ -116,28 +114,10 @@ const meta: Meta = {
         },
       },
     },
-    'click()': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '() => void',
-        },
-      },
-    },
     disabled: {
       table: {
         defaultValue: { summary: 'false' },
         type: { summary: 'boolean' },
-      },
-    },
-    'focus(options)': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
-        },
       },
     },
     'hide-label': {

--- a/src/toggle.stories.ts
+++ b/src/toggle.stories.ts
@@ -27,9 +27,7 @@ const meta: Meta = {
     label: 'Label',
     'addEventListener(event, listener)': '',
     checked: false,
-    'click()': '',
     disabled: false,
-    'focus(options)': '',
     'hide-label': false,
     orientation: 'horizontal',
     'slot="description"': '',
@@ -59,28 +57,10 @@ const meta: Meta = {
         type: { summary: 'boolean' },
       },
     },
-    'click()': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '() => void',
-        },
-      },
-    },
     disabled: {
       table: {
         defaultValue: { summary: 'false' },
         type: { summary: 'boolean' },
-      },
-    },
-    'focus(options)': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: '(options?: FocusOptions) => void',
-        },
       },
     },
     'hide-label': {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Our story controls have gotten a lot better. But they're still inconsistent. 

We started documenting `focus(options)` a little while back because Split Button (before its design change, which forced a new API) had an [`options.target`](https://github.com/CrowdStrike/glide-core/pull/361/files#diff-e9c95e360cb5724c1ffc4b987abfb8eb612b77c66cda5b277f8df9a6f941612bR10) property. 

It followed (or did for me) that if we're documenting `focus(options)`, we should document `click()` because not every component supports `click()` (though all components have a `click()` method regardless). Either way, Split Button's `focus()` method no longer has or needs an `options.target`. 

So what to do about the `focus()` and `click()` controls? And where do we  draw the line? What about all the other properties and methods inherited from `Element` or `HTMLElement`? 

Here's a [possible](https://github.com/CrowdStrike/glide-core/pull/424/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R80-R95) approach:

> ### Don't add Storybook controls for properties and methods inherited from `HTMLElement` or `Element`
>
> Our components extend `LitElement`, which extends `HTMLElement`—which extends `Element`. So our components can be assumed to implement properties and methods inherited from those classes. Ideally, we'd document everything. But Storybook's controls table would quickly become cluttered. And adding and maintaining controls isn't free.
>
> The exception is `addEventListener()`. It is inherited. But which events it supports isn't obvious. Document `addEventListener()` if your component dispatches events that aren't universal—like `"change"`, `"input"`, or `"toggle"`.


It's a simple rule that we could follow consistently. It would also let us remove some controls:

- `aria-controls`
- `aria-expanded`
- `aria-haspopup`
- `autofocus`
- `click()`
- `focus()`
- `popovertarget`
- `popovertargetaction`

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A
