### PR TITLE
Update sticky Tab Group background-color

### DIFF
--- a/.changeset/fuzzy-owls-hammer.md
+++ b/.changeset/fuzzy-owls-hammer.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Tab Group sets the background-color only when it is provided with the `sticky` attribute to prevent content from bleeding into the background while a user scrolls.

--- a/src/tab.group.styles.ts
+++ b/src/tab.group.styles.ts
@@ -8,13 +8,13 @@ export default [
       flex-direction: column;
 
       & .tab-container {
-        background-color: var(--glide-core-surface-page);
         border-block-end: 1px solid var(--glide-core-border-base-lighter);
         box-sizing: border-box;
         display: flex;
       }
 
       & .sticky {
+        background-color: var(--glide-core-surface-page);
         inset-block-start: 0;
         position: sticky;
       }


### PR DESCRIPTION
## 🚀 Description

Had an issue where a non-`sticky` Tab Group background color broke some things. We only want to apply this background color when it is `sticky` so that the content doesn't bleed through the Group itself. 

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

- Go to [Tab Group's story](https://glide-core.crowdstrike-ux.workers.dev/?path=/story/tab-group--tabs)
- Set a background-color on the body
- Verify the Tab Group background is transparent
- Use the Controls Table to set `sticky` to true
- Verify the Tab Group background is now colored

## 📸 Images/Videos of Functionality

The background-color does not apply by default.

| Before  | After |
| ------- | ----- |
|  <img width="617" alt="Screenshot 2024-10-30 at 9 09 27 AM" src="https://github.com/user-attachments/assets/d76b63d6-40de-436d-b8e0-d3a50f4db5f2">  | <img width="617" alt="Screenshot 2024-10-30 at 9 10 05 AM" src="https://github.com/user-attachments/assets/62ad5767-a9f5-4c05-87fa-48402abf4968"> |



But is added when `sticky` is applied so the background doesn't bleed through.

<img width="618" alt="Screenshot 2024-10-30 at 9 10 13 AM" src="https://github.com/user-attachments/assets/ad8686a4-b46d-41bf-8a2d-0f8630838a97">

