### PR TITLE
Fix Dropdown not animating on open

### DIFF
--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -6,7 +6,7 @@ import visuallyHidden from './styles/visually-hidden.js';
 export default [
   css`
     ${focusOutline('.add-button:focus-visible')}
-    ${opacityAndScaleAnimation('.options:popover-open')}
+    ${opacityAndScaleAnimation('.options-and-footer:popover-open')}
     ${visuallyHidden('.selected-option-labels')}
   `,
   css`


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Dropdown in Storybook.
2. Open Dropdown.
3. Verify the opening animation played.

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A