### PR TITLE
Handle Dropdown option programmatic `label` changes

### DIFF
--- a/.changeset/rare-bananas-act.md
+++ b/.changeset/rare-bananas-act.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+When an option is selected and that option's `label` is changed programmatically, Dropdown now updates the label of its button when single-select, the label of its tags when multiselect, and the value of its input field when filterable.

--- a/src/drawer.test.closing.ts
+++ b/src/drawer.test.closing.ts
@@ -31,7 +31,6 @@ it('closes when the "Escape" key is pressed', async () => {
     ?.dispatchEvent(new TransitionEvent('transitionend'));
 
   await elementUpdated(component);
-
   await sendKeys({ press: 'Escape' });
 
   setTimeout(() => {
@@ -41,7 +40,6 @@ it('closes when the "Escape" key is pressed', async () => {
   });
 
   await oneEvent(component, 'close');
-
   await elementUpdated(component);
 
   expect(

--- a/src/dropdown.option.test.events.ts
+++ b/src/dropdown.option.test.events.ts
@@ -5,11 +5,24 @@ import GlideCoreDropdownOption from './dropdown.option.js';
 
 GlideCoreDropdownOption.shadowRootOptions.mode = 'open';
 
+it('dispatches a "private-label-change" event', async () => {
+  const component = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option label="One"></glide-core-dropdown-option>`,
+  );
+
+  setTimeout(() => {
+    component.label = 'Two';
+  });
+
+  const event = await oneEvent(component, 'private-label-change');
+  expect(event instanceof Event).to.be.true;
+  expect(event.bubbles).to.be.true;
+});
+
 it('dispatches a "private-selected-change" event', async () => {
   const component = await fixture<GlideCoreDropdownOption>(
     html`<glide-core-dropdown-option
       label="Label"
-      value="value"
     ></glide-core-dropdown-option>`,
   );
 

--- a/src/dropdown.option.ts
+++ b/src/dropdown.option.ts
@@ -42,6 +42,12 @@ export default class GlideCoreDropdownOption extends LitElement {
     setTimeout(() => {
       this.#updateLabelOverflow();
     });
+
+    this.dispatchEvent(
+      new Event('private-label-change', {
+        bubbles: true,
+      }),
+    );
   }
 
   @property({ attribute: 'private-indeterminate', type: Boolean })

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -421,6 +421,35 @@ it('sets the first unfiltered option as active when the previously active option
   expect(input?.getAttribute('aria-activedescendant')).to.equal(option?.id);
 });
 
+it('updates the `value` of its `<input>` when the `label` of a selected option is changed programmatically', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      filterable
+    >
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = component.querySelector('glide-core-dropdown-option');
+  assert(option);
+
+  option.label = 'Three';
+  await elementUpdated(component);
+
+  const input = component.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(input?.value).to.equal('Three');
+});
+
 it('updates `value` when an option `value` is changed programmatically', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder">

--- a/src/dropdown.test.interactions.multiple.ts
+++ b/src/dropdown.test.interactions.multiple.ts
@@ -472,6 +472,30 @@ it('does not activate the next option on ArrowDown when a tag is focused', async
   expect(options[0]?.privateActive).to.be.true;
 });
 
+it('updates its tag when the `label` of a selected option is changed programmatically', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" multiple>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = component.querySelector('glide-core-dropdown-option');
+  assert(option);
+
+  option.label = 'Three';
+  await elementUpdated(component);
+
+  const tag =
+    component.shadowRoot?.querySelector<GlideCoreTag>('[data-test="tag"]');
+
+  expect(tag?.label).to.equal('Three');
+});
+
 it('selects and deselects options when `value` is changed programmatically', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" multiple>

--- a/src/dropdown.test.interactions.single.ts
+++ b/src/dropdown.test.interactions.single.ts
@@ -361,6 +361,29 @@ it('deselects all other options when one is newly selected', async () => {
   expect(options[2].selected).to.be.false;
 });
 
+it('updates its internal label when the `label` of a selected option is changed programmatically', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder">
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = component.querySelector('glide-core-dropdown-option');
+  assert(option);
+
+  option.label = 'Two';
+  await elementUpdated(component);
+
+  const label = component.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
+
+  expect(label?.textContent?.trim()).to.equal(option?.label);
+});
+
 it('selects and deselects options when `value` is changed programmatically', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder">

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -72,8 +72,7 @@ export default class GlideCoreDropdown extends LitElement {
       setTimeout(() => {
         this.updateComplete.then(() => {
           if (this.#inputElementRef.value && this.selectedOptions.length > 0) {
-            this.#inputElementRef.value.value =
-              this.#inputElementRef.value.value = this.selectedOptions[0].label;
+            this.#inputElementRef.value.value = this.selectedOptions[0].label;
           }
         });
       });
@@ -339,6 +338,7 @@ export default class GlideCoreDropdown extends LitElement {
       observer.observe(this.#componentElementRef.value);
 
       // Dropdown's "click" handler on `document` listens for clicks in the
+
       // capture phase. There's a comment explaining why. `#isComponentClick`
       // must be set before that handler is called so it has the information it
       // needs to determine whether or not to close Dropdown.
@@ -668,6 +668,7 @@ export default class GlideCoreDropdown extends LitElement {
             @focusin=${this.#onOptionsFocusin}
             @mousedown=${this.#onOptionsMousedown}
             @mouseover=${this.#onOptionsMouseover}
+            @private-label-change=${this.#onOptionsLabelChange}
             @private-selected-change=${this.#onOptionsSelectedChange}
             @private-value-change=${this.#onOptionsValueChange}
             ${ref(this.#optionsElementRef)}
@@ -1404,6 +1405,22 @@ export default class GlideCoreDropdown extends LitElement {
     this.#unfilter();
     this.dispatchEvent(new Event('change', { bubbles: true }));
     this.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  #onOptionsLabelChange() {
+    if (this.selectedOptions.length > 0) {
+      if (this.multiple) {
+        this.requestUpdate();
+
+        this.updateComplete.then(() => {
+          this.#setTagOverflowLimit();
+        });
+      } else if (this.#inputElementRef.value) {
+        this.#inputElementRef.value.value = this.selectedOptions[0].label;
+      } else {
+        this.requestUpdate();
+      }
+    }
   }
 
   #onOptionsMousedown(event: MouseEvent) {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->
When an option is selected and that option's `label` is changed programmatically, Dropdown now updates the label of its button when single-select, the label of its tags when multiselect, and the `value` of its `<input>` when filterable.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test


#### Single-select

1. Navigate to [single-select Dropdown](https://glide-core.crowdstrike-ux.workers.dev/dropdown-programmatic-label-changes?path=/story/dropdown--dropdown) in Storybook.
2. Select an option.
3. Using DevTools, programmatically change the `label` of the selected option.
4. Verify Dropdown shows the new `label`.

#### Multiselect

1. Navigate to [multiselect Dropdown](https://glide-core.crowdstrike-ux.workers.dev/dropdown-programmatic-label-changes?path=/story/dropdown--dropdown&args=multiple:!true) in Storybook.
2. Select an option.
3. Using DevTools, programmatically change the `label` of the selected option.
4. Verify Dropdown's tag has the new `label`.

#### Filterable

1. Navigate to [filterable Dropdown](https://glide-core.crowdstrike-ux.workers.dev/dropdown-programmatic-label-changes?path=/story/dropdown--dropdown&args=filterable:!true) in Storybook.
2. Select an option.
3. Using DevTools, programmatically change the `label` of the selected option.
4. Verify that the `value` of Dropdown's `<input>` is equal to the new `label`.



<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A
