### PR TITLE
Arrowing through Tree no longer scrolls the page

### DIFF
--- a/.changeset/moody-coins-decide.md
+++ b/.changeset/moody-coins-decide.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Arrowing through Tree no longer scrolls the page.

--- a/src/tab.group.test.interactions.ts
+++ b/src/tab.group.test.interactions.ts
@@ -257,7 +257,12 @@ it('scrolls tabs when overflow buttons are clicked', async () => {
       '[data-test="overflow-end-button"]',
     );
 
-  await click(endOverflowButton);
+  // The assertions below intermittently fail with `click()`. Seems to be
+  // a bug either in Web Test Runner or Playwright related to concurrency.
+  // They consistently pass when concurrency is disabled.
+  //
+  // https://github.com/modernweb-dev/web/issues/2374
+  endOverflowButton?.click();
 
   await waitUntil(
     () =>
@@ -278,7 +283,7 @@ it('scrolls tabs when overflow buttons are clicked', async () => {
   expect(startOverflowButton).to.be.not.null;
   expect(startOverflowButton?.disabled).to.be.false;
 
-  await click(startOverflowButton);
+  startOverflowButton?.click();
 
   await waitUntil(
     () =>

--- a/src/textarea.test.basics.ts
+++ b/src/textarea.test.basics.ts
@@ -243,7 +243,7 @@ it('has tabbable textarea', async () => {
 
   expect(component).to.have.focus;
 
-  await expect(
+  expect(
     component.shadowRoot?.activeElement?.tagName.toLocaleLowerCase(),
   ).to.be.equal('textarea');
 });
@@ -278,7 +278,7 @@ it('focuses the textarea when `focus()` is called', async () => {
 
   component.focus();
 
-  await expect(
+  expect(
     component.shadowRoot?.activeElement?.tagName.toLocaleLowerCase(),
   ).to.be.equal('textarea');
 });
@@ -290,13 +290,13 @@ it('blurs the textarea when `blur` is called', async () => {
 
   component.focus();
 
-  await expect(
+  expect(
     component.shadowRoot?.activeElement?.tagName.toLocaleLowerCase(),
   ).to.be.equal('textarea');
 
   component.blur();
 
-  await expect(
+  expect(
     component.shadowRoot?.activeElement?.tagName.toLocaleLowerCase(),
   ).to.not.equal('textarea');
 });

--- a/src/textarea.test.forms.ts
+++ b/src/textarea.test.forms.ts
@@ -19,7 +19,7 @@ it('can be reset to initial value', async () => {
 
   component.focus();
   await sendKeys({ type: '-value' });
-  await expect(component.value).to.equal('testing-value');
+  expect(component.value).to.equal('testing-value');
   form.reset();
 
   expect(component.value).to.equal('testing');

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -190,6 +190,20 @@ export default class GlideCoreTree extends LitElement {
     }
 
     if (
+      [
+        'ArrowRight',
+        'ArrowLeft',
+        'ArrowDown',
+        'ArrowUp',
+        'Home',
+        'End',
+      ].includes(event.key)
+    ) {
+      // Prevent page scroll.
+      event.preventDefault();
+    }
+
+    if (
       event.target &&
       event.target instanceof HTMLElement &&
       (event.target.closest('glide-core-tree-item-icon-button') ??


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Tree in Storybook.
2. Tab into Tree.
3. Do some arrowing.
4. Verify the page hasn't scrolled.
5. Tab to the kebab and gear icons.
6. Do some arrowing.
7. Verify the page hasn't scrolled.

## 📸 Images/Videos of Functionality

N/A