### PR TITLE
Pre-release grab bag

### DIFF
--- a/.changeset/brown-pears-walk.md
+++ b/.changeset/brown-pears-walk.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- When inside another web component and open, Menu now closes when its target is clicked.
+- Dropdown can now be navigated using ArrowUp and ArrowDown when opened via click.

--- a/.storybook/overrides.css
+++ b/.storybook/overrides.css
@@ -1,4 +1,5 @@
 .docs-story {
+  /* The element containing the component on the overview page. */
   & > div {
     padding: 0 !important;
   }
@@ -13,6 +14,7 @@
   background-color: var(--glide-core-surface-base-lightest) !important;
 }
 
+/* The tooltip shown when `argTypes[key].table.type` is clicked. */
 [data-popper-interactive] * {
   overflow: visible !important;
   text-wrap: pretty !important;

--- a/src/button.stories.ts
+++ b/src/button.stories.ts
@@ -224,6 +224,7 @@ export const WithIcons: StoryObj = {
           slot="prefix-icon"
           name="calendar"
         ></glide-core-example-icon>
+
         <glide-core-example-icon
           slot="suffix-icon"
           name="edit"

--- a/src/dropdown.test.focus.ts
+++ b/src/dropdown.test.focus.ts
@@ -52,3 +52,23 @@ it('closes and reports validity when it loses focus', async () => {
   expect(component.shadowRoot?.querySelector('glide-core-private-label')?.error)
     .to.be.true;
 });
+
+it('is focused when clicked', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder">
+      <glide-core-dropdown-option
+        label="Label"
+        value="value"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Calling `click()` would be sweet. The problem is it sets `event.detail` to `0`,
+  // which puts us in a guard in the event handler. `Event` has no `detail` property
+  // and would work. `CustomEvent` is used for completeness and to get us as close as
+  // possible to a real click. See the comment in the handler for more information.
+  const button = component.shadowRoot?.querySelector('[data-test="button"]');
+  button?.dispatchEvent(new CustomEvent('click', { bubbles: true, detail: 1 }));
+
+  expect(component.shadowRoot?.activeElement).to.equal(button);
+});

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -338,7 +338,7 @@ export default class GlideCoreDropdown extends LitElement {
     if (this.#componentElementRef.value) {
       observer.observe(this.#componentElementRef.value);
 
-      // Dropdown's "click" handler on the `document` listens for clicks in the
+      // Dropdown's "click" handler on `document` listens for clicks in the
       // capture phase. There's a comment explaining why. `#isComponentClick`
       // must be set before that handler is called so it has the information it
       // needs to determine whether or not to close Dropdown.
@@ -830,8 +830,7 @@ export default class GlideCoreDropdown extends LitElement {
       //
       // Checking that the click's `event.target` is an instance of  `GlideCoreDropdown`
       // or `GlideCoreDropdownOption` would be a lot simpler. But, when Dropdown is
-      // inside of another web component, `event.target` will be set to that component
-      // instead.
+      // inside of another web component, `event.target` will that component instead.
       setTimeout(() => {
         this.#isComponentClick = false;
       });
@@ -1191,6 +1190,7 @@ export default class GlideCoreDropdown extends LitElement {
       // of a form, Enter should submit the form instead of opening Dropdown.
     } else if (event.detail !== 0) {
       this.open = true;
+      this.focus();
     }
   }
 

--- a/src/tooltip.stories.ts
+++ b/src/tooltip.stories.ts
@@ -67,7 +67,7 @@ const meta: Meta = {
         defaultValue: { summary: 'false' },
         type: {
           summary: 'boolean',
-          detail: `// The tooltip is never shown when disabled. Useful when you have markup conditionally rendering Tooltip.\n// Instead of that, always render Tooltip and simply disable it when appropriate.`,
+          detail: `// The tooltip is never shown when disabled. Useful when you have markup conditionally rendering Tooltip.\n// Instead of doing that, always render Tooltip and simply disable it when appropriate.`,
         },
       },
     },


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- When inside another web component and open, Menu now closes when its target is clicked.
- Dropdown can now be navigated using ArrowUp and ArrowDown when opened via click.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

#### When inside another web component and open, Menu now closes when its target is clicked.

1. Navigate to the Split Button story.
2. Click the menu button twice.
3. Verify the menu is opened then closed.
4. Click the menu button.
5. Click outside of Split Button.
6. Verify the menu is closed.

#### Dropdown can now be navigated using ArrowUp and ArrowDown when opened via click.

1. Navigate to the Dropdown story.
2. Click Dropdown to open it.
3. Arrow down and back up.
7. Verify the options were activated.

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A