### PR TITLE
Dispatch a "filter" event when Dropdown is filtered

### DIFF
--- a/.changeset/mighty-eels-arrive.md
+++ b/.changeset/mighty-eels-arrive.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown now emits a custom "filter" event when filtering. The event's `detail` property is the value filtered.

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -60,8 +60,7 @@ const meta: Meta = {
     'slot="tooltip"': '',
     value: '',
     variant: '',
-    '<glide-core-dropdown-option>.label':
-      'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.',
+    '<glide-core-dropdown-option>.label': 'One',
     '<glide-core-dropdown-option>.selected': false,
     '<glide-core-dropdown-option>[slot="icon"]': '',
     '<glide-core-dropdown-option>.value': 'one',
@@ -79,7 +78,7 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail:
-            '(event: "change" | "input" | "invalid", listener: (event: Event)) => void) => void',
+            '(event: "change" | "filter" | "input" | "invalid", listener: (event: Event | CustomEvent<string>)) => void) => void\n\n// A custom event is emitted on "filter". The event\'s `detail` property is the value filtered.',
         },
       },
     },

--- a/src/dropdown.test.events.filterable.ts
+++ b/src/dropdown.test.events.filterable.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 import * as sinon from 'sinon';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreDropdown from './dropdown.js';
 import GlideCoreDropdownOption from './dropdown.option.js';
@@ -66,6 +66,23 @@ const defaultSlot = html`
   ></glide-core-dropdown-option>
 `;
 
+it('dispatches a "filter" event on "input"', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder">
+      ${defaultSlot}
+    </glide-core-dropdown>`,
+  );
+
+  component.focus();
+  sendKeys({ type: 'o' });
+
+  const event = await oneEvent(component, 'filter');
+
+  expect(event instanceof CustomEvent).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.detail).to.equal('o');
+});
+
 it('does not dispatch "input" events on input', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder">
@@ -76,7 +93,7 @@ it('does not dispatch "input" events on input', async () => {
   const spy = sinon.spy();
   component.addEventListener('input', spy);
   component.focus();
-  await sendKeys({ type: ' one ' });
+  await sendKeys({ type: 'one' });
 
   expect(spy.callCount).to.equal(0);
 });

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -1327,6 +1327,13 @@ export default class GlideCoreDropdown extends LitElement {
           ? true
           : false;
     }
+
+    this.dispatchEvent(
+      new CustomEvent('filter', {
+        bubbles: true,
+        detail: this.#inputElementRef.value.value,
+      }),
+    );
   }
 
   #onInputKeydown(event: KeyboardEvent) {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to [filterable Dropdown](https://glide-core.crowdstrike-ux.workers.dev/dropdown-dispatch-filter-on-input?path=/story/dropdown--dropdown&args=filterable:!true) in Storybook.
2. Add a "filter" event listener to Dropdown using DevTools.
3. Type something into Dropdown.
4. Verify the event was emitted and that its `detail` property is set to what you typed.

## 📸 Images/Videos of Functionality

N/A