### PR TITLE
fix(Drawer): improve animation responsiveness

### DIFF
--- a/src/drawer.stories.ts
+++ b/src/drawer.stories.ts
@@ -100,10 +100,10 @@ const meta: Meta = {
     'slot="default"': '',
     'addEventListener(event, handler)': '',
     'close()': '',
+    open: false,
     'show()': '',
     pinned: false,
     '--width': '',
-    open: false,
   },
   argTypes: {
     'slot="default"': {

--- a/src/drawer.styles.ts
+++ b/src/drawer.styles.ts
@@ -34,17 +34,8 @@ export default [
       block-size: auto;
       inline-size: var(--width, 27.375rem);
       inset: 0 0 0 auto;
-      opacity: 1;
       transform: none;
-      transition:
-        transform 0.3s cubic-bezier(0.33, 1, 0.68, 1),
-        opacity 0.3s ease-in;
       visibility: visible;
-    }
-
-    .closing {
-      transform: translateX(100%);
-      transition: transform 0.3s cubic-bezier(0.33, 1, 0.68, 1);
     }
   `,
 ];

--- a/src/drawer.test.accessibility.ts
+++ b/src/drawer.test.accessibility.ts
@@ -1,22 +1,32 @@
 import './drawer.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import {
+  assert,
+  elementUpdated,
+  expect,
+  fixture,
+  html,
+} from '@open-wc/testing';
 import GlideCoreDrawer from './drawer.js';
 
 GlideCoreDrawer.shadowRootOptions.mode = 'open';
-
-// NOTE: Due to https://github.com/modernweb-dev/web/issues/2520, we sometimes need
-// to manually dispatch the `transitionend` event in tests.
 
 it('is accessible', async () => {
   const component = await fixture<GlideCoreDrawer>(
     html`<glide-core-drawer>Drawer content</glide-core-drawer>`,
   );
 
-  component.shadowRoot
-    ?.querySelector('aside')
-    ?.dispatchEvent(new TransitionEvent('transitionend'));
-
   component.show();
+
+  await elementUpdated(component);
+
+  const animationPromises = component.shadowRoot
+    ?.querySelector('[data-test="open"]')
+    ?.getAnimations()
+    ?.map((animation) => animation.finished);
+
+  assert(animationPromises);
+
+  await Promise.allSettled(animationPromises!);
 
   await expect(component).to.be.accessible();
 });
@@ -28,9 +38,16 @@ it('focuses the aside upon opening', async () => {
 
   component.show();
 
-  component.shadowRoot
-    ?.querySelector('aside')
-    ?.dispatchEvent(new TransitionEvent('transitionend'));
+  await elementUpdated(component);
+
+  const animationPromises = component.shadowRoot
+    ?.querySelector('[data-test="open"]')
+    ?.getAnimations()
+    ?.map((animation) => animation.finished);
+
+  assert(animationPromises);
+
+  await Promise.allSettled(animationPromises!);
 
   expect(component.shadowRoot?.activeElement).to.equal(
     component.shadowRoot?.querySelector('aside'),

--- a/src/drawer.test.basics.ts
+++ b/src/drawer.test.basics.ts
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 import './drawer.js';
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import {
+  assert,
+  elementUpdated,
+  expect,
+  fixture,
+  html,
+} from '@open-wc/testing';
 import GlideCoreDrawer from './drawer.js';
 import expectArgumentError from './library/expect-argument-error.js';
 
@@ -53,6 +59,17 @@ it('sets the width of the element based on the "--width" CSS variable', async ()
   );
 
   component.show();
+
+  await elementUpdated(component);
+
+  const animationPromises = component.shadowRoot
+    ?.querySelector('[data-test="open"]')
+    ?.getAnimations()
+    ?.map((animation) => animation.finished);
+
+  assert(animationPromises);
+
+  await Promise.allSettled(animationPromises!);
 
   expect(component.shadowRoot?.querySelector('aside')?.clientWidth).to.equal(
     750,

--- a/src/drawer.test.methods.ts
+++ b/src/drawer.test.methods.ts
@@ -6,9 +6,6 @@ import GlideCoreDrawer from './drawer.js';
 
 GlideCoreDrawer.shadowRootOptions.mode = 'open';
 
-// NOTE: Due to https://github.com/modernweb-dev/web/issues/2520, we sometimes need
-// to manually dispatch the `transitionend` event in tests.
-
 it('opens the drawer via the "show()" method and closes it via "close()"', async () => {
   const component = await fixture<GlideCoreDrawer>(
     html`<glide-core-drawer>Drawer content</glide-core-drawer>`,
@@ -18,18 +15,10 @@ it('opens the drawer via the "show()" method and closes it via "close()"', async
 
   await elementUpdated(component);
 
-  component.shadowRoot
-    ?.querySelector('aside')
-    ?.dispatchEvent(new TransitionEvent('transitionend'));
-
   expect(component.shadowRoot?.querySelector('[data-test="open"]')).to.be.not
     .null;
 
   component.close();
-
-  component.shadowRoot
-    ?.querySelector('aside')
-    ?.dispatchEvent(new TransitionEvent('transitionend'));
 
   await elementUpdated(component);
 

--- a/src/drawer.ts
+++ b/src/drawer.ts
@@ -43,31 +43,63 @@ export default class GlideCoreDrawer extends LitElement {
     this.#isOpen = isOpen;
 
     if (this.#isOpen) {
-      this.#asideElementRef?.value?.addEventListener(
-        'transitionend',
-        () => {
-          // We set `tabindex="-1"` and call focus directly based on
-          // https://www.matuzo.at/blog/2023/focus-dialog/
-          // which came from https://adrianroselli.com/2020/10/dialog-focus-in-screen-readers.html
-          this.#asideElementRef?.value?.focus();
-        },
-        { once: true },
-      );
+      (async () => {
+        await this.#animationClose?.finished;
 
-      this.#asideElementRef?.value?.classList?.add('open');
+        this.#asideElementRef?.value?.classList?.add('open');
+
+        this.#animationOpen = this.#asideElementRef?.value?.animate(
+          { transform: ['translateX(100%)', 'translateX(0)'] },
+          {
+            duration: 300,
+            fill: 'forwards',
+            easing: 'cubic-bezier(0.33, 1, 0.68, 1)',
+          },
+        );
+
+        this.#asideElementRef?.value?.animate(
+          {
+            opacity: [0, 1],
+          },
+          {
+            duration: 300,
+            fill: 'forwards',
+            easing: 'ease-in',
+            composite: 'add',
+          },
+        );
+
+        await this.#animationOpen?.finished;
+        this.#asideElementRef?.value?.focus();
+      })();
     } else {
-      this.#asideElementRef?.value?.addEventListener(
-        'transitionend',
-        () => {
-          this.#asideElementRef?.value?.classList?.remove('open');
-          this.#asideElementRef?.value?.classList?.remove('closing');
+      (async () => {
+        await this.#animationOpen?.finished;
 
-          this.dispatchEvent(new Event('close', { bubbles: true }));
-        },
-        { once: true },
-      );
+        this.#animationClose = this.#asideElementRef?.value?.animate(
+          { transform: ['translateX(0)', 'translateX(100%)'] },
+          {
+            duration: 300,
+            fill: 'forwards',
+            easing: 'cubic-bezier(0.33, 1, 0.68, 1)',
+          },
+        );
 
-      this.#asideElementRef?.value?.classList?.add('closing');
+        this.#asideElementRef?.value?.animate(
+          {
+            opacity: [1, 0],
+          },
+          {
+            duration: 300,
+            fill: 'forwards',
+            composite: 'add',
+          },
+        );
+
+        await this.#animationClose?.finished;
+        this.#asideElementRef?.value?.classList?.remove('open');
+        this.dispatchEvent(new Event('close', { bubbles: true }));
+      })();
     }
   }
 
@@ -104,6 +136,10 @@ export default class GlideCoreDrawer extends LitElement {
   show() {
     this.open = true;
   }
+
+  #animationClose?: Animation;
+
+  #animationOpen?: Animation;
 
   #asideElementRef = createRef<HTMLElement>();
 


### PR DESCRIPTION
## 🚀 Description

Attempts to improve the responsiveness of the opening/closing animation in response to [this](https://github.com/CrowdStrike/glide-core/pull/497#issuecomment-2514607583) comment. 

## 📋 Checklist

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. In Storybook, navigate to the Drawer story and quickly toggle the `open` control. Observe that the drawer generally responds as expected. This is not always the case in `main`.

## 📸 Images/Videos of Functionality

Before, on `main`:

https://github.com/user-attachments/assets/a777a521-6799-47d0-b949-378800d876b7

After:

https://github.com/user-attachments/assets/c2df7aea-2c41-46b2-a227-57f767486799
