### PR TITLE
Rework Dropdown filtering

### DIFF
--- a/.changeset/polite-readers-melt.md
+++ b/.changeset/polite-readers-melt.md
@@ -1,0 +1,26 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Dropdown no longer dispatches a `"filter"` event when filtering.
+
+The `"filter"` event wasn't fully thought through and had a few shortcomings:
+
+- There was no way for consumers to override Dropdown's default and synchronous filtering predicate.
+- It required consumers to add and remove options from the DOM on `"filter"`.
+  And the removal of a selected option when filtering a multiselect Dropdown meant the option's corresponding tag was also removed.
+
+Replacing the event is `filter()` and its default implementation:
+
+```ts
+filter(filter: string, options: GlideCoreDropdownOption[]): Promise<GlideCoreDropdownOption[]> {
+  return options.filter(({ label }) =>
+    label.toLowerCase().trim().includes(filter),
+  );
+}
+```
+
+- You can override `filter()` with whatever filtering logic you need.
+- The options you return in `filter()` will be shown. All others will be hidden.
+- `filter()` must return a promise.
+  Dropdown will wait for it to resolve before showing and hiding options in case you're fetching them or your filtering logic lives on the server.

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -38,6 +38,7 @@ const meta: Meta = {
     'checkValidity()': '',
     disabled: false,
     filterable: false,
+    'filter(filter, options)': '',
     'hide-label': false,
     multiple: false,
     name: '',
@@ -92,7 +93,7 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail:
-            '(event: "change" | "filter" | "input" | "invalid", listener: (event: Event | CustomEvent<string>)) => void) => void\n\n// A custom event is emitted on "filter". The event\'s `detail` property is the value filtered.',
+            '(event: "change" | "input" | "invalid", listener: (event: Event) => void) => void',
         },
       },
     },
@@ -118,6 +119,19 @@ const meta: Meta = {
           summary: 'boolean',
           detail:
             '// Dropdown will be filterable regardless of this attribute when there are more than 10 options',
+        },
+      },
+    },
+    'filter(filter, options)': {
+      control: false,
+      table: {
+        type: {
+          summary: 'method',
+          detail: `(filter: string, options: GlideCoreDropdownOption[]): Promise<GlideCoreDropdownOption[]> {
+  return options.filter(({ label }) =>
+    label.toLowerCase().trim().includes(filter),
+  );
+}\n\n// When overriding, return the options you want visible. The rest will be hidden. If you fetch\n// when filtering, this is the place to do it.`,
         },
       },
     },

--- a/src/dropdown.test.events.filterable.ts
+++ b/src/dropdown.test.events.filterable.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 import * as sinon from 'sinon';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreDropdown from './dropdown.js';
 import GlideCoreDropdownOption from './dropdown.option.js';
@@ -22,24 +22,6 @@ const defaultSlot = html`
   <glide-core-dropdown-option label="Ten"></glide-core-dropdown-option>
   <glide-core-dropdown-option label="Eleven"></glide-core-dropdown-option>
 `;
-
-it('dispatches a "filter" event on "input"', async () => {
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown label="Label" placeholder="Placeholder">
-      ${defaultSlot}
-    </glide-core-dropdown>`,
-  );
-
-  component.focus();
-  sendKeys({ type: 'o' });
-
-  const event = await oneEvent(component, 'filter');
-
-  expect(event instanceof CustomEvent).to.be.true;
-  expect(event.bubbles).to.be.true;
-  expect(event.composed).to.be.true;
-  expect(event.detail).to.equal('o');
-});
 
 it('does not dispatch "input" events on input', async () => {
   const component = await fixture<GlideCoreDropdown>(

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -1162,3 +1162,56 @@ it('has no icon when filtering and an option is selected', async () => {
 
   expect(iconSlot).to.be.null;
 });
+
+it('supports custom filtering', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      filterable
+    >
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.filter = async (filter, options) => {
+    return options.filter(({ label }) => label.includes(filter));
+  };
+
+  component.focus();
+  await sendKeys({ type: 'O' });
+
+  const options = [
+    ...component.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ hidden }) => !hidden);
+
+  expect(options.length).to.equal(1);
+  expect(options[0].label).to.equal('One');
+});
+
+it('does nothing when filtering fails', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      filterable
+    >
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  component.filter = () => {
+    return Promise.reject();
+  };
+
+  component.focus();
+  await sendKeys({ type: 'O' });
+
+  const options = [
+    ...component.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ hidden }) => !hidden);
+
+  expect(options.length).to.equal(2);
+});


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

@ynotdraw were chatting about the asynchronous filtering case, which we hadn't been forced to think through until now. We realized that Dropdown doesn't handle that case and has other issues.

Dropdown currently dispatches a "filter" event on "input". The idea is that consumers can listen for that event and then decide to render or not render certain options. 

One problem with that approach is multiselect Dropdown has a tag for each selected option, and Dropdown [relies](https://github.com/CrowdStrike/glide-core/blob/main/src/dropdown.ts#L517) on those selected options being in the DOM. If consumers remove options from the DOM based on the "filter" event, then the corresponding tags for those options will also be removed.

Making matter worse is that Dropdown also does its [own filtering](https://github.com/CrowdStrike/glide-core/blob/main/src/dropdown.ts#L1681), which happens synchronously and doesn't take into account consumers wanting to filter a different way or on the server.

One solution, here, to both problems is to provide a `filter()` method that consumers can override. It's not very web component-y. But it seems to be the only path forward—though I'm totally open to alternatives.  `filter()` returns a promise that Dropdown awaits before showing and hiding options.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to [filterable Dropdown](https://glide-core.crowdstrike-ux.workers.dev/rework-dropdown-filtering?path=/story/dropdown--dropdown&args=filterable:!true) in Storybook.
2. Enter some text into the `<input>`.
3. Verify filtering works as it does in production.

## 📸 Images/Videos of Functionality

N/A