### PR TITLE
Move Button Group's `addEventListener` control to Button Group Button

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -5,7 +5,7 @@ import { create } from '@storybook/theming/create';
 import GlideCoreLogo from './assets/glide-core.png';
 
 addons.setConfig({
-  enableShortcuts: false,
+  enableShortcuts: false, // We found people triggered shortcuts accidentally more than not.
   theme: create({
     base: 'dark',
     brandImage: GlideCoreLogo,
@@ -15,7 +15,7 @@ addons.setConfig({
   }),
   toolbar: {
     fullscreen: {
-      hidden: true,
+      hidden: true, // Just clutter. Rarely used.
     },
   },
 });

--- a/src/button-group.stories.ts
+++ b/src/button-group.stories.ts
@@ -136,10 +136,10 @@ const meta: Meta = {
   args: {
     label: 'Label',
     'slot="default"': '',
-    'addEventListener(event, handler)': '',
     orientation: 'horizontal',
     variant: '',
     '<glide-core-button-group-button>.label': 'One',
+    '<glide-core-button-group-button>.addEventListener(event, handler)': '',
     '<glide-core-button-group-button>.disabled': false,
     '<glide-core-button-group-button>.one.selected': true,
     '<glide-core-button-group-button>[slot="icon"]': '',
@@ -160,15 +160,7 @@ const meta: Meta = {
       },
       type: { name: 'function', required: true },
     },
-    'addEventListener(event, handler)': {
-      control: false,
-      table: {
-        type: {
-          summary: 'method',
-          detail: 'event: "change" | "input", handler: (event: Event) => void',
-        },
-      },
-    },
+
     orientation: {
       control: { type: 'radio' },
       options: ['horizontal', 'vertical'],
@@ -191,6 +183,18 @@ const meta: Meta = {
         category: 'Button Group Button',
       },
       type: { name: 'string', required: true },
+    },
+    '<glide-core-button-group-button>.addEventListener(event, handler)': {
+      name: 'addEventListener(event, handler)',
+      control: false,
+      table: {
+        category: 'Button Group Button',
+        type: {
+          summary: 'method',
+          detail:
+            '(event: "change" | "input", handler: (event: Event) => void) => void',
+        },
+      },
     },
     '<glide-core-button-group-button>.disabled': {
       name: 'disabled',


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Button Group's "change" and "input" events are [actually](https://github.com/CrowdStrike/glide-core/blob/main/src/button-group.ts#L246-L247) dispatched from Button Group Button. I've updated Storybook to reflect that.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A


