### PR TITLE
Allow Dropdown to close when something other than its button is clicked

### DIFF
--- a/.changeset/fair-numbers-cheat.md
+++ b/.changeset/fair-numbers-cheat.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown now opens and closes when any part of it is clicked. Previously, it would only close from a click outside of itself or one on the button with the caret icon.

--- a/src/dropdown.test.interactions.multiple.ts
+++ b/src/dropdown.test.interactions.multiple.ts
@@ -1432,7 +1432,7 @@ it('does not set Select All as indeterminate when all options are selected', asy
   expect(selectAll?.privateIndeterminate).to.be.false;
 });
 
-it('remains open when a tag is clicked', async () => {
+it('closes when a tag is clicked', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown open multiple>
       <glide-core-dropdown-option
@@ -1463,7 +1463,7 @@ it('remains open when a tag is clicked', async () => {
 
   await elementUpdated(component);
 
-  expect(component.open).to.be.true;
+  expect(component.open).to.be.false;
 });
 
 it('cannot be tabbed to when `disabled`', async () => {

--- a/src/dropdown.test.interactions.ts
+++ b/src/dropdown.test.interactions.ts
@@ -702,34 +702,6 @@ it('opens when something other than the button is clicked', async () => {
   expect(component.open).to.be.true;
 });
 
-it('remains open when something other than the button is clicked', async () => {
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
-      <glide-core-dropdown-option
-        label="Label"
-        value="value"
-      ></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  const internalLabel = component.shadowRoot?.querySelector(
-    '[data-test="internal-label"]',
-  );
-
-  assert(internalLabel);
-
-  const { x, y } = internalLabel.getBoundingClientRect();
-
-  // A simple `option.click()` won't do because we need a "mousedown" so that
-  // `#onDropdownMousedown` gets covered.
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(x), Math.ceil(y)],
-  });
-
-  expect(component.open).to.be.true;
-});
-
 it('hides the tooltip of the active option when opened via click', async () => {
   // The period is arbitrary. 500 of them ensures we exceed the maximum
   // width even if it's increased.

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -1186,12 +1186,7 @@ export default class GlideCoreDropdown extends LitElement {
       return;
     }
 
-    if (
-      event.target instanceof Node &&
-      this.#buttonElementRef.value?.contains(event.target) &&
-      !this.#isSelectionViaSpaceOrEnter &&
-      this.open
-    ) {
+    if (!this.#isSelectionViaSpaceOrEnter && this.open) {
       this.open = false;
 
       // `event.detail` is an integer set to the number of clicks. When it's zero,


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Dropdown now opens and closes when any part of it is clicked. Previously, it would only close with a click outside of itself or one on the button with the caret icon.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Dropdown in Storybook.
2. Click the padding around Dropdown.
3. Verify Dropdown is open.
4. Click the padding again.
5. Verify Dropdown is closed.
6. Make Dropdown multiselect.
7. Select an option.
8. Click the option's tag.
9. Verify Dropdown is closed. 
10. Click the tag again.
11. Verify Dropdown is open.
12. Make Dropdown filterable.
13. Click the input field.
14. Verify Dropdown is open.
15. Click the input field again.
16. Verify Dropdown is closed.

## 📸 Images/Videos of Functionality

N/A