### PR TITLE
Grab bag!

### DIFF
--- a/.changeset/bright-icons-invent.md
+++ b/.changeset/bright-icons-invent.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Checkbox's `isReportValidityOrSubmit` property has been renamed to `privateIsReportValidityOrSubmit` to deter external use.

--- a/.changeset/few-trainers-nail.md
+++ b/.changeset/few-trainers-nail.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Drawer now respects the system setting for reduced motion when opening and closing.

--- a/.storybook/overrides.css
+++ b/.storybook/overrides.css
@@ -24,6 +24,11 @@
   white-space: nowrap !important;
 }
 
+/* The "default" column can get pretty long and wraps, making it hard to read. */
+.docblock-argstable-body tr td:nth-of-type(3) span {
+  white-space: nowrap !important;
+}
+
 .docs-story {
   background-color: var(--glide-core-surface-background-image) !important;
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,8 @@
   - [Typing property decorators](#typing-property-decorators)
   - [Avoid side effects in setters](#avoid-side-effects-in-setters)
   - [Prefer `.component` for the root element CSS selector](#prefer-component-for-the-root-element-css-selector)
-  - [Bubble events by default](#bubble-events-by-default)
+  - [Bubble and compose events](#bubble-and-compose-events)
+  - [Avoid custom events](#avoid-custom-events)
   - [Override and decorate inherited properties used in templates](#override-and-decorate-inherited-properties-used-in-templates)
   - [Translations and static strings](#translations-and-static-strings)
 - [Questions](#questions)
@@ -623,23 +624,37 @@ render() {
 }
 ```
 
-### Bubble events by default
+### Bubble and compose events
 
 Bubbling is what consumers expect because most events bubble.
 Bubbling also lets consumers use our components more flexibly by allowing [event delegation](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_delegation).
+And composing events means they can bubble through nested shadow roots.
 
 ```ts
 // ✅ -- GOOD
-this.dispatchEvent(new Event('change', { bubbles: true }));
+this.dispatchEvent(new Event('selected', { bubbles: true, composed: true }));
 ```
 
 ```ts
 // ❌ -- BAD
-this.dispatchEvent(new Event('change');
+this.dispatchEvent(new Event('selected');
 ```
 
-There are some exceptions such as Modal, whose "close" event doesn't bubble similar to `<dialog>`.
-When deciding to bubble, consider whether the native equivalent bubbles.
+There are some exceptions such as Modal, whose "close" event doesn't bubble to match `<dialog>`.
+When deciding to bubble, consider whether the native's equivalent event bubbles.
+Same when composing them.
+Native's "close" event isn't composed.
+Neither is "change".
+
+We're open to bubbling and composing any event if a use case presents itself.
+But our starting point is to follow native.
+
+### Avoid custom events
+
+Custom events are often unncessary because the value of the event's `detail` property is available or can be made available elsewhere more naturally.
+
+Before using a custom event, see if the value is already available externally via a component attribute.
+Or, if the value is an element, consider simply dispatching the event from the element and letting consumers retrieve it from `event.target`.
 
 ### Override and decorate inherited properties used in templates
 

--- a/src/button-group.button.ts
+++ b/src/button-group.button.ts
@@ -45,9 +45,11 @@ export default class GlideCoreButtonGroupButton extends LitElement {
   @property({ reflect: true })
   value? = '';
 
+  // Private because it's only meant to be used Button Group.
   @property()
   privateOrientation: 'horizontal' | 'vertical' = 'horizontal';
 
+  // Private because it's only meant to be used Button Group.
   @property()
   privateVariant?: 'icon-only';
 

--- a/src/checkbox-group.stories.ts
+++ b/src/checkbox-group.stories.ts
@@ -41,7 +41,7 @@ const meta: Meta = {
     'setValidity(flags, message)': '',
     'slot="description"': '',
     'slot="tooltip"': '',
-    value: '',
+    value: [],
     '<glide-core-checkbox>.one.checked': false,
     '<glide-core-checkbox>.two.checked': false,
     '<glide-core-checkbox>.three.checked': false,
@@ -141,7 +141,6 @@ const meta: Meta = {
       },
     },
     value: {
-      control: false,
       table: {
         defaultValue: { summary: '[]' },
         type: {
@@ -221,6 +220,7 @@ const meta: Meta = {
           ?disabled=${arguments_.disabled}
           ?hide-label=${arguments_['hide-label'] || nothing}
           ?required=${arguments_.required}
+          .value=${arguments_.value || nothing}
         >
           <glide-core-checkbox label="One" value="one" ?checked=${
             arguments_['<glide-core-checkbox>.one.checked']

--- a/src/checkbox-group.test.focus.ts
+++ b/src/checkbox-group.test.focus.ts
@@ -110,8 +110,8 @@ it('reports validity of checkboxes if blurred', async () => {
   await sendKeys({ press: 'Tab' });
 
   expect(document.activeElement === checkboxes[1]).to.be.true;
-  expect(checkboxes[0].isReportValidityOrSubmit).to.be.false;
-  expect(checkboxes[1].isReportValidityOrSubmit).to.be.false;
+  expect(checkboxes[0].privateIsReportValidityOrSubmit).to.be.false;
+  expect(checkboxes[1].privateIsReportValidityOrSubmit).to.be.false;
 
   await sendKeys({ press: 'Tab' });
 
@@ -119,7 +119,7 @@ it('reports validity of checkboxes if blurred', async () => {
 
   expect(component.validity.valid).to.be.false;
   expect(checkboxes[0].validity.valid).to.be.false;
-  expect(checkboxes[0].isReportValidityOrSubmit).to.be.true;
+  expect(checkboxes[0].privateIsReportValidityOrSubmit).to.be.true;
   expect(checkboxes[1].validity.valid).to.be.false;
-  expect(checkboxes[1].isReportValidityOrSubmit).to.be.true;
+  expect(checkboxes[1].privateIsReportValidityOrSubmit).to.be.true;
 });

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -58,6 +58,7 @@ export default class GlideCoreCheckboxGroup extends LitElement {
   @property({ reflect: true })
   name = '';
 
+  // Private because it's only meant to be used by Form Controls Layout.
   @property()
   privateSplit?: 'left' | 'middle';
 
@@ -415,7 +416,7 @@ export default class GlideCoreCheckboxGroup extends LitElement {
 
   #onBlur() {
     for (const checkbox of this.#checkboxes) {
-      checkbox.isReportValidityOrSubmit = true;
+      checkbox.privateIsReportValidityOrSubmit = true;
     }
   }
 

--- a/src/checkbox.styles.ts
+++ b/src/checkbox.styles.ts
@@ -3,9 +3,8 @@ import focusOutline from './styles/focus-outline.js';
 
 export default [
   css`
-    ${focusOutline(
-      'input:focus-visible ~ .checkbox, input:focus ~ .checkbox.error',
-    )}
+    ${focusOutline('.input:focus-visible ~ .checkbox')}
+    ${focusOutline('.input:focus ~ .checkbox.error')}
   `,
   css`
     /*
@@ -84,7 +83,7 @@ when browsers support them.
       }
     }
 
-    input {
+    .input {
       block-size: 100%;
       cursor: inherit;
       inline-size: 100%;

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -89,14 +89,15 @@ export default class GlideCoreCheckbox extends LitElement {
   @property({ reflect: true })
   name = '';
 
+  // Private because it's only meant to be used by Dropdown Option to offset the tooltip by the option's padding.
   @property({
     attribute: 'private-label-tooltip-offset',
     reflect: true,
     type: Number,
   })
-  // Unfortunate. Used by Dropdown Option to offset the tooltip by the option's padding.
   privateLabelTooltipOffset = 4;
 
+  // Private because it's only meant to be used by Dropdown Option.
   @property({
     attribute: 'private-show-label-tooltip',
     reflect: true,
@@ -104,6 +105,7 @@ export default class GlideCoreCheckbox extends LitElement {
   })
   privateShowLabelTooltip = false;
 
+  // Private because it's only meant to be used by Dropdown Option.
   @property({
     attribute: 'private-disable-label-tooltip',
     reflect: true,
@@ -111,12 +113,15 @@ export default class GlideCoreCheckbox extends LitElement {
   })
   privateDisableLabelTooltip = false;
 
+  // Private because it's only meant to be used by Dropdown.
   @property({ attribute: 'private-size' })
   privateSize: 'large' | 'small' = 'large';
 
+  // Private because it's only meant to be used by Form Controls Layout.
   @property()
   privateSplit?: 'left' | 'middle';
 
+  // Private because it's only meant to be used by Checkbox Group and Dropdown Option.
   @property({ attribute: 'private-variant' })
   privateVariant?: 'minimal';
 
@@ -150,9 +155,9 @@ export default class GlideCoreCheckbox extends LitElement {
     );
   }
 
-  // Not private, so that a parent checkbox group can programmatically set
+  // Used by Checkbox Group.
   @state()
-  isReportValidityOrSubmit = false;
+  privateIsReportValidityOrSubmit = false;
 
   get form() {
     return this.#internals.form;
@@ -266,6 +271,7 @@ export default class GlideCoreCheckbox extends LitElement {
             <div class="input-and-checkbox">
               <input
                 aria-invalid=${this.#isShowValidationFeedback}
+                class="input"
                 data-test="input"
                 type="checkbox"
                 .checked=${this.checked}
@@ -355,6 +361,7 @@ export default class GlideCoreCheckbox extends LitElement {
               <input
                 aria-describedby="summary description"
                 aria-invalid=${this.#isShowValidationFeedback}
+                class="input"
                 data-test="input"
                 id="input"
                 type="checkbox"
@@ -408,7 +415,7 @@ export default class GlideCoreCheckbox extends LitElement {
   }
 
   reportValidity() {
-    this.isReportValidityOrSubmit = true;
+    this.privateIsReportValidityOrSubmit = true;
 
     const isValid = this.#internals.reportValidity();
 
@@ -479,7 +486,7 @@ export default class GlideCoreCheckbox extends LitElement {
         return;
       }
 
-      this.isReportValidityOrSubmit = true;
+      this.privateIsReportValidityOrSubmit = true;
 
       const isFirstInvalidFormElement =
         this.form?.querySelector(':invalid') === this;
@@ -540,11 +547,13 @@ export default class GlideCoreCheckbox extends LitElement {
     // If minimal, `disabled`, `required`, and whether the form has been submitted
     // don't apply because the parent component handles those states itself.
     if (this.privateVariant === 'minimal') {
-      return !this.validity.valid && this.isReportValidityOrSubmit;
+      return !this.validity.valid && this.privateIsReportValidityOrSubmit;
     }
 
     return (
-      !this.disabled && !this.validity.valid && this.isReportValidityOrSubmit
+      !this.disabled &&
+      !this.validity.valid &&
+      this.privateIsReportValidityOrSubmit
     );
   }
 

--- a/src/dropdown.option.ts
+++ b/src/dropdown.option.ts
@@ -76,12 +76,15 @@ export default class GlideCoreDropdownOption extends LitElement {
     );
   }
 
+  // Private because it's only meant to be used by Dropdown.
   @property({ attribute: 'private-indeterminate', type: Boolean })
   privateIndeterminate = false;
 
+  // Private because it's only meant to be used by Dropdown.
   @property({ type: Boolean })
   privateIsEditActive = false;
 
+  // Private because it's only meant to be used by Dropdown.
   @property({ attribute: 'private-multiple', type: Boolean })
   privateMultiple = false;
 
@@ -123,10 +126,12 @@ export default class GlideCoreDropdownOption extends LitElement {
     this.dispatchEvent(new Event('private-selected-change', { bubbles: true }));
   }
 
+  // Private because it's only meant to be used by Dropdown.
   @property({ attribute: 'private-size', reflect: true })
   privateSize: 'small' | 'large' = 'large';
 
   // An option is considered active when it's interacted with via keyboard or hovered.
+  // Used by Dropdown.
   @state()
   privateActive = false;
 

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -54,7 +54,7 @@ const meta: Meta = {
     'slot="description"': '',
     'slot="icon:<value>"': '',
     'slot="tooltip"': '',
-    value: '',
+    value: [],
     variant: '',
     '<glide-core-dropdown-option>.label': 'One',
     '<glide-core-dropdown-option>.addEventListener(event, handler)': false,
@@ -260,7 +260,6 @@ async (query: string): Promise<GlideCoreDropdownOption[]> {
       },
     },
     value: {
-      control: false,
       table: {
         defaultValue: { summary: '[]' },
         type: {
@@ -447,6 +446,7 @@ async (query: string): Promise<GlideCoreDropdownOption[]> {
       ?readonly=${arguments_.readonly}
       ?required=${arguments_.required}
       ?select-all=${arguments_['select-all']}
+      .value=${arguments_.value}
     >
       <glide-core-dropdown-option
         label=${arguments_['<glide-core-dropdown-option>.label'] || nothing}
@@ -527,6 +527,7 @@ export const WithIcons: StoryObj = {
       ?readonly=${arguments_.readonly}
       ?required=${arguments_.required}
       ?select-all=${arguments_['select-all']}
+      .value=${arguments_.value}
     >
       <glide-core-example-icon
         slot="icon:edit"

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -140,6 +140,7 @@ export default class GlideCoreDropdown extends LitElement {
   @property({ reflect: true })
   placeholder?: string;
 
+  // Private because it's only meant to be used by Form Controls Layout.
   @property()
   privateSplit?: 'left' | 'middle';
 
@@ -197,6 +198,7 @@ export default class GlideCoreDropdown extends LitElement {
   @property({ reflect: true, type: Boolean })
   required = false;
 
+  // Intentionally not reflected to match native.
   @property({ type: Array })
   get value() {
     return this.#value;

--- a/src/input.ts
+++ b/src/input.ts
@@ -64,7 +64,7 @@ export default class GlideCoreInput extends LitElement {
   @property({ reflect: true })
   name = '';
 
-  // `value` is intentionally not reflected here to match native
+  // Intentionally not reflected to match native.
   @property()
   value = '';
 
@@ -115,6 +115,7 @@ export default class GlideCoreInput extends LitElement {
   @property({ reflect: true, type: Boolean })
   disabled = false;
 
+  // Private because it's only meant to be used by Form Controls Layout.
   @property()
   privateSplit?: 'left' | 'middle';
 

--- a/src/menu.button.ts
+++ b/src/menu.button.ts
@@ -25,8 +25,9 @@ export default class GlideCoreMenuButton extends LitElement {
   @property({ reflect: true })
   label?: string;
 
-  @property({ type: Boolean })
   // A button is considered active when it's interacted with via keyboard or hovered.
+  // Private because it's only meant to be used by Menu.
+  @property({ type: Boolean })
   privateActive = false;
 
   override connectedCallback() {

--- a/src/menu.link.ts
+++ b/src/menu.link.ts
@@ -30,8 +30,9 @@ export default class GlideCoreMenuLink extends LitElement {
   @property({ reflect: true })
   url?: string;
 
-  @property({ type: Boolean })
   // A link is considered active when it's interacted with via keyboard or hovered.
+  // Private because it's only meant to be used by Menu.
+  @property({ type: Boolean })
   privateActive = false;
 
   override click() {

--- a/src/radio-group.ts
+++ b/src/radio-group.ts
@@ -54,6 +54,7 @@ export default class GlideCoreRadioGroup extends LitElement {
   @property({ reflect: true })
   name = '';
 
+  // Private because it's only meant to be used by Form Controls Layout.
   @property()
   privateSplit?: 'left' | 'middle';
 

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -34,7 +34,7 @@ export default class GlideCoreTag extends LitElement {
   @property({ reflect: true })
   label?: string;
 
-  // Private because it's only used by Dropdown.
+  // Private because it's only meant to be used by Dropdown.
   @property({ attribute: 'private-editable', reflect: true, type: Boolean })
   privateEditable = false;
 

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -36,7 +36,7 @@ export default class GlideCoreTextarea extends LitElement {
 
   static override styles = styles;
 
-  // `value` is intentionally not reflected here to match native
+  // Intentionally not reflected to match native.
   @property()
   value = '';
 
@@ -92,6 +92,7 @@ export default class GlideCoreTextarea extends LitElement {
   @property({ reflect: true })
   autocomplete: 'on' | 'off' = 'on';
 
+  // Private because it's only meant to be used by Form Controls Layout.
   @property()
   privateSplit?: 'left' | 'middle';
 

--- a/src/toggle.ts
+++ b/src/toggle.ts
@@ -45,6 +45,7 @@ export default class GlideCoreToggle extends LitElement {
   @property({ reflect: true })
   name?: string;
 
+  // Private because it's only meant to be used by Form Controls Layout.
   @property()
   privateSplit?: 'left' | 'middle';
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

- Drawer now respects the system setting for reduced motion when opening and closing.
- Checkbox Group and Dropdown's `value` attribute is now editable in Storybook.
- Storybook's "Default" column no longer wraps.
- Added "Avoid custom events" to CONTRIBUTING.md.
- Renamed Checkbox's `isReportValidityOrSubmit` to `privateIsReportValidityOrSubmit`.
- Various other small changes.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Enable the reduced motion system setting.
2. Navigate to Drawer in Storybook.
3. Open and close Drawer.
4. Verify the animations didn't play.

## 📸 Images/Videos of Functionality

N/A