### PR TITLE
Set Checkbox's value before dispatching "private-value-changed"

### DIFF
--- a/.changeset/sweet-lemons-admire.md
+++ b/.changeset/sweet-lemons-admire.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Checkbox Group no longer unchecks Checkboxes whose `value` is changed programmatically.

--- a/src/checkbox.test.events.ts
+++ b/src/checkbox.test.events.ts
@@ -48,6 +48,21 @@ it('dispatches an "input" event when clicked', async () => {
   expect(event.bubbles).to.be.true;
 });
 
+it('dispatches a "private-value-change" event when its `value` is changed programmatically', async () => {
+  const component = await fixture<GlideCoreCheckbox>(
+    html`<glide-core-checkbox label="One" value="one"></glide-core-checkbox>`,
+  );
+
+  setTimeout(() => (component.value = 'two'));
+
+  const event = await oneEvent(component, 'private-value-change');
+
+  expect(event instanceof CustomEvent).to.be.true;
+  expect(event.detail.old).to.equal('one');
+  expect(event.detail.new).to.equal('two');
+  expect(component.value).to.equal('two');
+});
+
 it('dispatches an "invalid" event on submit when required and unchecked', async () => {
   const form = document.createElement('form');
 

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -124,6 +124,9 @@ export default class GlideCoreCheckbox extends LitElement {
   }
 
   set value(value: string) {
+    const old = this.#value;
+    this.#value = value;
+
     // `this.value` can be changed programmatically. Checkbox Group needs to know when
     // that happens so it can update its own `this.value`.
     this.dispatchEvent(
@@ -132,13 +135,11 @@ export default class GlideCoreCheckbox extends LitElement {
         detail: {
           // Without knowing what the old value was, Checkbox Group would be unable to
           // find the value in its `this.value` array and remove it.
-          old: this.value,
+          old,
           new: value,
         },
       }),
     );
-
-    this.#value = value;
   }
 
   // Not private, so that a parent checkbox group can programmatically set


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Checkbox Group no longer unchecks Checkboxes whose value is changed programmatically.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Checkbox Group in Storybook.
2. Check the first Checkbox.
3. Using DevTools, change the `value` of that Checkbox.
4. Verify that Checkbox is still checked.
5. Using DevTools, verify that the `value` of Checkbox Group includes the new Checkbox `value`.

## 📸 Images/Videos of Functionality

N/A