### PR TITLE
Ensure correct gap between Tree Item prefix icon and label

### DIFF
--- a/.changeset/dull-comics-help.md
+++ b/.changeset/dull-comics-help.md
@@ -1,0 +1,8 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Ensure correct gap between Tree Item prefix icon and label
+
+We were previously targeting the slotted element,
+which wasn't working if that slotted element had `display:contents`

--- a/src/tree.item.styles.ts
+++ b/src/tree.item.styles.ts
@@ -96,10 +96,10 @@ export default [
           background-color: var(--glide-core-color-dark-blue);
         }
       }
-    }
 
-    ::slotted([slot='prefix']) {
-      margin-inline-end: var(--glide-core-spacing-xs);
+      &.prefix-icon .label {
+        padding-inline-start: var(--glide-core-spacing-xs);
+      }
     }
 
     ::slotted([slot='menu']) {

--- a/src/tree.item.ts
+++ b/src/tree.item.ts
@@ -86,6 +86,7 @@ export default class GlideCoreTreeItem extends LitElement {
       <div
         class=${classMap({
           'label-container': true,
+          'prefix-icon': this.hasPrefixIcon,
         })}
         tabindex="-1"
         @focusout=${this.#handleFocusOut}
@@ -135,7 +136,11 @@ export default class GlideCoreTreeItem extends LitElement {
           `,
         )}
 
-        <slot name="prefix"></slot>
+        <slot
+          name="prefix"
+          ${ref(this.#prefixSlotElementRef)}
+          @slotchange=${this.#onPrefixSlotChange}
+        ></slot>
         <div class="label">${this.label}</div>
         <div class="icon-container">
           <slot
@@ -190,6 +195,9 @@ export default class GlideCoreTreeItem extends LitElement {
   @state()
   private childTreeItems: GlideCoreTreeItem[] = [];
 
+  @state()
+  private hasPrefixIcon = false;
+
   #defaultSlotElementRef = createRef<HTMLSlotElement>();
 
   #labelContainerElementRef = createRef<HTMLInputElement>();
@@ -197,6 +205,8 @@ export default class GlideCoreTreeItem extends LitElement {
   #localize = new LocalizeController(this);
 
   #menuSlotElementRef = createRef<HTMLSlotElement>();
+
+  #prefixSlotElementRef = createRef<HTMLSlotElement>();
 
   get #ariaExpanded() {
     if (this.hasChildTreeItems) {
@@ -255,6 +265,11 @@ export default class GlideCoreTreeItem extends LitElement {
         assignedElement.label = this.#localize.term('actionsFor', this.label);
       }
     }
+  }
+
+  #onPrefixSlotChange() {
+    const assignedNodes = this.#prefixSlotElementRef.value?.assignedNodes();
+    this.hasPrefixIcon = Boolean(assignedNodes && assignedNodes.length > 0);
   }
 
   #setTabIndexes(tabIndex: -1 | 0) {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Changes where the gap is:

### Before

![image](https://github.com/user-attachments/assets/f6c527c1-5dd9-43d1-9840-ae0f286c2888)

### After

![image](https://github.com/user-attachments/assets/09fc4a38-d495-4291-b792-0809ac049384)


We were previously targeting the slotted element,
which wasn't working if that slotted element had `display:contents`

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

- Go to https://glide-core.crowdstrike-ux.workers.dev/tree-item-spacing-dont-target-slots?path=/docs/tree--overview
- Find a prefix icon, and set `display: contents` on the `glide-core-example-icon`
- Validate the gap is still there

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed. Before and after images are ideal when adjusting styling.

Use a markdown table to display changes side-by-side for easier comparison.

| Before  | After |
| ------- | ----- |
|  Image  | Image |

-->
