### PR TITLE
Update placeholder colors and get new Figma variables

### DIFF
--- a/.changeset/dull-plums-help.md
+++ b/.changeset/dull-plums-help.md
@@ -1,0 +1,20 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+`@crowdstrike/glide-core/styles/variables.css` has been updated with the latest from Figma:
+
+## Dark
+
+### Changed
+
+```diff
+- --glide-core-surface-primary-disabled: #3989da99
++ --glide-core-surface-primary-disabled: #3888d999;
+
+- --glide-core-text-link-table: #73b2f3;
++ --glide-core-text-link-table: #93c4f6;
+
+- --glide-core-text-placeholder: #c9c9c9;
++ --glide-core-text-placeholder: #9e9e9e;
+```

--- a/.changeset/smooth-seas-smell.md
+++ b/.changeset/smooth-seas-smell.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown, Input, and Textarea placeholder states were updated to use a new placeholder variable.

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -233,21 +233,12 @@ export default [
     }
 
     .placeholder {
-      /*
-        Using the browser's default placeholder color for now, as
-        '--glide-core-text-placeholder' has dark mode issues. Aligns
-        with Input and Textarea as suggested by design.
-      */
-      color: rgb(117 117 117);
+      color: var(--glide-core-text-placeholder);
 
       &.quiet {
         &:not(.disabled) {
           color: var(--glide-core-text-body-1);
         }
-      }
-
-      &.disabled {
-        color: var(--glide-core-text-tertiary-disabled);
       }
     }
 
@@ -358,6 +349,7 @@ export default [
       }
 
       &::placeholder {
+        color: var(--glide-core-text-placeholder);
         font-family: var(--glide-core-font-sans);
       }
     }

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -643,7 +643,6 @@ export default class GlideCoreDropdown extends LitElement {
                     return html`<span
                       class=${classMap({
                         placeholder: true,
-                        disabled: this.disabled,
                         quiet: this.variant === 'quiet',
                       })}
                     >

--- a/src/input.styles.ts
+++ b/src/input.styles.ts
@@ -87,6 +87,10 @@ export default [
       outline: none;
       padding: 0;
 
+      &::placeholder {
+        color: var(--glide-core-text-placeholder);
+      }
+
       &::-webkit-search-decoration,
       &::-webkit-search-cancel-button,
       &::-webkit-search-results-button,

--- a/src/styles/variables/dark.css
+++ b/src/styles/variables/dark.css
@@ -79,7 +79,7 @@
   --glide-core-surface-modal: #464242;
   --glide-core-surface-page: #212121;
   --glide-core-surface-primary: #3989da;
-  --glide-core-surface-primary-disabled: #3989da99;
+  --glide-core-surface-primary-disabled: #3888d999;
   --glide-core-surface-secondary: #f0f0f0;
   --glide-core-surface-secondary-disabled: #f0f0f0;
   --glide-core-surface-selected: #3989da;
@@ -99,8 +99,8 @@
   --glide-core-text-header-2: #f0f0f0;
   --glide-core-text-link: #73b2f3;
   --glide-core-text-link-dark-surface: #73b2f3;
-  --glide-core-text-link-table: #73b2f3;
-  --glide-core-text-placeholder: #c9c9c9;
+  --glide-core-text-link-table: #93c4f6;
+  --glide-core-text-placeholder: #9e9e9e;
   --glide-core-text-primary: #73b2f3;
   --glide-core-text-primary-hover: #4d99e7;
   --glide-core-text-secondary: #3989da;

--- a/src/textarea.styles.ts
+++ b/src/textarea.styles.ts
@@ -72,6 +72,10 @@ export default [
         border-color: var(--glide-core-border-focus);
       }
 
+      &::placeholder {
+        color: var(--glide-core-text-placeholder);
+      }
+
       &.error {
         border-color: var(--glide-core-status-error);
       }


### PR DESCRIPTION
## 🚀 Description

- Updates the placeholder colors for Dropdown, Input, and Textarea to match designs.
- Updates the variables from Figma.

## 📋 Checklist

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

Placeholder colors were updated throughout, so double-check these situations:

- Visit [Input in dark mode](https://glide-core.crowdstrike-ux.workers.dev/placeholder-and-disabled-fixes?path=/story/input--input&globals=theme:dark)
- Visit [Dropdown in dark mode](https://glide-core.crowdstrike-ux.workers.dev/placeholder-and-disabled-fixes?path=/story/dropdown--dropdown&globals=theme:dark)
- Visit [Textarea in dark mode](https://glide-core.crowdstrike-ux.workers.dev/placeholder-and-disabled-fixes?path=/story/textarea--textarea&globals=theme:dark)

There should be more contrast!

## 📸 Images/Videos of Functionality

| Before  | After |
| ------- | ----- |
| <img width="517" alt="before-input-disabled-placeholder" src="https://github.com/user-attachments/assets/3b1508df-640a-4c0b-84b1-33a67a2b6a68">  | <img width="518" alt="after-input-disabled-placeholder" src="https://github.com/user-attachments/assets/872db924-2478-4fb0-a498-535b4ff917f8"> |
| <img width="516" alt="before-textarea-disabled-placeholder" src="https://github.com/user-attachments/assets/72f169ec-a3f3-4a7c-be12-46aa18ea39e1">  | <img width="519" alt="after-textarea-disabled-placeholder" src="https://github.com/user-attachments/assets/097e6f6e-6a8c-4026-b4c3-4b22b86fca32"> |
|  <img width="516" alt="before-dropdown-disabled-placeholder" src="https://github.com/user-attachments/assets/8548c0c7-e5ff-49c1-a6b5-20a6ec043c6f">  | <img width="520" alt="after-dropdown-disabled-placeholder" src="https://github.com/user-attachments/assets/04c3f1bd-6fb8-4cda-8acd-aafd9a5c74ad"> |
|  <img width="518" alt="before-dropdown" src="https://github.com/user-attachments/assets/e90d96a6-a60d-4223-8f19-3d65788d3d2b">  | <img width="518" alt="after-dropdown" src="https://github.com/user-attachments/assets/ea2f6fe8-4ce6-420c-a614-2fad600f4a41"> |
|  <img width="518" alt="before-textarea" src="https://github.com/user-attachments/assets/22d39b6a-f329-42a0-9cd9-d69a1abd1ad8">  | <img width="518" alt="after-textarea" src="https://github.com/user-attachments/assets/778947e7-bc3d-444e-b866-36eb327b1d75"> |
|  <img width="518" alt="before-input" src="https://github.com/user-attachments/assets/ffa340ff-5265-48f5-9245-256c43309f81">  | <img width="514" alt="after-input" src="https://github.com/user-attachments/assets/cba414ff-c9e9-45db-910b-138f6c7840d9"> |
|  <img width="520" alt="before-dropdown-filterable" src="https://github.com/user-attachments/assets/a9ea9a1b-3665-43be-b5e9-a76b1d6b63f7">  | <img width="520" alt="after-dropdown-filterable" src="https://github.com/user-attachments/assets/d5bccd67-2e5d-43e2-9cd4-a37f27d8478e"> |














