### PR TITLE
Dispatch "selected" instead of "change" and "input" in Toggle

### DIFF
--- a/.changeset/breezy-scissors-notice.md
+++ b/.changeset/breezy-scissors-notice.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Toggle no longer dispatches "change" and "input" events to match Button Group, Tab, and Tree.

--- a/src/toggle.test.events.ts
+++ b/src/toggle.test.events.ts
@@ -3,6 +3,7 @@
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import GlideCoreToggle from './toggle.js';
 import click from './library/click.js';
+import sinon from 'sinon';
 
 GlideCoreToggle.shadowRootOptions.mode = 'open';
 
@@ -25,27 +26,27 @@ it('dispatches a "click" event when clicked', async () => {
   expect(event.composed).to.be.true;
 });
 
-it('dispatches a "change" event when clicked', async () => {
+it('dispatches a "selected" event when clicked', async () => {
   const component = await fixture<GlideCoreToggle>(
     html`<glide-core-toggle label="Label"></glide-core-toggle>`,
   );
 
   click(component.shadowRoot?.querySelector('[data-test="input"]'));
 
-  const event = await oneEvent(component, 'change');
-  expect(event instanceof Event).to.be.true;
-  expect(event.bubbles).to.be.true;
-});
-
-it('dispatches an "input" event when clicked', async () => {
-  const component = await fixture<GlideCoreToggle>(
-    html`<glide-core-toggle label="Label"></glide-core-toggle>`,
-  );
-
-  click(component.shadowRoot?.querySelector('[data-test="input"]'));
-
-  const event = await oneEvent(component, 'input');
+  const event = await oneEvent(component, 'selected');
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
   expect(event.composed).to.be.true;
+});
+
+it('does not dispatch an "input" event when clicked', async () => {
+  const component = await fixture<GlideCoreToggle>(
+    html`<glide-core-toggle label="Label"></glide-core-toggle>`,
+  );
+
+  const spy = sinon.spy();
+  component.addEventListener('input', spy);
+  await click(component.shadowRoot?.querySelector('[data-test="input"]'));
+
+  expect(spy.callCount).to.equal(0);
 });

--- a/src/toggle.test.interactions.ts
+++ b/src/toggle.test.interactions.ts
@@ -66,31 +66,12 @@ it('is still unchecked after being clicked when unchecked and disabled', async (
   expect(input?.getAttribute('aria-checked')).to.equal('false');
 });
 
-it('is unchecked after being clicked then forcibly unchecked via a "change" listener', async () => {
+it('is unchecked after being clicked then forcibly unchecked via a "selected" listener', async () => {
   const component = await fixture<GlideCoreToggle>(
     html`<glide-core-toggle label="Label"></glide-core-toggle>`,
   );
 
-  component.addEventListener('change', async () => {
-    await component.updateComplete;
-    component.checked = false;
-  });
-
-  await click(component.shadowRoot?.querySelector('[data-test="input"]'));
-
-  expect(component.hasAttribute('checked')).to.be.false;
-  expect(component.checked).to.be.false;
-
-  const input = component.shadowRoot?.querySelector('[data-test="input"]');
-  expect(input?.getAttribute('aria-checked')).to.equal('false');
-});
-
-it('is unchecked after being clicked then forcibly unchecked via an "input" listener', async () => {
-  const component = await fixture<GlideCoreToggle>(
-    html`<glide-core-toggle label="Label"></glide-core-toggle>`,
-  );
-
-  component.addEventListener('input', async () => {
+  component.addEventListener('selected', async () => {
     await component.updateComplete;
     component.checked = false;
   });

--- a/src/toggle.ts
+++ b/src/toggle.ts
@@ -106,8 +106,7 @@ export default class GlideCoreToggle extends LitElement {
             type="checkbox"
             .checked=${this.checked}
             ?disabled=${this.disabled}
-            @change=${this.#onChangeOrInput}
-            @input=${this.#onChangeOrInput}
+            @input=${this.#onInput}
             ${ref(this.#inputElementRef)}
           />
         </div>
@@ -144,15 +143,17 @@ export default class GlideCoreToggle extends LitElement {
   // If "input" events were dispatched after "change" events, only handling
   // "change" here would suffice because an update from "change" would already
   // be pending by the time "input" is dispatched.
-  #onChangeOrInput(event: Event) {
+  #onInput(event: Event) {
     if (event.target instanceof HTMLInputElement) {
       this.checked = event.target.checked;
     }
 
-    if (event.type === 'change') {
-      // Unlike "input" events, "change" events aren't composed. So we have to
-      // manually dispatch them.
-      this.dispatchEvent(new Event(event.type, event));
-    }
+    // Unlike "change", "input" is composed and so will escape the shadow DOM
+    // unless we stop it from propagating.
+    event.stopPropagation();
+
+    this.dispatchEvent(
+      new Event('selected', { bubbles: true, composed: true }),
+    );
   }
 }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

From https://github.com/CrowdStrike/glide-core/pull/562#discussion_r1900240504: 

> Toggle, because it's not a form control, should actually dispatch a single "selected" event to match Button Group, Tab, and Tree. I'll change it to "selected" in a followup PR 👍.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

The tests should have us covered. But you're welcome to add an event listener using DevTools and verify.

## 📸 Images/Videos of Functionality

N/A
