### PR TITLE
Prevent Safari from leaving full screen

### DIFF
--- a/.changeset/afraid-buttons-love.md
+++ b/.changeset/afraid-buttons-love.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Safari no longer leaves full screen on Escape in Menu, Modal, and Split Button.

--- a/src/drawer.ts
+++ b/src/drawer.ts
@@ -117,6 +117,9 @@ export default class GlideCoreDrawer extends LitElement {
 
   #onKeydown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
+      // Prevent Safari from leaving full screen.
+      event.preventDefault();
+
       this.close();
     }
   }

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -1322,7 +1322,7 @@ export default class GlideCoreDropdown extends LitElement {
     }
 
     if (event.key === 'Escape') {
-      // Prevents Safari from leaving full screen.
+      // Prevent Safari from leaving full screen.
       event.preventDefault();
 
       this.open = false;

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -384,6 +384,9 @@ export default class GlideCoreMenu extends LitElement {
     }
 
     if (['Escape'].includes(event.key) && this.open) {
+      // Prevent Safari from leaving full screen.
+      event.preventDefault();
+
       this.open = false;
 
       // For VoiceOver. Options normally don't receive focus. But VoiceOver

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -371,6 +371,9 @@ export default class GlideCoreModal extends LitElement {
       return;
     }
 
+    // Prevent Safari from leaving full screen.
+    event.preventDefault();
+
     document.documentElement.classList.remove(
       'private-glide-core-modal-lock-scroll',
     );


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Safari no longer leaves full screen on Escape in Menu, Modal, and Split Button.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

You know what to do!

## 📸 Images/Videos of Functionality

N/A
