### PR TITLE
Close single-select Dropdown when an already selected option is clicked

### DIFF
--- a/.changeset/unlucky-rings-add.md
+++ b/.changeset/unlucky-rings-add.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Single-select Dropdown now closes when an already selected option is clicked.

--- a/src/dropdown.test.events.single.ts
+++ b/src/dropdown.test.events.single.ts
@@ -208,6 +208,32 @@ it('dispatches one "input" event when an option is selected via Space', async ()
   expect(spy.callCount).to.equal(1);
 });
 
+it('does not dispatch a "change" event when an already selected option is clicked', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for it to open.
+  await aTimeout(0);
+
+  const spy = sinon.spy();
+  component.addEventListener('change', spy);
+
+  setTimeout(() => {
+    component.querySelector('glide-core-dropdown-option')?.click();
+  });
+
+  await aTimeout(0);
+  expect(spy.callCount).to.equal(0);
+});
+
 it('does not dispatch a "change" event when `value` is changed programmatically', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>

--- a/src/dropdown.test.interactions.single.ts
+++ b/src/dropdown.test.interactions.single.ts
@@ -251,6 +251,9 @@ it('closes when an option is selected via click', async () => {
     </glide-core-dropdown>`,
   );
 
+  // Wait for it to open.
+  await aTimeout(0);
+
   component.querySelector('glide-core-dropdown-option')?.click();
 
   expect(component.open).to.be.false;
@@ -265,6 +268,9 @@ it('closes when an option is selected via Space', async () => {
       ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
+
+  // Wait for it to open.
+  await aTimeout(0);
 
   component.focus();
   await sendKeys({ press: ' ' });
@@ -281,6 +287,9 @@ it('closes when an option is selected via Enter', async () => {
       ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
+
+  // Wait for it to open.
+  await aTimeout(0);
 
   component.focus();
   await sendKeys({ press: 'Enter' });
@@ -324,6 +333,24 @@ it('closes when an option is selected via Space', async () => {
 
   option?.focus();
   await sendKeys({ press: ' ' });
+
+  expect(component.open).to.be.false;
+});
+
+it('closes when an already selected option is clicked', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
+      <glide-core-dropdown-option
+        label="Label"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for it to open.
+  await aTimeout(0);
+
+  component.querySelector('glide-core-dropdown-option')?.click();
 
   expect(component.open).to.be.false;
 });

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -1380,7 +1380,7 @@ export default class GlideCoreDropdown extends LitElement {
     if (event.target instanceof Element) {
       const option = event.target.closest('glide-core-dropdown-option');
 
-      if (option instanceof GlideCoreDropdownOption && !option.selected) {
+      if (option && !option.selected) {
         option.selected = true;
         this.#unfilter();
 
@@ -1390,6 +1390,13 @@ export default class GlideCoreDropdown extends LitElement {
 
         this.dispatchEvent(new Event('change', { bubbles: true }));
         this.dispatchEvent(new Event('input', { bubbles: true }));
+
+        return;
+      }
+
+      if (option?.selected && !this.multiple) {
+        this.open = false;
+        return;
       }
     }
   }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Dropdown in Storybook.
2. Open Dropdown and click the first option.
3. Open Dropdown again and click the first option.
4. Verify Dropdown is closed.

## 📸 Images/Videos of Functionality

N/A
