### PR TITLE
Put Dropdown and Input into a hover state when their label is hovered

### DIFF
--- a/.changeset/rare-frogs-care.md
+++ b/.changeset/rare-frogs-care.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown and Input now appear hovered visually when their labels are hovered.

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -99,6 +99,7 @@ export default [
 
       &:is(
           :hover,
+          :has(.primary-button:hover),
           :has(.primary-button:focus-visible, .input:focus-visible)
         ):not(&.disabled, &.error, &.quiet, &.readonly) {
         border-color: var(--glide-core-border-focus);

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -487,7 +487,7 @@ export default class GlideCoreDropdown extends LitElement {
         ?hide=${this.hideLabel}
         ?required=${this.required}
       >
-        <label id="label"> ${this.label} </label>
+        <label for="primary-button" id="label"> ${this.label} </label>
         <slot name="tooltip" slot="tooltip"></slot>
 
         <div

--- a/src/input.styles.ts
+++ b/src/input.styles.ts
@@ -42,14 +42,14 @@ export default [
       background-color: var(--glide-core-surface-base-lighter);
       border: 1px solid var(--glide-core-border-base);
       border-radius: var(--glide-core-spacing-xs);
-      box-sizing: border-box;
       color: var(--glide-core-text-body-1);
       display: flex;
       line-height: var(--glide-core-body-xs-line-height);
       padding-inline: var(--glide-core-spacing-sm);
 
       &.focused,
-      &:hover {
+      &:hover,
+      &:has(.input:hover) {
         border-color: var(--glide-core-border-focus);
         transition: border-color 200ms ease-in-out;
       }
@@ -59,9 +59,8 @@ export default [
       }
 
       /* We had to resort to a class selector because there may be a bug in Chrome and Safari
-    * with ":read-only"
-    * https://bugs.chromium.org/p/chromium/issues/detail?id=1519649
-    */
+       * with ":read-only": https://bugs.chromium.org/p/chromium/issues/detail?id=1519649
+       */
       &.readonly {
         border: 1px solid transparent;
         padding-inline-start: 0;
@@ -72,45 +71,45 @@ export default [
         border-color: var(--glide-core-border-base-light);
         color: var(--glide-core-text-tertiary-disabled);
       }
+    }
 
-      input {
-        background-color: transparent;
-        block-size: 2.125rem;
-        border: none;
-        color: inherit;
-        cursor: inherit;
-        font-family: var(--glide-core-font-sans);
-        font-size: var(--glide-core-body-sm-font-size);
-        font-weight: var(--glide-core-body-xs-font-weight);
-        inline-size: 100%;
-        min-inline-size: 0;
-        outline: none;
-        padding: 0;
+    .input {
+      background-color: transparent;
+      block-size: 2rem;
+      border: none;
+      color: inherit;
+      cursor: inherit;
+      font-family: var(--glide-core-font-sans);
+      font-size: var(--glide-core-body-sm-font-size);
+      font-weight: var(--glide-core-body-xs-font-weight);
+      inline-size: 100%;
+      min-inline-size: 0;
+      outline: none;
+      padding: 0;
 
-        &::-webkit-search-decoration,
-        &::-webkit-search-cancel-button,
-        &::-webkit-search-results-button,
-        &::-webkit-search-results-decoration {
-          appearance: none;
-        }
-
-        /* The input obscures an offset outline for -webkit-calendar-picker-indicator, so 'focus-outline' is not used */
-        &[type='date'] {
-          &::-webkit-calendar-picker-indicator {
-            border-radius: 0.125rem;
-            padding: var(--glide-core-spacing-xxs);
-          }
-          /* stylelint-disable-next-line csstools/use-nesting */
-          &::-webkit-calendar-picker-indicator:focus-visible {
-            outline: 2px solid var(--glide-core-border-focus);
-          }
-        }
+      &::-webkit-search-decoration,
+      &::-webkit-search-cancel-button,
+      &::-webkit-search-results-button,
+      &::-webkit-search-results-decoration {
+        appearance: none;
       }
 
-      .suffix-icon {
-        align-items: center;
-        display: flex;
+      /* The input obscures an offset outline for -webkit-calendar-picker-indicator, so 'focus-outline' is not used */
+      &[type='date'] {
+        &::-webkit-calendar-picker-indicator {
+          border-radius: 0.125rem;
+          padding: var(--glide-core-spacing-xxs);
+        }
+        /* stylelint-disable-next-line csstools/use-nesting */
+        &::-webkit-calendar-picker-indicator:focus-visible {
+          outline: 2px solid var(--glide-core-border-focus);
+        }
       }
+    }
+
+    .suffix-icon {
+      align-items: center;
+      display: flex;
     }
 
     .clear-icon-button,

--- a/src/input.ts
+++ b/src/input.ts
@@ -257,6 +257,7 @@ export default class GlideCoreInput extends LitElement {
             aria-describedby="meta"
             aria-invalid=${this.#isShowValidationFeedback ||
             this.#isMaxCharacterCountExceeded}
+            class="input"
             id="input"
             type=${this.type === 'password' && this.passwordVisible
               ? 'text'


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

I noticed that Textarea was in a hover state when its label was hovered. I thought it was a bug at first but then compared it  to native. It turns out hovering the label puts the thing labeled into a hover state.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Dropdown and Input in Storybook.
2. Hover over each component's label.
3. Verify the controls have a blue border.


## 📸 Images/Videos of Functionality

N/A
