### PR TITLE
Tooltip dark mode support

### DIFF
--- a/.changeset/shaggy-ladybugs-drum.md
+++ b/.changeset/shaggy-ladybugs-drum.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Tooltip was updated to have a higher contrast in dark mode.

--- a/.changeset/twenty-chairs-sin.md
+++ b/.changeset/twenty-chairs-sin.md
@@ -1,0 +1,20 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+`@crowdstrike/glide-core/styles/variables.css` has been updated with the latest from Figma:
+
+## System
+
+```diff
++ --glide-core-page-size-details-panel: 27.375rem;
++ --glide-core-page-size-height: 46.875rem;
++ --glide-core-page-size-width: 83.3125rem;
+```
+
+## Dark
+
+```diff
+- --glide-core-surface-base-dark: #212121;
++ --glide-core-surface-base-dark: #f0f0f0;
+```

--- a/src/styles/variables/dark.css
+++ b/src/styles/variables/dark.css
@@ -46,7 +46,7 @@
   --glide-core-surface-active: #ffffff;
   --glide-core-surface-attention: #fffbeb;
   --glide-core-surface-base: #424242;
-  --glide-core-surface-base-dark: #212121;
+  --glide-core-surface-base-dark: #f0f0f0;
   --glide-core-surface-base-gray: #00000066;
   --glide-core-surface-base-gray-dark: #ffffff8c;
   --glide-core-surface-base-gray-light: #00000066;

--- a/src/styles/variables/system.css
+++ b/src/styles/variables/system.css
@@ -12,6 +12,9 @@
   --glide-core-border-width-md: 0.125rem;
   --glide-core-border-width-none: 0rem;
   --glide-core-border-width-sm: 0.0625rem;
+  --glide-core-page-size-details-panel: 27.375rem;
+  --glide-core-page-size-height: 46.875rem;
+  --glide-core-page-size-width: 83.3125rem;
   --glide-core-spacing-lg: 1.5rem;
   --glide-core-spacing-md: 1rem;
   --glide-core-spacing-sm: 0.75rem;

--- a/src/tooltip.styles.ts
+++ b/src/tooltip.styles.ts
@@ -86,6 +86,7 @@ export default [
       --arrow-height: 0.375rem;
       --arrow-width: 0.625rem;
 
+      color: var(--glide-core-surface-base-dark);
       display: flex;
       position: relative;
 
@@ -123,7 +124,7 @@ export default [
     }
 
     .default-slot {
-      color: var(--glide-core-text-selected);
+      color: var(--glide-core-text-selected-2);
       display: block;
       hyphens: auto;
       max-inline-size: 11.25rem;

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -71,8 +71,8 @@ export default class GlideCoreTooltip extends LitElement {
     }
   }
 
-  /* 
-    The placement of the tooltip relative to its target. Automatic placement will 
+  /*
+    The placement of the tooltip relative to its target. Automatic placement will
     take over if the tooltip is cut off by the viewport. "bottom" by default.
   */
   @property()
@@ -176,7 +176,7 @@ export default class GlideCoreTooltip extends LitElement {
                   <svg viewBox="0 0 10 6" fill="none">
                     <path
                       d="M4.23178 5.07814C4.63157 5.55789 5.36843 5.55789 5.76822 5.07813L10 -7.9486e-08L-2.62268e-07 3.57628e-07L4.23178 5.07814Z"
-                      fill="#212121"
+                      fill="currentColor"
                     />
                   </svg>
                 `,
@@ -187,7 +187,7 @@ export default class GlideCoreTooltip extends LitElement {
                   <svg viewBox="0 0 6 10" fill="none">
                     <path
                       d="M0.921865 4.23178C0.442111 4.63157 0.442112 5.36843 0.921866 5.76822L6 10L6 -2.62268e-07L0.921865 4.23178Z"
-                      fill="#212121"
+                      fill="currentColor"
                     />
                   </svg>
                 `,
@@ -198,7 +198,7 @@ export default class GlideCoreTooltip extends LitElement {
                   <svg viewBox="0 0 10 6" fill="none">
                     <path
                       d="M4.23178 0.921865C4.63157 0.442111 5.36843 0.442112 5.76822 0.921866L10 6L-2.62268e-07 6L4.23178 0.921865Z"
-                      fill="#212121"
+                      fill="currentColor"
                     />
                   </svg>
                 `,
@@ -209,7 +209,7 @@ export default class GlideCoreTooltip extends LitElement {
                   <svg viewBox="0 0 6 10" fill="none">
                     <path
                       d="M5.07814 4.23178C5.55789 4.63157 5.55789 5.36843 5.07813 5.76822L-4.37114e-07 10L0 -2.62268e-07L5.07814 4.23178Z"
-                      fill="#212121"
+                      fill="currentColor"
                     />
                   </svg>
                 `,


### PR DESCRIPTION
## 🚀 Description

- Updated our Figma color tokens using the script
- Updated Tooltip to use the the updated tokens for better dark mode support

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality


| Before  | After |
| ------- | ----- |
| <img width="997" alt="Screenshot 2024-10-21 at 2 33 00 PM" src="https://github.com/user-attachments/assets/7cbc09e5-73a9-4c9e-adaa-fdc17bd25472">  | <img width="999" alt="Screenshot 2024-10-21 at 2 32 34 PM" src="https://github.com/user-attachments/assets/5af0c833-b312-4e1f-a1b3-a766d4a5e708"> |



