### PR TITLE
Handle Menu Options slot changes

### DIFF
--- a/.changeset/new-spiders-collect.md
+++ b/.changeset/new-spiders-collect.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Menu nows reacts to options added dynamically to Menu Options.
+- Menu no longer activates the first option when another option is already active and a new option is dynamically added.

--- a/src/menu.options.test.events.ts
+++ b/src/menu.options.test.events.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+import './menu.button.js';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import GlideCoreMenu from './menu.js';
+import GlideCoreMenuOptions from './menu.options.js';
+
+GlideCoreMenu.shadowRootOptions.mode = 'open';
+
+it('dispatches a "private-slot-change" event', async () => {
+  const component = await fixture<GlideCoreMenuOptions>(
+    html`<glide-core-menu-options>
+      <glide-core-menu-button label="One"></glide-core-menu-button>
+    </glide-core-menu-options>`,
+  );
+
+  setTimeout(() => {
+    const option = document.createElement('glide-core-menu-button');
+    option.label = 'Label';
+
+    component.append(option);
+  });
+
+  const event = await oneEvent(component, 'private-slot-change');
+
+  expect(event instanceof Event).to.be.true;
+  expect(event.bubbles).to.be.true;
+});

--- a/src/menu.options.ts
+++ b/src/menu.options.ts
@@ -50,12 +50,12 @@ export default class GlideCoreMenuOptions extends LitElement {
   }
 
   override firstUpdated() {
-    owSlot(this.#defaultSlotElementRef.value);
+    owSlot(this.#slotElementRef.value);
 
     // `Text` is allowed so slotted content can be rendered asychronously. Think of
     // a case where the only slotted content is a `repeat` whose array is empty
     // at first then populated after a fetch.
-    owSlotType(this.#defaultSlotElementRef.value, [
+    owSlotType(this.#slotElementRef.value, [
       GlideCoreMenuButton,
       GlideCoreMenuLink,
       Text,
@@ -72,13 +72,11 @@ export default class GlideCoreMenuOptions extends LitElement {
       role="none"
     >
       <slot
-        @slotchange=${this.#onDefaultSlotChange}
-        ${ref(this.#defaultSlotElementRef)}
+        @slotchange=${this.#onSlotChange}
+        ${ref(this.#slotElementRef)}
       ></slot>
     </div>`;
   }
-
-  #defaultSlotElementRef = createRef<HTMLSlotElement>();
 
   // Established here instead of in `connectedCallback` so the ID remains
   // constant even if this component is removed and re-added to the DOM.
@@ -87,13 +85,17 @@ export default class GlideCoreMenuOptions extends LitElement {
   // for sure. But one we can protect against with little effort.
   #id = nanoid();
 
-  #onDefaultSlotChange() {
-    owSlot(this.#defaultSlotElementRef.value);
+  #slotElementRef = createRef<HTMLSlotElement>();
 
-    owSlotType(this.#defaultSlotElementRef.value, [
+  #onSlotChange() {
+    owSlot(this.#slotElementRef.value);
+
+    owSlotType(this.#slotElementRef.value, [
       GlideCoreMenuButton,
       GlideCoreMenuLink,
       Text,
     ]);
+
+    this.dispatchEvent(new Event('private-slot-change', { bubbles: true }));
   }
 }

--- a/src/menu.test.interactions.ts
+++ b/src/menu.test.interactions.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
+import './menu.button.js';
 import './menu.link.js';
 import './menu.options.js';
 import { LitElement } from 'lit';
@@ -1394,6 +1395,54 @@ it('does not wrap on ArrowDown', async () => {
   await sendKeys({ up: 'Meta' });
 
   expect(options[1].privateActive).to.be.true;
+});
+
+it('sets the first option as active when optionless and an option is dynamically added', async () => {
+  const component = await fixture<GlideCoreMenu>(html`
+    <glide-core-menu>
+      <button slot="target">Target</button>
+      <glide-core-menu-options> </glide-core-menu-options>
+    </glide-core-menu>
+  `);
+
+  const option = document.createElement('glide-core-menu-button');
+  option.label = 'Label';
+
+  component.querySelector('glide-core-menu-options')?.append(option);
+  await elementUpdated(component);
+
+  expect(option?.privateActive).to.be.true;
+});
+
+it('retains its active option when an option is dynamically added', async () => {
+  const component = await fixture<GlideCoreMenu>(html`
+    <glide-core-menu>
+      <button slot="target">Target</button>
+
+      <glide-core-menu-options>
+        <glide-core-menu-button label="One"></glide-core-menu-button>
+        <glide-core-menu-button label="Two"></glide-core-menu-button>
+      </glide-core-menu-options>
+    </glide-core-menu>
+  `);
+
+  component
+    .querySelectorAll('glide-core-menu-button')[1]
+    ?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+
+  await elementUpdated(component);
+
+  const button = document.createElement('glide-core-menu-button');
+  button.label = 'Three';
+
+  component.querySelector('glide-core-menu-options')?.append(button);
+  await elementUpdated(component);
+
+  const options = component.querySelectorAll('glide-core-menu-button');
+
+  expect(options[0]?.privateActive).to.be.false;
+  expect(options[1]?.privateActive).to.be.true;
+  expect(options[2]?.privateActive).to.be.false;
 });
 
 it('has `set offset()` coverage', async () => {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -186,6 +186,7 @@ export default class GlideCoreMenu extends LitElement {
           @focusin=${this.#onDefaultSlotFocusin}
           @keydown=${this.#onSlotKeydown}
           @mouseover=${this.#onDefaultSlotMouseover}
+          @private-slot-change=${this.#onOptionsSlotChange}
           @slotchange=${this.#onDefaultSlotChange}
           ${ref(this.#defaultSlotElementRef)}
         ></slot>
@@ -272,12 +273,6 @@ export default class GlideCoreMenu extends LitElement {
     owSlot(this.#defaultSlotElementRef.value);
     owSlotType(this.#defaultSlotElementRef.value, [GlideCoreMenuOptions]);
 
-    const firstOption = this.#optionElements?.at(0);
-
-    if (firstOption) {
-      firstOption.privateActive = true;
-    }
-
     this.#optionsElement.privateSize = this.size;
   }
 
@@ -332,6 +327,18 @@ export default class GlideCoreMenu extends LitElement {
 
     if (!isMenuFocused && !isOptionsFocused && !isOptionFocused) {
       this.open = false;
+    }
+  }
+
+  #onOptionsSlotChange() {
+    const activeOption = this.#optionElements?.find(
+      ({ privateActive }) => privateActive,
+    );
+
+    const firstOption = this.#optionElements?.at(0);
+
+    if (!activeOption && firstOption) {
+      firstOption.privateActive = true;
     }
   }
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Menu isn't reactive to dynamically added or removed options because options are wrapped in a Menu Options for accessibility. So Menu isn't aware when a Menu Options slot change occurs.

It's not pretty. But I'm dispatching a `"private-slot-change"` event from Menu Options. Menu then listens for that event and sets the first option as active instead of setting the first option as active in its `#onDefaultSlotChange`, which assumes that options are exist on first render.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Menu in Storybook.
2. Remove the options using DevTools.
3. Add the options back via CMD + Z.
4. Open Menu.
5. Verify the first option is active.

## 📸 Images/Videos of Functionality

N/A