### PR TITLE
Tab Group: Move CSS flex attributes to host element

### DIFF
--- a/.changeset/popular-turtles-fry.md
+++ b/.changeset/popular-turtles-fry.md
@@ -1,0 +1,7 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+CSS flex attributes for Tab Group have been moved to the host element.
+
+Having a separate, intermediate flex container inside the closed shadow root made it difficult to impossible for consumers to control their flex layout.

--- a/src/tab.group.styles.ts
+++ b/src/tab.group.styles.ts
@@ -2,10 +2,14 @@ import { css } from 'lit';
 
 export default [
   css`
-    .component {
+    :host {
       background-color: transparent;
       display: flex;
       flex-direction: column;
+    }
+
+    .component {
+      display: contents;
 
       & .tab-container {
         border-block-end: 1px solid var(--glide-core-border-base-lighter);


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Currently, there is an intermediate parent/container element in the shadow root of glide-core-tab-group, and this makes it difficult for consumers to set flex css attributes for the layout of the tab group elements, as they don't have access to this element (due to closed shadow root).

To make things more sensible for consumers, we're now setting this shadow parent element to display: contents, and we've moved the display: flex and flex-direction: column to the :host. 

Normally we don't like to set CSS directly on the `:host`, but I think this is a situation where it makes more sense to do so, because consumers are used to being able to place elements in their layout, and use flex properties to control it. 

So now, effectively, the tab-container and panel slot are direct descendants of the host element (due to `.component` being `display: contents;`)

<img width="507" alt="image" src="https://github.com/user-attachments/assets/7c9e0d05-2f93-4695-b41f-c788070fd1b4">


## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed. Before and after images are ideal when adjusting styling.

Use a markdown table to display changes side-by-side for easier comparison.

| Before  | After |
| ------- | ----- |
|  Image  | Image |

-->
