### PR TITLE
Add `value` to form controls

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -98,7 +98,14 @@ export default {
                     argumentKeyWithoutSubcomponent,
                   );
 
-                  if (value === argumentValue) {
+                  // People using Storybook often interact with form controls and inspect their
+                  // `value` using DevTools. However, without a `value` on each Checkbox, for
+                  // example, Checkbox Group's `value` will be an empty string, leading to confusion
+                  // or a bug report. So `value` is always left alone.
+                  if (
+                    value === argumentValue &&
+                    argumentKeyWithoutSubcomponent !== 'value'
+                  ) {
                     $subcomponent.removeAttribute(
                       argumentKeyWithoutSubcomponent,
                     );
@@ -107,7 +114,8 @@ export default {
               }
             } else if (
               defaultValue &&
-              argumentValue === context.initialArgs[argumentKey]
+              argumentValue === context.initialArgs[argumentKey] &&
+              argumentKey !== 'value'
             ) {
               $component?.removeAttribute(argumentKey);
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,10 +85,14 @@ Ideally, we'd document everything.
 But Storybook's controls table would quickly become cluttered.
 And adding and maintaining controls isn't free.
 
-The exception is `addEventListener()`.
+One exception is `addEventListener()`.
 It is inherited.
 But which events it supports isn't obvious.
 Document `addEventListener()` if your component dispatches events that aren't universal—like `"change"`, `"input"`, or `"toggle"`.
+
+Another is `value` with certain form controls.
+People using Storybook often interact with a control and inspect its `value` using DevTools.
+However, without a `value` on each Checkbox, for example, Checkbox Group's `value` will be an empty string, leading to confusion or a bug report.
 
 If you're unsure where a property or method comes from, TypeScript's [Playground](https://www.typescriptlang.org/play) can help.
 So can your editor and [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes).

--- a/src/checkbox-group.stories.ts
+++ b/src/checkbox-group.stories.ts
@@ -177,9 +177,9 @@ const meta: Meta = {
           ?hide-label=${arguments_['hide-label'] || nothing}
           ?required=${arguments_.required}
         >
-          <glide-core-checkbox label="One"></glide-core-checkbox>
-          <glide-core-checkbox label="Two"></glide-core-checkbox>
-          <glide-core-checkbox label="Three"></glide-core-checkbox>
+          <glide-core-checkbox label="One" value="one"></glide-core-checkbox>
+          <glide-core-checkbox label="Two" value="two"></glide-core-checkbox>
+          <glide-core-checkbox label="Three" value="three"></glide-core-checkbox>
 
           ${
             arguments_['slot="description"']

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -388,8 +388,16 @@ const meta: Meta = {
         ?editable=${arguments_['<glide-core-dropdown-option>.editable']}
         ?selected=${arguments_['<glide-core-dropdown-option>.selected']}
       ></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+      ></glide-core-dropdown-option>
       ${arguments_['slot="description"']
         ? html`<div slot="description">
             ${unsafeHTML(arguments_['slot="description"'])}

--- a/src/dropdown.test.focus.single.ts
+++ b/src/dropdown.test.focus.single.ts
@@ -1,16 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 import './dropdown.option.js';
-import {
-  aTimeout,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import GlideCoreDropdown from './dropdown.js';
 import GlideCoreDropdownOption from './dropdown.option.js';
-import type GlideCoreTooltip from './tooltip.js';
 
 GlideCoreDropdown.shadowRootOptions.mode = 'open';
 GlideCoreDropdownOption.shadowRootOptions.mode = 'open';
@@ -81,31 +74,4 @@ it('does not focus the primary button when `checkValidity` is called', async () 
 
   component.checkValidity();
   expect(component.shadowRoot?.activeElement).to.equal(null);
-});
-
-it('has a tooltip on focus when its internal label is overflowing', async () => {
-  // The period is arbitrary. 500 of them ensures we overflow.
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown label="Label" placeholder="Placeholder">
-      <glide-core-dropdown-option
-        label=${'.'.repeat(500)}
-        selected
-      ></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  component.focus();
-  await elementUpdated(component);
-
-  // Wait for the Resize Observer to do its thing.
-  await aTimeout(0);
-
-  const tooltip = component.shadowRoot?.querySelector<GlideCoreTooltip>(
-    '[data-test="internal-label-tooltip"]',
-  );
-
-  await tooltip?.updateComplete;
-
-  expect(tooltip?.open).to.be.true;
-  expect(tooltip?.disabled).to.be.false;
 });

--- a/src/radio-group.stories.ts
+++ b/src/radio-group.stories.ts
@@ -63,8 +63,8 @@ const meta: Meta = {
           value=${arguments_['<glide-core-radio>.value'] || nothing}
           ?checked=${arguments_['<glide-core-radio>.checked']}
         ></glide-core-radio>
-        <glide-core-radio label="Two"></glide-core-radio>
-        <glide-core-radio label="Three"></glide-core-radio>
+        <glide-core-radio label="Two" value="two"></glide-core-radio>
+        <glide-core-radio label="Three" value="three"></glide-core-radio>
 
         ${arguments_['slot="description"']
           ? html`<div slot="description">
@@ -95,7 +95,7 @@ const meta: Meta = {
     value: '',
     '<glide-core-radio>.label': 'One',
     '<glide-core-radio>.checked': true,
-    '<glide-core-radio>.value': '',
+    '<glide-core-radio>.value': 'one',
   },
   argTypes: {
     label: {


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

The **third paragraph** I'm adding to `CONTRIBUTING.md` should give some context:

> ### Don't add Storybook controls for properties and methods inherited from `HTMLElement` or `Element`
>
> Our components extend `LitElement`, which extends `HTMLElement`—which extends `Element`. So our components can be assumed to implement properties and methods inherited from those classes. Ideally, we'd document everything. But Storybook's controls table would quickly become cluttered. And adding and maintaining controls isn't free.
>
> One exception is `addEventListener()`. It is inherited. But which events it supports isn't obvious.
Document `addEventListener()` if your component dispatches events that aren't universal—like `"change"`, `"input"`, or `"toggle"`.
>
> **Another is `value` with certain form controls. People using Storybook often interact with a control and inspect its `value` property using DevTools. Without a `value` on each Checkbox, for example, Checkbox Group's `value` will be an empty string, leading to confusion or a bug report.**


<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

You know what to do!

## 📸 Images/Videos of Functionality

N/A