### PR TITLE
Refresh Menu and Split Button story pages on navigation

### DIFF
--- a/src/menu.stories.ts
+++ b/src/menu.stories.ts
@@ -161,6 +161,22 @@ const meta: Meta = {
         attributeFilter: ['open'],
       });
     }
+
+    menu?.addEventListener('click', (event: Event) => {
+      const isLink =
+        event.target instanceof Element &&
+        event.target.closest('glide-core-menu-link');
+
+      if (isLink && window.top) {
+        event.preventDefault();
+
+        // The Storybook user expects to navigate when the link is clicked but
+        // doesn't expect to be redirected to the first story. So we refresh the
+        // page to give the impression of a navigation while keeping the user
+        // on the same page.
+        window.top.location.reload();
+      }
+    });
   },
   render(arguments_) {
     /* eslint-disable unicorn/explicit-length-check */

--- a/src/split-button.stories.ts
+++ b/src/split-button.stories.ts
@@ -36,6 +36,24 @@ const meta: Meta = {
     },
   },
   play(context) {
+    context.canvasElement
+      .querySelector('glide-core-split-button')
+      ?.addEventListener('click', (event: Event) => {
+        const isLink =
+          event.target instanceof Element &&
+          event.target.closest('glide-core-menu-link');
+
+        if (isLink && window.top) {
+          event.preventDefault();
+
+          // The Storybook user expects to navigate when the link is clicked but
+          // doesn't expect to be redirected to the first story. So we refresh the
+          // page to give the impression of a navigation while keeping the user
+          // on the same page.
+          window.top.location.reload();
+        }
+      });
+
     const secondaryButton = context.canvasElement.querySelector(
       'glide-core-split-button-secondary-button',
     );


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Very minor. But it's been bugging me, and will probably bug some users, that clicking a Menu Link in Storybook kicks the user to the first story. This fixes that behavior by listening for a click, canceling the event, and then refreshing the page.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

1. Navigate to Menu and Split Button in Storybook.
2. Open the menu.
3. Click the Menu Link (third option).
4. Verify the page is refreshed.

## 📸 Images/Videos of Functionality

N/A