### PR TITLE
Add `sendMouse` abstraction

### DIFF
--- a/src/accordion.test.interactions.ts
+++ b/src/accordion.test.interactions.ts
@@ -1,16 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 import './accordion.js';
-import { assert, expect, fixture, html, waitUntil } from '@open-wc/testing';
 import { emulateMedia } from '@web/test-runner-commands';
-import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreAccordion from './accordion.js';
+import click from './library/click.js';
 
 GlideCoreAccordion.shadowRootOptions.mode = 'open';
-
-afterEach(async () => {
-  await resetMouse();
-});
 
 it('can be opened via click', async () => {
   await emulateMedia({ reducedMotion: 'reduce' });
@@ -31,17 +28,7 @@ it('can be opened via click when animated', async () => {
     html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
   );
 
-  const summary = component.shadowRoot?.querySelector('[data-test="summary"]');
-  assert(summary);
-
-  const { height, width, x, y } = summary.getBoundingClientRect();
-
-  // `sendMouse` is used to work around some flakiness with `click()` where the
-  // animation never plays.
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(x + width / 2), Math.ceil(y + height / 2)],
-  });
+  await click(component.shadowRoot?.querySelector('[data-test="summary"]'));
 
   let animation: Animation | undefined;
   let isAnimationFinished = false;

--- a/src/dropdown.test.focus.filterable.ts
+++ b/src/dropdown.test.focus.filterable.ts
@@ -1,8 +1,9 @@
 import './dropdown.option.js';
 import { aTimeout, assert, expect, fixture, html } from '@open-wc/testing';
-import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreDropdown from './dropdown.js';
 import GlideCoreDropdownOption from './dropdown.option.js';
+import click from './library/click.js';
 
 GlideCoreDropdown.shadowRootOptions.mode = 'open';
 GlideCoreDropdownOption.shadowRootOptions.mode = 'open';
@@ -20,10 +21,6 @@ const defaultSlot = html`
   <glide-core-dropdown-option label="Ten"></glide-core-dropdown-option>
   <glide-core-dropdown-option label="Eleven"></glide-core-dropdown-option>
 `;
-
-afterEach(async () => {
-  await resetMouse();
-});
 
 it('focuses the input when `focus()` is called', async () => {
   const component = await fixture<GlideCoreDropdown>(
@@ -54,21 +51,11 @@ it('retains focus on the input when an option is selected via click', async () =
   await aTimeout(0);
 
   component.focus();
+  await click(component.querySelector('glide-core-dropdown-option'));
 
-  const option = component.querySelector('glide-core-dropdown-option');
-  assert(option);
-
-  const { x, y } = option.getBoundingClientRect();
-
-  // A simple `option.click()` won't do because we need a "mousedown" so that
-  // `#onOptionsMousedown` is covered.
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(x), Math.ceil(y)],
-  });
+  assert(component.shadowRoot?.activeElement);
 
   const input = component.shadowRoot?.querySelector('[data-test="input"]');
-  assert(component.shadowRoot?.activeElement);
   expect(component.shadowRoot?.activeElement).to.equal(input);
 });
 
@@ -104,20 +91,11 @@ it('retains focus on the the input when the primary button is clicked', async ()
 
   component.focus();
 
-  const button = component.shadowRoot?.querySelector(
-    '[data-test="primary-button"]',
+  await click(
+    component.shadowRoot?.querySelector('[data-test="primary-button"]'),
   );
 
-  assert(button);
-
-  const { x, y } = button.getBoundingClientRect();
-
-  // A simple `option.click()` won't do because we need a "mousedown" so that
-  // `#onDropdownMousedown` gets covered.
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(x), Math.ceil(y)],
-  });
+  assert(component.shadowRoot?.activeElement);
 
   const input = component.shadowRoot?.querySelector('[data-test="input"]');
   expect(component.shadowRoot?.activeElement).to.equal(input);

--- a/src/dropdown.test.interactions.multiple.ts
+++ b/src/dropdown.test.interactions.multiple.ts
@@ -11,10 +11,11 @@ import {
   oneEvent,
 } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
-import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreDropdown from './dropdown.js';
 import GlideCoreDropdownOption from './dropdown.option.js';
 import GlideCoreTag from './tag.js';
+import click from './library/click.js';
 
 @customElement('glide-core-dropdown-in-another-component')
 class GlideCoreDropdownInAnotherComponent extends LitElement {
@@ -41,10 +42,6 @@ GlideCoreDropdown.shadowRootOptions.mode = 'open';
 GlideCoreDropdownOption.shadowRootOptions.mode = 'open';
 GlideCoreDropdownInAnotherComponent.shadowRootOptions.mode = 'open';
 GlideCoreTag.shadowRootOptions.mode = 'open';
-
-afterEach(async () => {
-  await resetMouse();
-});
 
 it('opens on click', async () => {
   const component = await fixture<GlideCoreDropdown>(
@@ -322,23 +319,11 @@ it('remains open when an option is selected via click', async () => {
   // Wait for it to open.
   await aTimeout(0);
 
-  const option = component.shadowRoot?.querySelector(
-    'glide-core-dropdown-option',
+  await click(
+    component.shadowRoot?.querySelector('glide-core-dropdown-option'),
   );
 
-  assert(option);
-
-  const { x, y } = option.getBoundingClientRect();
-
-  // Calling `click()` won't do because Dropdown relies on a "mouseup" event to
-  // decide if it should close.
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(x), Math.ceil(y)],
-  });
-
   const dropdown = component.shadowRoot?.querySelector('glide-core-dropdown');
-
   expect(dropdown?.open).to.be.true;
 });
 
@@ -1455,19 +1440,7 @@ it('closes when a tag is clicked', async () => {
     </glide-core-dropdown>`,
   );
 
-  const tag = component.shadowRoot?.querySelector('[data-test="tag"]');
-  assert(tag);
-
-  const { x, y } = tag.getBoundingClientRect();
-
-  // A simple `tag.click()` won't do because it would remove the tag. We want to
-  // click elsewhere on the tag so focus is moved to `document.body`. This ensures
-  // Dropdown's "focusout" handler doesn't cause Dropdown to close.
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(x), Math.ceil(y)],
-  });
-
+  await click(component.shadowRoot?.querySelector('[data-test="tag"]'), 'left');
   await elementUpdated(component);
 
   expect(component.open).to.be.false;

--- a/src/dropdown.test.interactions.ts
+++ b/src/dropdown.test.interactions.ts
@@ -2,23 +2,19 @@
 
 import {
   aTimeout,
-  assert,
   elementUpdated,
   expect,
   fixture,
   html,
 } from '@open-wc/testing';
-import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreDropdown from './dropdown.js';
 import GlideCoreDropdownOption from './dropdown.option.js';
+import click from './library/click.js';
 import sinon from 'sinon';
 
 GlideCoreDropdown.shadowRootOptions.mode = 'open';
 GlideCoreDropdownOption.shadowRootOptions.mode = 'open';
-
-afterEach(async () => {
-  await resetMouse();
-});
 
 it('opens when opened programmatically', async () => {
   const component = await fixture<GlideCoreDropdown>(
@@ -976,20 +972,9 @@ it('opens when something other than the primary button is clicked', async () => 
     </glide-core-dropdown>`,
   );
 
-  const internalLabel = component.shadowRoot?.querySelector(
-    '[data-test="internal-label"]',
+  await click(
+    component.shadowRoot?.querySelector('[data-test="internal-label"]'),
   );
-
-  assert(internalLabel);
-
-  const { x, y } = internalLabel.getBoundingClientRect();
-
-  // A simple `option.click()` won't do because we need a "mousedown" so that
-  // `#onDropdownMousedown` gets covered.
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(x), Math.ceil(y)],
-  });
 
   expect(component.open).to.be.true;
 });

--- a/src/library/click.ts
+++ b/src/library/click.ts
@@ -1,0 +1,35 @@
+import { assert } from '@open-wc/testing';
+import { resetMouse, sendMouse } from '@web/test-runner-commands';
+
+export default async (
+  element: Element | null | undefined,
+  position:
+    | 'top'
+    | 'right'
+    | 'bottom'
+    | 'left'
+    | 'outside'
+    | 'center' = 'center',
+) => {
+  assert(element);
+
+  const { height, width, x, y } = element.getBoundingClientRect();
+
+  await sendMouse({
+    type: 'click',
+    position:
+      position === 'top'
+        ? [Math.ceil(x + width / 2), Math.ceil(y)]
+        : position === 'right'
+          ? [Math.floor(x + width), Math.ceil(y + height / 2)]
+          : position === 'bottom'
+            ? [Math.ceil(x + width / 2), Math.floor(y + height)]
+            : position === 'left'
+              ? [Math.ceil(x), Math.ceil(y + height / 2)]
+              : position === 'outside'
+                ? [Math.floor(x - 1), Math.floor(y - 1)]
+                : [Math.ceil(x + width / 2), Math.ceil(y + height / 2)],
+  });
+
+  await resetMouse();
+};

--- a/src/menu.test.interactions.ts
+++ b/src/menu.test.interactions.ts
@@ -13,12 +13,9 @@ import {
   html,
 } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
-import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreMenu from './menu.js';
-
-afterEach(async () => {
-  await resetMouse();
-});
+import click from './library/click.js';
 
 @customElement('glide-core-nested-slot')
 class GlideCoreNestedSlot extends LitElement {
@@ -197,16 +194,9 @@ it('remains open when the menu edge is clicked', async () => {
   await aTimeout(0);
 
   const target = component.querySelector('button');
-  const defaultSlot = component.querySelector('glide-core-menu-link');
+  const defaultSlot = component.shadowRoot?.querySelector('slot:not([name])');
 
-  assert(defaultSlot);
-
-  const { x, y } = defaultSlot.getBoundingClientRect();
-
-  await sendMouse({
-    type: 'click',
-    position: [Math.floor(x - 1), Math.ceil(y)],
-  });
+  await click(component.shadowRoot?.querySelector('slot:not([name])'), 'left');
 
   expect(component.open).to.be.true;
   expect(defaultSlot?.checkVisibility()).to.be.true;
@@ -259,24 +249,7 @@ it('remains open when a disabled link is clicked via `sendMouse()`', async () =>
   // Wait for Floating UI.
   await aTimeout(0);
 
-  const link = component.querySelector('glide-core-menu-link');
-  assert(link);
-
-  const { x, y, width } = link.getBoundingClientRect();
-
-  // `sendMouse()` because we need coverage for Menu Link's `#onClick` method.
-  // Calling `link.click()` would produce a "click" event and result in the
-  // `#onClick` method being called if not for the `!this.disabled` condition
-  // in that handler. There's a comment in the handler that explains why the
-  // condition is needed.
-  //
-  // It's not clear why `Math.ceil(x)` doesn't click Menu Link. I verified using
-  // DevTools that the value of `x` is correct. Could be something I'm missing.
-  // Could also be another test runner bug.
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(x + width / 2), Math.ceil(y)],
-  });
+  await click(component.querySelector('glide-core-menu-link'));
 
   const defaultSlot =
     component?.shadowRoot?.querySelector<HTMLSlotElement>('slot:not([name])');
@@ -704,16 +677,6 @@ it('closes when its target clicked', async () => {
   await aTimeout(0);
 
   const target = component.shadowRoot?.querySelector('button');
-  assert(target);
-
-  const { x, y } = target.getBoundingClientRect();
-
-  // Calling `click()` won't do because Menu relies on a "mouseup" event to
-  // decide if it should close.
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(x), Math.ceil(y)],
-  });
 
   const menu = component.shadowRoot?.querySelector('glide-core-menu');
 
@@ -721,6 +684,8 @@ it('closes when its target clicked', async () => {
     menu?.shadowRoot?.querySelector<HTMLSlotElement>('slot:not([name])');
 
   const options = menu?.querySelector('glide-core-menu-options');
+
+  await click(target);
 
   expect(menu?.open).to.be.false;
   expect(defaultSlot?.checkVisibility()).to.be.false;

--- a/src/modal.test.events.ts
+++ b/src/modal.test.events.ts
@@ -2,15 +2,12 @@
 
 import './modal.js';
 import { expect, fixture, html } from '@open-wc/testing';
-import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreModal from './modal.js';
+import click from './library/click.js';
 import sinon from 'sinon';
 
 GlideCoreModal.shadowRootOptions.mode = 'open';
-
-afterEach(async () => {
-  await resetMouse();
-});
 
 it('dispatches a "close" event when the modal is closed via the "close" method', async () => {
   const spy = sinon.spy();
@@ -118,17 +115,8 @@ it('does not emit a "close" event when clicking inside the dialog and the mouse 
 
   component.showModal();
   component.addEventListener('close', spy);
-  const dialogElement = component?.shadowRoot?.querySelector('dialog');
-  const boundingRectangle = dialogElement?.getBoundingClientRect();
 
-  expect(boundingRectangle).is.not.null;
-
-  const { top, left } = boundingRectangle!;
-
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(left + 1), Math.ceil(top + 1)],
-  });
+  await click(component?.shadowRoot?.querySelector('dialog'), 'left');
 
   expect(spy.callCount).to.equal(0);
 });
@@ -166,17 +154,8 @@ it('emits a "close" event when clicking outside the dialog', async () => {
 
   component.showModal();
   component.addEventListener('close', spy);
-  const dialogElement = component?.shadowRoot?.querySelector('dialog');
-  const boundingRectangle = dialogElement?.getBoundingClientRect();
 
-  expect(boundingRectangle).is.not.null;
-
-  const { top, left } = boundingRectangle!;
-
-  await sendMouse({
-    type: 'click',
-    position: [Math.floor(left - 1), Math.floor(top - 1)],
-  });
+  await click(component?.shadowRoot?.querySelector('dialog'), 'outside');
 
   expect(spy.callCount).to.equal(1);
 });

--- a/src/modal.test.lock-scroll.ts
+++ b/src/modal.test.lock-scroll.ts
@@ -2,8 +2,9 @@
 
 import * as sinon from 'sinon';
 import { expect, fixture, html } from '@open-wc/testing';
-import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreModal from './modal.js';
+import click from './library/click.js';
 
 GlideCoreModal.shadowRootOptions.mode = 'open';
 
@@ -11,7 +12,6 @@ const addSpy = sinon.spy(document.documentElement.classList, 'add');
 const removeSpy = sinon.spy(document.documentElement.classList, 'remove');
 
 afterEach(async () => {
-  await resetMouse();
   addSpy.resetHistory();
   removeSpy.resetHistory();
 });
@@ -101,10 +101,6 @@ it('removes class "private-glide-core-modal-lock-scroll" from document when clic
   );
 
   component.showModal();
-  const dialogElement = component?.shadowRoot?.querySelector('dialog');
-  const boundingRectangle = dialogElement?.getBoundingClientRect();
-
-  expect(boundingRectangle).is.not.null;
 
   expect(
     document.documentElement.classList.contains(
@@ -112,12 +108,7 @@ it('removes class "private-glide-core-modal-lock-scroll" from document when clic
     ),
   ).to.be.true;
 
-  const { top, left } = boundingRectangle!;
-
-  await sendMouse({
-    type: 'click',
-    position: [Math.floor(left - 1), Math.floor(top - 1)],
-  });
+  await click(component?.shadowRoot?.querySelector('dialog'), 'outside');
 
   expect(
     document.documentElement.classList.contains(

--- a/src/popover.test.interactions.ts
+++ b/src/popover.test.interactions.ts
@@ -1,14 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 import { aTimeout, assert, expect, fixture, html } from '@open-wc/testing';
-import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import GlideCorePopover from './popover.js';
+import click from './library/click.js';
 
 GlideCorePopover.shadowRootOptions.mode = 'open';
-
-afterEach(async () => {
-  await resetMouse();
-});
 
 it('opens when opened programmatically', async () => {
   const component = await fixture<GlideCorePopover>(
@@ -122,17 +119,7 @@ it('opens on click', async () => {
     </glide-core-popover>`,
   );
 
-  const target = component.querySelector('button');
-  assert(target);
-
-  const { height, width, x, y } = target.getBoundingClientRect();
-
-  // `sendMouse` so the "mouseup" handler in `firstUpdated()` also
-  // gets coverage.
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(x + width / 2), Math.ceil(y + height / 2)],
-  });
+  await click(component.querySelector('button'));
 
   // Wait for Floating UI.
   await aTimeout(0);
@@ -201,15 +188,7 @@ it('remains open when its popover is clicked', async () => {
     '[data-test="popover"]',
   );
 
-  assert(popover);
-
-  const { height, width, x, y } = popover.getBoundingClientRect();
-
-  // `sendMouse` so the "mouseup" handler in `firstUpdated()` can do its thing.
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(x + width / 2), Math.ceil(y + height / 2)],
-  });
+  await click(popover);
 
   expect(popover?.checkVisibility()).to.be.true;
 });
@@ -229,15 +208,7 @@ it('remains open when its arrow is clicked', async () => {
     '[data-test="arrow"]',
   );
 
-  assert(arrow);
-
-  const { height, width, x, y } = arrow.getBoundingClientRect();
-
-  // `sendMouse` so the "mouseup" handler in `firstUpdated()` can do its thing.
-  await sendMouse({
-    type: 'click',
-    position: [Math.ceil(x + width / 2), Math.ceil(y + height / 2)],
-  });
+  await click(arrow);
 
   expect(arrow?.checkVisibility()).to.be.true;
 });

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -26,6 +26,13 @@ export default {
       // It's excluded so we don't have to reduce our coverage thresholds.
       'src/library/ow.ts',
 
+      // Juice not worth the squeeze. Testing this wouldn't add much given the
+      // test code would look more or less like the code that's under test.
+      // Testing whether the center of an element was clicked, for example, would
+      // require the same `Math.ceil(x + width / 2)` and `Math.ceil(y + height / 2)`
+      // calculations that are in the library itself.
+      'src/library/click.ts',
+
       // Istanbul claims it has a branch that's missing coverage even though
       // there are no branches in this file. It's excluded so we don't have
       // to reduce our coverage thresholds.


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

We started calling `click()` in our tests for simplicity, even though `sendMouse` is closer to a real click. Over time, however, we've accumulated a number of cases where calling `click()` didn't suffice.

One case is Modal, where we [need](https://github.com/CrowdStrike/glide-core/blob/f4ea044814e826b785b8bc5703dc4482baa33e82/src/modal.test.events.ts#L160-L182) to click outside Modal to verify a "close" event is dispatched. Another case is Menu, where we [need](https://github.com/CrowdStrike/glide-core/blob/f4ea044814e826b785b8bc5703dc4482baa33e82/src/menu.test.interactions.ts#L185-L209) to click the menu's padding edge to verify Menu remains open. There are [quite a few](https://github.com/search?q=repo%3ACrowdStrike%2Fglide-core%20sendmouse&type=code) other cases.

Given `click()` doesn't always suffice and `sendMouse()` is closer to a real click, it may make sense to simply use `sendMouse` across the board. But doing so would be unwieldy given every call also requires a call of `assert()`, `getBoundingClientRect()`, and `resetMouse()`. 

So I've added `./src/library/click.ts` to make `sendMouse()` simpler to use. `click.ts` has a single, default export:


```ts
export default async (
  element: Element | null | undefined,
  position:
    | 'top'
    | 'right'
    | 'bottom'
    | 'left'
    | 'outside'
    | 'center' = 'center',
) => Promise<void>
```

To start, I've replaced every call of `sendMouse()` with this abstraction. If everyone is on board, I'll follow up and replace most calls of `HTMLElement.prototype.click()` too. 

I'd suggest a lint rule against `HTMLElement.prototype.click()` in tests. But some calls will have to stick around because that method itself is under test. Dropdown, which [has logic](https://github.com/CrowdStrike/glide-core/blob/f4ea044814e826b785b8bc5703dc4482baa33e82/src/dropdown.ts#L256-L263) in its `click()` method, is one such case. Other calls will have to remain for test coverage purposes.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A
