### PR TITLE
Add a `sticky` attribute to TabGroup

### DIFF
--- a/.changeset/wise-dingos-bow.md
+++ b/.changeset/wise-dingos-bow.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Tab Group now supports a `sticky` attribute, enabling the group to remain fixed at the top of the panel even when the panel content is scrolled.

--- a/src/tab.group.styles.ts
+++ b/src/tab.group.styles.ts
@@ -8,9 +8,15 @@ export default [
       flex-direction: column;
 
       & .tab-container {
+        background-color: var(--glide-core-surface-page);
         border-block-end: 1px solid var(--glide-core-border-base-lighter);
         box-sizing: border-box;
         display: flex;
+      }
+
+      & .sticky {
+        inset-block-start: 0;
+        position: sticky;
       }
 
       & .tab-group {

--- a/src/tab.group.ts
+++ b/src/tab.group.ts
@@ -3,7 +3,12 @@ import { LitElement, html } from 'lit';
 import { LocalizeController } from './library/localize.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
-import { customElement, queryAssignedElements, state } from 'lit/decorators.js';
+import {
+  customElement,
+  property,
+  queryAssignedElements,
+  state,
+} from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
 import GlideCoreTab from './tab.js';
 import GlideCoreTabPanel from './tab.panel.js';
@@ -28,6 +33,9 @@ export default class GlideCoreTabGroup extends LitElement {
   };
 
   static override styles = styles;
+
+  @property({ type: Boolean, reflect: true })
+  sticky = false;
 
   @state()
   get activeTab() {
@@ -75,7 +83,7 @@ export default class GlideCoreTabGroup extends LitElement {
       @keydown=${this.#onKeydown}
       ${ref(this.#componentElementRef)}
     >
-      <div class="tab-container">
+      <div class=${classMap({ 'tab-container': true, sticky: this.sticky })}>
         ${when(
           this.isShowOverflowButtons,
           () => html`

--- a/src/tabs.stories.ts
+++ b/src/tabs.stories.ts
@@ -24,6 +24,7 @@ const meta: Meta = {
     'slot="default"': '',
     'slot="nav"': '',
     'addEventListener(event, listener)': '',
+    sticky: false,
     '<glide-core-tab>.panel': '',
     '<glide-core-tab>[slot="default"]': 'Tab',
     '<glide-core-tab>.active': true,
@@ -35,7 +36,7 @@ const meta: Meta = {
   render(arguments_) {
     /* eslint-disable @typescript-eslint/no-unsafe-argument */
     return html`
-      <glide-core-tab-group>
+      <glide-core-tab-group ?sticky=${arguments_.sticky}>
         <glide-core-tab
           slot="nav"
           panel="1"
@@ -92,6 +93,13 @@ const meta: Meta = {
         },
       },
       type: { name: 'function' },
+    },
+    sticky: {
+      name: 'sticky',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
     },
     '<glide-core-tab>.panel': {
       name: 'panel',


### PR DESCRIPTION
## 🚀 Description

Allows for a Tab Group to set `position: sticky` + `top: 0` via a `sticky` attribute to satisfy a design requirement.

It's been a while since I've written some code - let me know if I missed anything 🙈 

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

- Navigate to [Tab Group's story](https://glide-core.crowdstrike-ux.workers.dev/sticky-tabs?path=/story/tab-group--tabs&args=sticky:!true) with `sticky` enabled.
- Using Dev Tools, select the first `glide-core-tab-panel`.
- Add an inline style that sets `height: 200vh;`.
- Now scroll the panel and verify the Tab Group remains stuck to the top.

## 📸 Images/Videos of Functionality


https://github.com/user-attachments/assets/3fd0b33c-ec17-4cf6-9900-68b7c4ba7b60
