### PR TITLE
Make Form Controls Layout's code example reactive

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -109,17 +109,6 @@ export default {
                       argumentKeyWithoutSubcomponent,
                     );
                   }
-
-                  if ($subcomponent.tagName === 'GLIDE-CORE-DROPDOWN-OPTION') {
-                    $subcomponent.removeAttribute('aria-selected');
-                    $subcomponent.removeAttribute('role');
-                  }
-
-                  if ($subcomponent.tagName === 'GLIDE-CORE-RADIO') {
-                    $subcomponent.removeAttribute('aria-checked');
-                    $subcomponent.removeAttribute('aria-disabled');
-                    $subcomponent.removeAttribute('aria-label');
-                  }
                 }
               }
             } else if (
@@ -164,38 +153,99 @@ export default {
             }
           }
 
-          // https://github.com/CrowdStrike/glide-core/pull/400#discussion_r1775956358
-          if (
-            context.componentId === 'tooltip' &&
-            JSON.stringify(context.args.shortcut) !==
-              JSON.stringify(context.initialArgs.shortcut)
-          ) {
-            $component.setAttribute(
-              'shortcut',
-              JSON.stringify(context.args.shortcut),
-            );
+          if (context.componentId === 'checkbox-group') {
+            // `toString()` is used instead of `JSON.stringify()` to make the
+            // comparison slightly easier to read.
+            const isCheckboxGroupValueChanged =
+              context.args.value.toString() !==
+              context.initialArgs.value.toString();
+
+            if (isCheckboxGroupValueChanged) {
+              $component.setAttribute(
+                'value',
+                JSON.stringify(context.args.value),
+              );
+            }
           }
 
-          if (
-            context.componentId === 'dropdown' &&
-            JSON.stringify(context.args.value) !==
-              JSON.stringify(context.initialArgs.value)
-          ) {
-            $component.setAttribute(
-              'value',
-              JSON.stringify(context.args.value),
-            );
+          if (context.componentId === 'form-controls-layout') {
+            const isDropdownValueChanged =
+              context.args['<glide-core-dropdown>.value'].toString() !==
+              context.initialArgs['<glide-core-dropdown>.value'].toString();
+
+            if (isDropdownValueChanged) {
+              $component
+                .querySelector('glide-core-dropdown')
+                .setAttribute(
+                  'value',
+                  JSON.stringify(context.args['<glide-core-dropdown>.value']),
+                );
+            }
+
+            const isCheckboxGroupValueChanged =
+              context.args['<glide-core-checkbox-group>.value'].toString() !==
+              context.initialArgs[
+                '<glide-core-checkbox-group>.value'
+              ].toString();
+
+            if (isCheckboxGroupValueChanged) {
+              $component
+                .querySelector('glide-core-checkbox-group')
+                .setAttribute(
+                  'value',
+                  JSON.stringify(
+                    context.args['<glide-core-checkbox-group>.value'],
+                  ),
+                );
+            }
+
+            for (const $option of $component.querySelectorAll(
+              'glide-core-dropdown-option',
+            )) {
+              $option.removeAttribute('aria-selected');
+            }
           }
 
-          if (
-            context.componentId === 'checkbox-group' &&
-            JSON.stringify(context.args.value) !==
-              JSON.stringify(context.initialArgs.value)
-          ) {
-            $component.setAttribute(
-              'value',
-              JSON.stringify(context.args.value),
-            );
+          if (context.componentId === 'dropdown') {
+            const isDropdownValueChanged =
+              context.args.value.toString() !==
+              context.initialArgs.value.toString();
+
+            if (isDropdownValueChanged) {
+              $component.setAttribute(
+                'value',
+                JSON.stringify(context.args.value),
+              );
+            }
+
+            for (const $option of $component.querySelectorAll(
+              'glide-core-dropdown-option',
+            )) {
+              $option.removeAttribute('aria-selected');
+            }
+          }
+
+          if (context.componentId === 'radio-group') {
+            for (const $radio of $component.querySelectorAll(
+              'glide-core-radio',
+            )) {
+              $radio.removeAttribute('aria-checked');
+              $radio.removeAttribute('aria-disabled');
+              $radio.removeAttribute('aria-label');
+            }
+          }
+
+          if (context.componentId === 'tooltip') {
+            const isTooltipShortChanged =
+              context.args.shortcut?.toString() !==
+              context.initialArgs.shortcut?.toString();
+
+            if (isTooltipShortChanged) {
+              $component.setAttribute(
+                'shortcut',
+                JSON.stringify(context.args.shortcut),
+              );
+            }
           }
 
           // Clean up boolean attributes before returning: `disabled=""` → `disabled`.

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -362,6 +362,10 @@ async (query: string): Promise<GlideCoreDropdownOption[]> {
   play(context) {
     const dropdown = context.canvasElement.querySelector('glide-core-dropdown');
 
+    const option = context.canvasElement.querySelector(
+      'glide-core-dropdown-option',
+    );
+
     if (
       context.name.includes('Error') &&
       dropdown instanceof GlideCoreDropdown
@@ -408,10 +412,6 @@ async (query: string): Promise<GlideCoreDropdownOption[]> {
         attributeFilter: ['open', 'value'],
       });
     }
-
-    const option = context.canvasElement.querySelector(
-      'glide-core-dropdown-option',
-    );
 
     if (option) {
       const observer = new MutationObserver(() => {

--- a/src/form-controls-layout.stories.ts
+++ b/src/form-controls-layout.stories.ts
@@ -1,10 +1,13 @@
-import './checkbox-group.js';
-import './dropdown';
 import './form-controls-layout.js';
-import './input.js';
 import './radio-group.js';
 import './radio-group.radio.js';
-import { html } from 'lit';
+import { UPDATE_STORY_ARGS } from '@storybook/core-events';
+import { addons } from '@storybook/preview-api';
+import { html, nothing } from 'lit';
+import GlideCoreCheckboxGroup from './checkbox-group.js';
+import GlideCoreDropdown from './dropdown.js';
+import GlideCoreInput from './input.js';
+import GlideCoreTextarea from './textarea.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
 const meta: Meta = {
@@ -20,9 +23,21 @@ const meta: Meta = {
         ${story()}
       </form>`,
   ],
+  parameters: {
+    docs: {
+      story: {
+        autoplay: true,
+      },
+    },
+  },
   args: {
     'slot="default"': '',
     split: 'left',
+    '<glide-core-checkbox-group>.value': [],
+    '<glide-core-dropdown>.open': false,
+    '<glide-core-dropdown>.value': [],
+    '<glide-core-input>.value': '',
+    '<glide-core-textarea>.value': '',
   },
   argTypes: {
     'slot="default"': {
@@ -42,32 +57,177 @@ const meta: Meta = {
         type: { summary: '"left" | "middle"' },
       },
     },
+    '<glide-core-checkbox-group>.value': {
+      table: {
+        disable: true,
+      },
+    },
+    '<glide-core-dropdown>.open': {
+      table: {
+        disable: true,
+      },
+    },
+    '<glide-core-dropdown>.value': {
+      table: {
+        disable: true,
+      },
+    },
+    '<glide-core-input>.value': {
+      table: {
+        disable: true,
+      },
+    },
+    '<glide-core-textarea>.value': {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  play(context) {
+    const checkboxGroup = context.canvasElement.querySelector(
+      'glide-core-checkbox-group',
+    );
+
+    if (checkboxGroup instanceof GlideCoreCheckboxGroup) {
+      checkboxGroup.addEventListener('change', () => {
+        addons.getChannel().emit(UPDATE_STORY_ARGS, {
+          storyId: context.id,
+          updatedArgs: {
+            '<glide-core-checkbox-group>.value': checkboxGroup.value,
+          },
+        });
+      });
+    }
+
+    const dropdown = context.canvasElement.querySelector('glide-core-dropdown');
+
+    const option = context.canvasElement.querySelector(
+      'glide-core-dropdown-option',
+    );
+
+    if (dropdown instanceof GlideCoreDropdown) {
+      dropdown.addEventListener('change', () => {
+        if (option) {
+          addons.getChannel().emit(UPDATE_STORY_ARGS, {
+            storyId: context.id,
+            updatedArgs: {
+              '<glide-core-dropdown>.value': dropdown.value,
+            },
+          });
+        }
+      });
+
+      const observer = new MutationObserver(() => {
+        if (dropdown instanceof GlideCoreDropdown) {
+          addons.getChannel().emit(UPDATE_STORY_ARGS, {
+            storyId: context.id,
+            updatedArgs: {
+              '<glide-core-dropdown>.open': dropdown.open,
+            },
+          });
+        }
+      });
+
+      observer.observe(dropdown, {
+        attributes: true,
+        attributeFilter: ['open'],
+      });
+    }
+
+    const input = context.canvasElement.querySelector('glide-core-input');
+
+    if (input instanceof GlideCoreInput) {
+      input.addEventListener('input', () => {
+        addons.getChannel().emit(UPDATE_STORY_ARGS, {
+          storyId: context.id,
+          updatedArgs: {
+            '<glide-core-input>.value': input.value,
+          },
+        });
+      });
+    }
+
+    const textarea = context.canvasElement.querySelector('glide-core-textarea');
+
+    if (textarea instanceof GlideCoreTextarea) {
+      textarea.addEventListener('input', () => {
+        addons.getChannel().emit(UPDATE_STORY_ARGS, {
+          storyId: context.id,
+          updatedArgs: {
+            '<glide-core-textarea>.value': textarea.value,
+          },
+        });
+      });
+    }
   },
   render(arguments_) {
+    /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
     return html`
       <glide-core-form-controls-layout split=${arguments_.split}>
         <glide-core-checkbox-group label="Label">
-          <glide-core-checkbox label="One"></glide-core-checkbox>
-          <glide-core-checkbox label="Two"></glide-core-checkbox>
-          <glide-core-checkbox label="Three"></glide-core-checkbox>
+          <glide-core-checkbox
+            label="One"
+            value="one"
+            ?checked=${arguments_['<glide-core-checkbox-group>.value'].includes(
+              'one',
+            )}
+          ></glide-core-checkbox>
+          <glide-core-checkbox
+            label="Two"
+            value="two"
+            ?checked=${arguments_['<glide-core-checkbox-group>.value'].includes(
+              'two',
+            )}
+          ></glide-core-checkbox>
+          <glide-core-checkbox
+            label="Three"
+            value="three"
+            ?checked=${arguments_['<glide-core-checkbox-group>.value'].includes(
+              'three',
+            )}
+          ></glide-core-checkbox>
         </glide-core-checkbox-group>
 
-        <glide-core-dropdown label="Label" placeholder="Placeholder">
-          <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-          <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+        <glide-core-dropdown
+          label="Label"
+          placeholder="Placeholder"
+          ?open=${arguments_['<glide-core-dropdown>.open']}
+        >
+          <glide-core-dropdown-option
+            label="One"
+            value="one"
+            ?selected=${arguments_['<glide-core-dropdown>.value'].includes(
+              'one',
+            )}
+          ></glide-core-dropdown-option>
+
+          <glide-core-dropdown-option
+            label="Two"
+            value="two"
+            ?selected=${arguments_['<glide-core-dropdown>.value'].includes(
+              'two',
+            )}
+          ></glide-core-dropdown-option>
+
           <glide-core-dropdown-option
             label="Three"
+            value="three"
+            ?selected=${arguments_['<glide-core-dropdown>.value'].includes(
+              'three',
+            )}
           ></glide-core-dropdown-option>
         </glide-core-dropdown>
 
         <glide-core-input
           label="Label"
           placeholder="Placeholder"
+          value=${arguments_['<glide-core-input>.value'] || nothing}
         ></glide-core-input>
 
         <glide-core-textarea
           label="Label"
           placeholder="Placeholder"
+          value=${arguments_['<glide-core-textarea>.value'] || nothing}
         ></glide-core-textarea>
       </glide-core-form-controls-layout>
     `;

--- a/src/split-button.stories.ts
+++ b/src/split-button.stories.ts
@@ -5,7 +5,7 @@ import './split-button.js';
 import './split-button.primary-button.js';
 import './split-button.primary-link.js';
 import './split-button.secondary-button.js';
-import { STORY_ARGS_UPDATED } from '@storybook/core-events';
+import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
 import type { Meta, StoryObj } from '@storybook/web-components';
@@ -36,23 +36,14 @@ const meta: Meta = {
     },
   },
   play(context) {
-    // eslint-disable-next-line no-underscore-dangle
-    let arguments_: Meta['args'] = context.args;
-
-    addons.getChannel().addListener(STORY_ARGS_UPDATED, (event) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      arguments_ = event.args as typeof context.args;
-    });
-
-    const splitButtonContainer = context.canvasElement.querySelector(
+    const secondaryButton = context.canvasElement.querySelector(
       'glide-core-split-button-secondary-button',
     );
 
     const observer = new MutationObserver(() => {
-      addons.getChannel().emit(STORY_ARGS_UPDATED, {
+      addons.getChannel().emit(UPDATE_STORY_ARGS, {
         storyId: context.id,
-        args: {
-          ...arguments_,
+        updatedArgs: {
           ['<glide-core-split-button-secondary-button>.menu-open']:
             context.canvasElement.querySelector<GlideCoreSplitButtonSecondaryButton>(
               'glide-core-split-button-secondary-button',
@@ -61,8 +52,8 @@ const meta: Meta = {
       });
     });
 
-    if (splitButtonContainer) {
-      observer.observe(splitButtonContainer, {
+    if (secondaryButton) {
+      observer.observe(secondaryButton, {
         attributes: true,
         attributeFilter: ['menu-open'],
       });


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Form Controls Layout's story uses Checkbox Group, Dropdown, Input, and Textarea. Each of those components shows up in Form Controls Layout's code example. But the code example isn't updated when those components are interacted with. Now it is!

Split Button's code example also updates now when its menu is open and closed.


<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

Verify Form Controls Layout's code example. Also spotcheck that of  Dropdown, Radio Group, and Split Button.
<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A