### PR TITLE
Dropdown add no results fallback

### DIFF
--- a/.changeset/stupid-carpets-buy.md
+++ b/.changeset/stupid-carpets-buy.md
@@ -1,0 +1,7 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Single-select Dropdown now reliably unhides every option when reopened after filtering.
+- Dropdown now falls back to "No Results Found" if every option has been filtered out.
+- Dropdown's Select All and Add button have a new visual design.

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -122,22 +122,15 @@ export default [
       min-inline-size: var(--min-inline-size);
       padding: 0;
       position: absolute;
-
-      &.hidden {
-        display: none;
-      }
     }
 
     .options {
-      --padding: var(--glide-core-spacing-xxxs);
-
       box-sizing: border-box;
       max-block-size: calc(
-        var(--private-option-height) * 9 + var(--padding) * 2 +
+        var(--private-option-height) * 9 + var(--glide-core-spacing-xxxs) * 2 +
           var(--border-width) * 2
       );
       overflow: auto;
-      padding: var(--padding);
       scroll-behavior: smooth;
 
       &.large {
@@ -147,13 +140,19 @@ export default [
       &.small {
         --private-option-height: 1.25rem;
       }
+
+      &.hidden {
+        display: none;
+      }
+    }
+
+    .options-slot {
+      display: block;
+      padding: var(--glide-core-spacing-xxxs);
     }
 
     .footer {
-      background-color: var(--glide-core-surface-page);
-      border-block-start: 1px solid var(--glide-core-border-base);
-      box-shadow: 0 -8px 8px -8px
-        var(--glide-core-surface-base-gray, rgb(0 0 0 / 40%));
+      background-color: var(--glide-core-surface-base-gray-lighter);
       display: none;
       inline-size: calc(100% - var(--glide-core-spacing-xxxs) * 2);
       inset-block-end: 0;
@@ -215,13 +214,21 @@ export default [
     }
 
     .select-all {
-      border-block-end: 1px solid var(--glide-core-border-base-light);
-      margin-block-end: var(--glide-core-spacing-xxxs);
-      padding-block-end: var(--glide-core-spacing-xxxs);
+      background-color: var(--glide-core-surface-base-gray-lighter);
+      padding: var(--glide-core-spacing-xxxs);
 
       &:not([hidden]) {
         display: block;
       }
+    }
+
+    .no-results {
+      font-family: var(--glide-core-body-sm-font-family);
+      font-size: var(--glide-core-body-sm-font-size);
+      font-weight: var(--glide-core-body-sm-font-weight);
+      line-height: var(--glide-core-body-sm-line-height);
+      padding: 0.625rem 0.875rem;
+      text-transform: capitalize;
     }
 
     .placeholder {
@@ -269,6 +276,7 @@ export default [
       align-content: center;
       color: var(--glide-core-text-link);
       margin-inline-end: var(--glide-core-spacing-md);
+      white-space: nowrap;
     }
 
     .single-select-icon-slot {

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -422,6 +422,44 @@ it('hides Select All when filtering', async () => {
   expect(selectAll?.checkVisibility()).to.not.be.ok;
 });
 
+it('unhides every option after filtering when one is selected and Dropdown is reopened', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      open
+      filterable
+    >
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for it to open.
+  await aTimeout(0);
+
+  component.focus();
+  await sendKeys({ type: 'two' });
+
+  component.blur();
+  await elementUpdated(component);
+
+  component.open = true;
+
+  // Wait for it to open.
+  await aTimeout(0);
+
+  const options = [
+    ...component.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ hidden }) => !hidden);
+
+  expect(options.length).to.equal(2);
+});
+
 it('sets the first unfiltered option as active when the previously active option is filtered out', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -119,11 +119,16 @@ export default class GlideCoreDropdown extends LitElement {
     ) {
       this.#inputElementRef.value.value = this.selectedOptions[0].label;
       this.isFiltering = false;
+      this.isNoResults = false;
 
       this.isShowSingleSelectIcon =
         !this.multiple &&
         this.selectedOptions.length > 0 &&
         Boolean(this.selectedOptions.at(0)?.value);
+
+      for (const option of this.#optionElements) {
+        option.hidden = false;
+      }
     }
 
     this.#hide();
@@ -743,10 +748,7 @@ export default class GlideCoreDropdown extends LitElement {
             aria-labelledby=${this.filterable || this.isFilterable
               ? 'input'
               : 'primary-button'}
-            class=${classMap({
-              'options-and-footer': true,
-              hidden: this.isOptionsAndFooterHidden,
-            })}
+            class="options-and-footer"
             ${ref(this.#optionsAndFooterElementRef)}
           >
             <div
@@ -755,6 +757,7 @@ export default class GlideCoreDropdown extends LitElement {
                 : 'button'}
               class=${classMap({
                 options: true,
+                hidden: this.isNoResults,
                 [this.size]: true,
               })}
               data-test="options"
@@ -784,10 +787,17 @@ export default class GlideCoreDropdown extends LitElement {
               ></glide-core-dropdown-option>
 
               <slot
+                class="options-slot"
                 @slotchange=${this.#onDefaultSlotChange}
                 ${ref(this.#defaultSlotElementRef)}
               ></slot>
             </div>
+
+            ${when(this.isNoResults, () => {
+              return html`<div class="no-results">
+                ${this.#localize.term('noResults')}
+              </div>`;
+            })}
 
             <footer
               class=${classMap({
@@ -965,7 +975,7 @@ export default class GlideCoreDropdown extends LitElement {
   private isInternalLabelTooltipOpen = false;
 
   @state()
-  private isOptionsAndFooterHidden = false;
+  private isNoResults = false;
 
   @state()
   private isReportValidityOrSubmit = false;
@@ -1750,7 +1760,7 @@ export default class GlideCoreDropdown extends LitElement {
         firstVisibleOption.privateActive = true;
       }
 
-      this.isOptionsAndFooterHidden =
+      this.isNoResults =
         !this.#optionElementsNotHidden ||
         this.#optionElementsNotHidden.length === 0
           ? true

--- a/src/library/localize.ts
+++ b/src/library/localize.ts
@@ -27,6 +27,7 @@ export interface Translation extends DefaultTranslation {
   notifications: string;
   nextTab: string;
   previousTab: string;
+  noResults: string;
 
   announcedCharacterCount: (current: number, maximum: number) => string;
   displayedCharacterCount: (current: number, maximum: number) => string;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7,6 +7,7 @@
   "notifications": "Notifications",
   "nextTab": "Next tab",
   "previousTab": "Previous tab",
+  "noResults": "No results found",
   "announcedCharacterCount": "Character count {current} of {maximum}",
   "displayedCharacterCount": "{current}/{maximum}",
   "clearEntry": "Clear {label} entry",

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -15,6 +15,7 @@ const translation: Translation = {
   notifications: 'Notifications',
   nextTab: 'Next tab',
   previousTab: 'Previous tab',
+  noResults: 'No results found',
 
   announcedCharacterCount: (current: number, maximum: number) =>
     `Character count ${current} of ${maximum}`,

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1,6 +1,11 @@
 import type { Translation } from '../library/localize.js';
 
-export const PENDING_STRINGS = ['editOption', 'editTag', 'itemCount'] as const;
+export const PENDING_STRINGS = [
+  'editOption',
+  'editTag',
+  'itemCount',
+  'noResults',
+] as const;
 
 type PendingTranslation = (typeof PENDING_STRINGS)[number];
 

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -1,6 +1,11 @@
 import type { Translation } from '../library/localize.js';
 
-export const PENDING_STRINGS = ['editOption', 'editTag', 'itemCount'] as const;
+export const PENDING_STRINGS = [
+  'editOption',
+  'editTag',
+  'itemCount',
+  'noResults',
+] as const;
 
 type PendingTranslation = (typeof PENDING_STRINGS)[number];
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- Dropdown now falls back to "No Results Found" if every option has been filtered out.
- Dropdown's Select All and Add button have a new visual design.
- Single-select Dropdown now reliably unhides every option when reopened after filtering.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to [filterable Dropdown](https://glide-core.crowdstrike-ux.workers.dev/dropdown-add-no-results-fallback?path=/story/dropdown--dropdown&args=filterable:!true) in Storybook.
2. Add a nonsense filter.
3. Verify "No Results Found" is shown.
4. Remove the nonsense.
5. Verify the correct options are shown.

## 📸 Images/Videos of Functionality

### No Results

<img width="263" alt="image" src="https://github.com/user-attachments/assets/37f6ea00-f2c3-4413-b2db-26ca148038d6">

### New Select All and Add button visual design 

#### Before

<img width="343" alt="image" src="https://github.com/user-attachments/assets/85be303e-880d-4cbc-831f-c5ce71b520f8">


#### After

<img width="343" alt="image" src="https://github.com/user-attachments/assets/0dc02090-4f38-40bc-b74c-77f5aa1cae62">

