### PR TITLE
Remove speculative Button attributes

### DIFF
--- a/.changeset/quick-cups-live.md
+++ b/.changeset/quick-cups-live.md
@@ -1,0 +1,11 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Button no longer supports `aria-controls`, `aria-expanded`, `aria-haspopup`, `formaction`, `formenctype`, `formmethod`, `formnovalidate`, `formtarget`, `popovertarget`, and `popovertargetaction`.
+We added these attributes to match native.
+But we suspect they won't be used.
+And they visually complicate Storybook's controls table.
+
+Let us know if you have a use case for one.
+We're happy to add them back as needed.

--- a/src/button.stories.ts
+++ b/src/button.stories.ts
@@ -22,10 +22,6 @@ const meta: Meta = {
     /* eslint-disable @typescript-eslint/no-unsafe-argument, unicorn/explicit-length-check */
     return html`
       <glide-core-button
-        formaction=${arguments_.formaction || nothing}
-        formenctype=${arguments_.formenctype || nothing}
-        formmethod=${arguments_.formmethod || nothing}
-        formtarget=${arguments_.formtarget || nothing}
         label=${arguments_.label || nothing}
         name=${arguments_.name || nothing}
         size=${arguments_.size || nothing}
@@ -33,7 +29,6 @@ const meta: Meta = {
         value=${arguments_.value || nothing}
         variant=${arguments_.variant || nothing}
         ?disabled=${arguments_.disabled || nothing}
-        ?formnovalidate=${arguments_.formnovalidate}
       >
         ${unsafeHTML(arguments_['slot="default"'])}
       </glide-core-button>
@@ -42,12 +37,6 @@ const meta: Meta = {
   args: {
     label: 'Label',
     disabled: false,
-    form: '',
-    formaction: '',
-    formenctype: 'application/x-www-form-urlencoded',
-    formmethod: 'get',
-    formnovalidate: false,
-    formtarget: '_self',
     name: '',
     size: 'large',
     'slot="prefix-icon"': '',
@@ -67,71 +56,6 @@ const meta: Meta = {
       table: {
         defaultValue: {
           summary: 'false',
-        },
-      },
-    },
-    form: {
-      control: false,
-      table: {
-        defaultValue: {
-          summary: 'null',
-        },
-        type: { summary: 'readonly HTMLFormElement | readonly null' },
-      },
-    },
-    formaction: {
-      table: {
-        defaultValue: {
-          summary: '""',
-        },
-      },
-    },
-    formenctype: {
-      control: { type: 'select' },
-      options: [
-        '',
-        'application/x-www-form-urlencoded',
-        'multipart/form-data',
-        'text/plain',
-      ],
-      table: {
-        defaultValue: {
-          summary: '"application/x-www-form-urlencoded"',
-        },
-        type: {
-          summary:
-            '"application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain"',
-        },
-      },
-    },
-    formmethod: {
-      control: { type: 'select' },
-      options: ['', 'get', 'dialog', 'post'],
-      table: {
-        defaultValue: {
-          summary: '"get"',
-        },
-        type: {
-          summary: '"dialog" | "get" | "post"',
-        },
-      },
-    },
-    formnovalidate: {
-      table: {
-        defaultValue: {
-          summary: 'false',
-        },
-      },
-    },
-    formtarget: {
-      control: { type: 'select' },
-      options: ['', '_blank', '_parent', '_self', '_top'],
-      table: {
-        defaultValue: {
-          summary: '"_self"',
-        },
-        type: {
-          summary: '"_blank" | "_parent" | "_self" | "_top"',
         },
       },
     },
@@ -205,10 +129,6 @@ export const WithIcons: StoryObj = {
   render(arguments_) {
     return html`
       <glide-core-button
-        formaction=${arguments_.formaction || nothing}
-        formenctype=${arguments_.formenctype || nothing}
-        formmethod=${arguments_.formmethod || nothing}
-        formtarget=${arguments_.formtarget || nothing}
         label=${arguments_.label || nothing}
         name=${arguments_.name || nothing}
         size=${arguments_.size || nothing}
@@ -216,7 +136,6 @@ export const WithIcons: StoryObj = {
         value=${arguments_.value || nothing}
         variant=${arguments_.variant || nothing}
         ?disabled=${arguments_.disabled}
-        ?formnovalidate=${arguments_.formnovalidate}
       >
         ${arguments_['slot="default"']}
 

--- a/src/button.test.basics.ts
+++ b/src/button.test.basics.ts
@@ -25,41 +25,17 @@ it('has defaults', async () => {
     <glide-core-button label="Label"></glide-core-button>
   `);
 
-  expect(component.ariaControls).to.be.null;
-  expect(component.ariaExpanded).to.be.null;
-  expect(component.ariaHasPopup).to.be.null;
-  expect(component.autofocus).to.be.false;
   expect(component.disabled).to.be.false;
-  expect(component.formAction).to.be.empty.string;
-  expect(component.formEncType).to.be.empty.string;
-  expect(component.formMethod).to.be.empty.string;
-  expect(component.formNoValidate).to.be.false;
   expect(component.name).to.be.empty.string;
-  expect(component.popoverTarget).to.be.undefined;
-  expect(component.popoverTargetAction).to.be.empty.string;
   expect(component.value).to.be.empty.string;
   expect(component.type).to.equal('button');
 
-  expect(component.hasAttribute('autofocus')).to.be.false;
-  expect(component.getAttribute('aria-controls')).to.be.null;
-  expect(component.getAttribute('aria-expanded')).to.be.null;
-  expect(component.getAttribute('aria-haspopup')).to.be.null;
   expect(component.hasAttribute('disabled')).to.be.false;
-  expect(component.getAttribute('formaction')).to.be.empty.string;
-  expect(component.getAttribute('formenctype')).to.be.empty.string;
-  expect(component.getAttribute('formmethod')).to.be.empty.string;
-  expect(component.hasAttribute('formnovalidate')).to.be.false;
   expect(component.getAttribute('name')).to.be.empty.string;
-  expect(component.getAttribute('popovertarget')).to.be.null;
-  expect(component.getAttribute('popovertargetaction')).to.be.empty.string;
   expect(component.getAttribute('type')).to.equal('button');
   expect(component.getAttribute('value')).to.be.empty.string;
 
   const button = component.shadowRoot?.querySelector('button');
-
-  expect(button?.getAttribute('aria-controls')).to.be.null;
-  expect(button?.ariaExpanded).to.be.null;
-  expect(button?.ariaHasPopup).to.be.null;
   expect(button?.disabled).to.be.false;
 });
 

--- a/src/button.ts
+++ b/src/button.ts
@@ -2,7 +2,6 @@ import { LitElement, html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './button.styles.js';
 
 declare global {
@@ -28,60 +27,11 @@ export default class GlideCoreButton extends LitElement {
 
   static override styles = styles;
 
-  @property({ attribute: 'aria-controls', reflect: true })
-  ariaControls: string | null = null;
-
-  @property({ attribute: 'aria-expanded', reflect: true })
-  override ariaExpanded: 'true' | 'false' | null = null;
-
-  @property({ attribute: 'aria-haspopup', reflect: true })
-  override ariaHasPopup:
-    | 'true'
-    | 'false'
-    | 'menu'
-    | 'listbox'
-    | 'tree'
-    | 'grid'
-    | 'dialog'
-    | null = null;
-
-  @property({ type: Boolean, reflect: true }) override autofocus = false;
-
   @property({ type: Boolean, reflect: true }) disabled = false;
-
-  @property({ attribute: 'formaction', reflect: true }) formAction = '';
-
-  @property({ attribute: 'formenctype', reflect: true }) formEncType:
-    | ''
-    | 'application/x-www-form-urlencoded'
-    | 'multipart/form-data'
-    | 'text/plain' = '';
-
-  @property({ attribute: 'formmethod', reflect: true }) formMethod:
-    | ''
-    | 'dialog'
-    | 'get'
-    | 'post' = '';
-
-  @property({ attribute: 'formnovalidate', type: Boolean, reflect: true })
-  formNoValidate = false;
-
-  @property({ attribute: 'formtarget', reflect: true }) formTarget:
-    | ''
-    | '_blank'
-    | '_parent'
-    | '_self'
-    | '_top' = '';
 
   @property({ reflect: true }) label?: string;
 
   @property({ reflect: true }) name = '';
-
-  @property({ attribute: 'popovertarget', reflect: true })
-  popoverTarget?: string;
-
-  @property({ attribute: 'popovertargetaction', reflect: true })
-  popoverTargetAction: '' | 'hide' | 'show' | 'toggle' = '';
 
   @property({ reflect: true })
   size: 'large' | 'small' = 'large';
@@ -103,10 +53,6 @@ export default class GlideCoreButton extends LitElement {
 
   override render() {
     return html`<button
-      aria-controls=${ifDefined(this.ariaControls ?? undefined)}
-      aria-expanded=${ifDefined(this.ariaExpanded ?? undefined)}
-      aria-haspopup=${ifDefined(this.ariaHasPopup ?? undefined)}
-      ?autofocus=${this.autofocus}
       class=${classMap({
         component: true,
         primary: this.variant === 'primary',


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

From the changeset:

> Button no longer supports `aria-controls`, `aria-expanded`, `aria-haspopup`, `formaction`, `formenctype`, `formmethod`, `formnovalidate`, `formtarget`, `popovertarget`, and `popovertargetaction`. We added these attributes to match native. But we suspect they won't be used. And they visually complicate Storybook's controls table. 
>
> Let us know if you have a use case for one. We're happy to add them back as needed.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Button in Storybook.
2. Verify all the above attributes have been removed.

## 📸 Images/Videos of Functionality

N/A