### PR TITLE
Update readonly backgrounds per latest designs

### DIFF
--- a/.changeset/happy-parrots-flash.md
+++ b/.changeset/happy-parrots-flash.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown, Input, and Textarea now follow the same design patterns when in the `readonly` state by removing inline-start padding, removing the border, and having a transparent background.

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -83,6 +83,7 @@ export default [
       }
 
       &.readonly {
+        background-color: transparent;
         border-color: transparent;
         padding-inline-start: 0;
       }

--- a/src/input.styles.ts
+++ b/src/input.styles.ts
@@ -62,6 +62,7 @@ export default [
        * with ":read-only": https://bugs.chromium.org/p/chromium/issues/detail?id=1519649
        */
       &.readonly {
+        background-color: transparent;
         border: 1px solid transparent;
         padding-inline-start: 0;
       }

--- a/src/textarea.styles.ts
+++ b/src/textarea.styles.ts
@@ -81,8 +81,10 @@ export default [
       }
 
       &[readonly] {
+        background-color: transparent;
         border-color: transparent;
         outline: none;
+        padding-inline-start: 0;
         resize: none;
         transition: none;
       }


### PR DESCRIPTION
## 🚀 Description

Per design, some adjustments to Dropdown, Input, and Textarea's `readonly` state.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

I worked directly with Zheng on all of these changes and he has approved, but to review:

- Use https://glide-core.crowdstrike-ux.workers.dev/update-readonly-backgrounds to visit the readonly states of Dropdown, Input, and Textarea

## 📸 Images/Videos of Functionality

| Before  | After |
| ------- | ----- |
| <img width="500" alt="before-input-light" src="https://github.com/user-attachments/assets/a652d2c0-1544-49b4-8a7d-a022c770a980">  | <img width="500" alt="after-input-light" src="https://github.com/user-attachments/assets/98b50aa5-67a4-4f39-bf11-73210d0f12e7"> |
| <img width="500" alt="before-input-dark" src="https://github.com/user-attachments/assets/9ecb05e7-ac68-4a36-8d22-c697639c868e">  | <img width="496" alt="after-input-dark" src="https://github.com/user-attachments/assets/ba2dcee4-c967-4397-9855-d8d407a6245e"> |
| <img width="500" alt="before-textarea-light" src="https://github.com/user-attachments/assets/e2c954e3-028a-4453-baa4-41a3504cd21b">  | <img width="498" alt="after-textarea-light" src="https://github.com/user-attachments/assets/834573ca-cc35-403e-890a-626494784fef"> |
|  <img width="496" alt="before-textarea-dark" src="https://github.com/user-attachments/assets/5917b410-3a83-4d7d-90ba-174a7e384cbe">  | <img width="496" alt="after-textarea-dark" src="https://github.com/user-attachments/assets/37fd90fd-4b74-4c23-985f-5d9c9a1b08a2"> |
|  <img width="500" alt="before-dropdown-light" src="https://github.com/user-attachments/assets/6c673e5c-558f-48e4-967f-08c39aace2ee">  | <img width="502" alt="after-dropdown-light" src="https://github.com/user-attachments/assets/0020a85d-f4ec-452c-b065-9192900dfda7"> |
| <img width="497" alt="before-dropdown-dark" src="https://github.com/user-attachments/assets/7f380ba2-16f5-41ba-8e6b-e9df266ae2cf">  | <img width="499" alt="after-dropdown-dark" src="https://github.com/user-attachments/assets/171bf80a-428f-4c05-ac8b-11b1fa11e90f"> |
|  <img width="497" alt="before-dropdown-dark-options" src="https://github.com/user-attachments/assets/815beff4-355c-4acb-bb78-0d71b8fe34d2">  | <img width="498" alt="after-dropdown-dark-options" src="https://github.com/user-attachments/assets/f3262fae-d3b8-447d-9062-d7fa5841e2b5"> |








