### PR TITLE
Add Menu `offset` attribute

### DIFF
--- a/.changeset/chilled-pillows-bathe.md
+++ b/.changeset/chilled-pillows-bathe.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Menu now has an `offset` attribute for changing the distance between its menu and target.

--- a/src/menu.stories.ts
+++ b/src/menu.stories.ts
@@ -33,6 +33,7 @@ const meta: Meta = {
   args: {
     'slot="default"': '',
     'slot="target"': '',
+    offset: 4,
     open: false,
     placement: 'bottom-start',
     size: 'large',
@@ -52,6 +53,12 @@ const meta: Meta = {
         type: { summary: 'Element', detail: 'Any focusable element.' },
       },
       type: { name: 'function', required: true },
+    },
+    offset: {
+      table: {
+        defaultValue: { summary: '4' },
+        type: { summary: 'number' },
+      },
     },
     open: {
       table: {
@@ -137,6 +144,7 @@ const meta: Meta = {
   render(arguments_) {
     /* eslint-disable unicorn/explicit-length-check */
     return html`<glide-core-menu
+      offset=${arguments_.offset}
       placement=${arguments_.placement}
       size=${arguments_.size || nothing}
       ?open=${arguments_.open}
@@ -182,41 +190,35 @@ export const WithIcons: StoryObj = {
     });
 
     return html`<glide-core-menu
+      offset=${arguments_.offset}
       placement=${arguments_.placement}
       size=${arguments_.size || nothing}
       ?open=${arguments_.open}
     >
+      <glide-core-button label="Target" slot="target"></glide-core-button>
+
       <glide-core-menu-options>
-        <glide-core-menu-link label="Edit">
+        <glide-core-menu-button label="Edit">
           <glide-core-example-icon
             slot="icon"
             name="edit"
           ></glide-core-example-icon>
-        </glide-core-menu-link>
+        </glide-core-menu-button>
 
-        <glide-core-menu-link label="Move">
+        <glide-core-menu-button label="Move">
           <glide-core-example-icon
             slot="icon"
             name="move"
           ></glide-core-example-icon>
-        </glide-core-menu-link>
+        </glide-core-menu-button>
 
-        <glide-core-menu-link label="Share">
+        <glide-core-menu-link label="Share" url="/">
           <glide-core-example-icon
             slot="icon"
             name="share"
           ></glide-core-example-icon>
         </glide-core-menu-link>
-
-        <glide-core-menu-link label="Settings">
-          <glide-core-example-icon
-            slot="icon"
-            name="settings"
-          ></glide-core-example-icon>
-        </glide-core-menu-link>
       </glide-core-menu-options>
-
-      <glide-core-button label="Target" slot="target"></glide-core-button>
     </glide-core-menu>`;
   },
 };

--- a/src/menu.test.interactions.ts
+++ b/src/menu.test.interactions.ts
@@ -1284,3 +1284,18 @@ it('does not wrap on ArrowDown', async () => {
 
   expect(options[1].privateActive).to.be.true;
 });
+
+it('has `set offset()` coverage', async () => {
+  const component = await fixture<GlideCoreMenu>(html`
+    <glide-core-menu>
+      <button slot="target">Target</button>
+
+      <glide-core-menu-options>
+        <glide-core-menu-link label="One"></glide-core-menu-link>
+        <glide-core-menu-link label="Two"></glide-core-menu-link>
+      </glide-core-menu-options>
+    </glide-core-menu>
+  `);
+
+  component.offset = 10;
+});

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -34,6 +34,25 @@ export default class GlideCoreMenu extends LitElement {
 
   static override styles = styles;
 
+  @property({ reflect: true, type: Number })
+  get offset() {
+    return (
+      this.#offset ??
+      Number.parseFloat(
+        window
+          .getComputedStyle(document.body)
+          .getPropertyValue('--glide-core-spacing-xxs'),
+      ) *
+        Number.parseFloat(
+          window.getComputedStyle(document.documentElement).fontSize,
+        )
+    );
+  }
+
+  set offset(offset: number) {
+    this.#offset = offset;
+  }
+
   @property({ reflect: true, type: Boolean })
   get open() {
     return this.#isOpen;
@@ -185,6 +204,8 @@ export default class GlideCoreMenu extends LitElement {
   #isOpen = false;
 
   #isTargetSlotClick = false;
+
+  #offset: number | undefined;
 
   #shadowRoot?: ShadowRoot;
 
@@ -538,21 +559,7 @@ export default class GlideCoreMenu extends LitElement {
                 this.#defaultSlotElementRef.value,
                 {
                   placement: this.placement,
-                  middleware: [
-                    offset({
-                      mainAxis:
-                        Number.parseFloat(
-                          window
-                            .getComputedStyle(document.body)
-                            .getPropertyValue('--glide-core-spacing-xxs'),
-                        ) *
-                        Number.parseFloat(
-                          window.getComputedStyle(document.documentElement)
-                            .fontSize,
-                        ),
-                    }),
-                    flip(),
-                  ],
+                  middleware: [offset(this.offset), flip()],
                 },
               );
 

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -54,7 +54,23 @@ export default class GlideCoreTooltip extends LitElement {
   }
 
   @property({ reflect: true, type: Number })
-  offset = 4;
+  get offset() {
+    return (
+      this.#offset ??
+      Number.parseFloat(
+        window
+          .getComputedStyle(document.body)
+          .getPropertyValue('--glide-core-spacing-xxs'),
+      ) *
+        Number.parseFloat(
+          window.getComputedStyle(document.documentElement).fontSize,
+        )
+    );
+  }
+
+  set offset(offset: number) {
+    this.#offset = offset;
+  }
 
   @property({ reflect: true, type: Boolean })
   get open() {
@@ -270,6 +286,8 @@ export default class GlideCoreTooltip extends LitElement {
   #isDisabled = false;
 
   #isOpen = false;
+
+  #offset: number | undefined;
 
   #openTimeoutId?: ReturnType<typeof setTimeout>;
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Menu in Storybook.
2. Change its `offset` using the control.
3. Open Menu.
4. Verify the menu is the correct distance from its target.
5. Rinse and repeat for Tooltip.


## 📸 Images/Videos of Functionality

N/A