### PR TITLE
Tab Panel `isSelected` renamed to `privateIsSelected`

### DIFF
--- a/.changeset/plenty-bats-shop.md
+++ b/.changeset/plenty-bats-shop.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Tab Panel's `isSelected` property has been renamed to `privateIsSelected` to deter external use.

--- a/src/tab.group.test.interactions.ts
+++ b/src/tab.group.test.interactions.ts
@@ -536,15 +536,15 @@ it('has only one tab panel that is selected and tabbable when a tab is clicked',
   const [, secondTab] = component.tabElements;
   const [firstPanel, secondPanel] = component.panelElements;
 
-  expect(firstPanel.isSelected).to.be.true;
-  expect(secondPanel.isSelected).to.be.false;
+  expect(firstPanel.privateIsSelected).to.be.true;
+  expect(secondPanel.privateIsSelected).to.be.false;
   expect(firstPanel.tabIndex).to.equal(0);
   expect(secondPanel.tabIndex).to.equal(-1);
 
   secondTab.click();
 
-  expect(firstPanel.isSelected).to.be.false;
-  expect(secondPanel.isSelected).to.be.true;
+  expect(firstPanel.privateIsSelected).to.be.false;
+  expect(secondPanel.privateIsSelected).to.be.true;
   expect(firstPanel.tabIndex).to.equal(-1);
   expect(secondPanel.tabIndex).to.equal(0);
 });
@@ -563,8 +563,8 @@ it('has only one tab panel that is selected and tabbable when using the keyboard
   const [firstTab] = component.tabElements;
   const [firstPanel, secondPanel] = component.panelElements;
 
-  expect(firstPanel.isSelected).to.be.true;
-  expect(secondPanel.isSelected).to.be.false;
+  expect(firstPanel.privateIsSelected).to.be.true;
+  expect(secondPanel.privateIsSelected).to.be.false;
   expect(firstPanel.tabIndex).to.equal(0);
   expect(secondPanel.tabIndex).to.equal(-1);
 
@@ -573,8 +573,8 @@ it('has only one tab panel that is selected and tabbable when using the keyboard
   await sendKeys({ press: 'ArrowRight' });
   await sendKeys({ press: 'Enter' });
 
-  expect(firstPanel.isSelected).to.be.false;
-  expect(secondPanel.isSelected).to.be.true;
+  expect(firstPanel.privateIsSelected).to.be.false;
+  expect(secondPanel.privateIsSelected).to.be.true;
   expect(firstPanel.tabIndex).to.equal(-1);
   expect(secondPanel.tabIndex).to.equal(0);
 });

--- a/src/tab.group.ts
+++ b/src/tab.group.ts
@@ -413,7 +413,7 @@ export default class GlideCoreTabGroup extends LitElement {
       const selectedTabPanelName = this.selectedTab?.getAttribute('panel');
       const thisPanelName = panel.getAttribute('name');
 
-      panel.isSelected = thisPanelName === selectedTabPanelName;
+      panel.privateIsSelected = thisPanelName === selectedTabPanelName;
       panel.tabIndex = thisPanelName === selectedTabPanelName ? 0 : -1;
     }
 

--- a/src/tab.panel.ts
+++ b/src/tab.panel.ts
@@ -30,7 +30,8 @@ export default class GlideCoreTabPanel extends LitElement {
    */
   @property({ reflect: true }) name = '';
 
-  @property({ type: Boolean }) isSelected = true;
+  // Private because it's only meant to be used by Tab Group.
+  @property({ type: Boolean }) privateIsSelected = true;
 
   protected override firstUpdated() {
     this.setAttribute('role', 'tabpanel');
@@ -42,8 +43,8 @@ export default class GlideCoreTabPanel extends LitElement {
     return html`<div
       class=${classMap({
         component: true,
-        hidden: !this.isSelected,
-        selected: this.isSelected,
+        hidden: !this.privateIsSelected,
+        selected: this.privateIsSelected,
       })}
       data-test="tab-panel"
     >
@@ -54,8 +55,11 @@ export default class GlideCoreTabPanel extends LitElement {
   protected override updated(changes: PropertyValues) {
     super.updated(changes);
 
-    if (changes.has('isSelected')) {
-      this.setAttribute('aria-hidden', this.isSelected ? 'false' : 'true');
+    if (changes.has('privateIsSelected')) {
+      this.setAttribute(
+        'aria-hidden',
+        this.privateIsSelected ? 'false' : 'true',
+      );
     }
   }
 


### PR DESCRIPTION
## 🚀 Description

Tab Panel's `isSelected` property has been renamed to `privateIsSelected` to deter external use.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

- Go to [Tabs](https://glide-core.crowdstrike-ux.workers.dev/tab-private-prop?path=/docs/tab-group--overview)
- Verify they're operating normally

## 📸 Images/Videos of Functionality

N/A
