### PR TITLE
Remove the sticky attribute from Tab Group

### DIFF
--- a/.changeset/young-bags-fry.md
+++ b/.changeset/young-bags-fry.md
@@ -1,0 +1,14 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+The `sticky` attribute for Tab Group wasn't fully thought through. It was decided it is safe to remove it in favor of making the Tab Panel scroll when needed instead.
+
+```diff
+- <glide-core-tab-group sticky>
++ <glide-core-tab-group>
+```
+
+```html
+<glide-core-tab-panel style="overflow-y: auto"></glide-core-tab-panel>
+```

--- a/src/tab.group.styles.ts
+++ b/src/tab.group.styles.ts
@@ -17,12 +17,6 @@ export default [
         padding-inline-start: var(--tabs-padding-inline-start);
       }
 
-      & .sticky {
-        background-color: var(--glide-core-surface-page);
-        inset-block-start: 0;
-        position: sticky;
-      }
-
       & .tab-group {
         display: flex;
         gap: var(--glide-core-spacing-xl);

--- a/src/tab.group.ts
+++ b/src/tab.group.ts
@@ -3,12 +3,7 @@ import { LitElement, html } from 'lit';
 import { LocalizeController } from './library/localize.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
-import {
-  customElement,
-  property,
-  queryAssignedElements,
-  state,
-} from 'lit/decorators.js';
+import { customElement, queryAssignedElements, state } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
 import GlideCoreTab from './tab.js';
 import GlideCoreTabPanel from './tab.panel.js';
@@ -40,9 +35,6 @@ export default class GlideCoreTabGroup extends LitElement {
   };
 
   static override styles = styles;
-
-  @property({ type: Boolean, reflect: true })
-  sticky = false;
 
   @state()
   get activeTab() {
@@ -90,10 +82,7 @@ export default class GlideCoreTabGroup extends LitElement {
       @keydown=${this.#onKeydown}
       ${ref(this.#componentElementRef)}
     >
-      <div
-        class=${classMap({ 'tab-container': true, sticky: this.sticky })}
-        data-test="tab-container"
-      >
+      <div class="tab-container" data-test="tab-container">
         ${when(
           this.isShowOverflowButtons,
           () => html`

--- a/src/tabs.stories.ts
+++ b/src/tabs.stories.ts
@@ -25,7 +25,6 @@ const meta: Meta = {
     'slot="default"': '',
     'slot="nav"': '',
     'addEventListener(event, listener)': '',
-    sticky: false,
     '--panel-padding-inline-end': '',
     '--panel-padding-inline-start': '',
     '--tabs-padding-block-end': '',
@@ -85,10 +84,7 @@ const meta: Meta = {
 
     /* eslint-disable @typescript-eslint/no-unsafe-argument */
     return html`
-      <glide-core-tab-group
-        ?sticky=${arguments_.sticky}
-        style="${ifDefined(addInlineStyles())}"
-      >
+      <glide-core-tab-group style="${ifDefined(addInlineStyles())}">
         <glide-core-tab
           slot="nav"
           panel="1"
@@ -145,13 +141,6 @@ const meta: Meta = {
         },
       },
       type: { name: 'function' },
-    },
-    sticky: {
-      name: 'sticky',
-      table: {
-        defaultValue: { summary: 'false' },
-        type: { summary: 'boolean' },
-      },
     },
     '--panel-padding-inline-end': {
       table: {


### PR DESCRIPTION
## 🚀 Description

Adding `sticky` wasn't a fully thought out solution unfortunately, and @danwenzel tinkered elsewhere and found something that works better. Due to that, let's remove it.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A - removing functionality.

## 📸 Images/Videos of Functionality

N/A - removing functionality.
