### PR TITLE
Add story actions for events

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@eslint/js": "^9.17.0",
     "@open-wc/testing": "^4.0.0",
     "@rollup/plugin-commonjs": "^25.0.8",
+    "@storybook/addon-actions": "^8.4.7",
     "@storybook/addon-essentials": "^8.4.7",
     "@storybook/addon-links": "^8.4.7",
     "@storybook/blocks": "^8.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@rollup/plugin-commonjs':
         specifier: ^25.0.8
         version: 25.0.8(rollup@4.28.1)
+      '@storybook/addon-actions':
+        specifier: ^8.4.7
+        version: 8.4.7(storybook@8.4.7(prettier@3.4.2))
       '@storybook/addon-essentials':
         specifier: ^8.4.7
         version: 8.4.7(@types/react@18.3.12)(storybook@8.4.7(prettier@3.4.2))

--- a/src/accordion.stories.ts
+++ b/src/accordion.stories.ts
@@ -3,11 +3,13 @@ import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreAccordion from './accordion.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
 const meta: Meta = {
   decorators: [
+    withActions,
     (story) =>
       html`<div style="min-height: 6rem;">
         <script type="ignore">
@@ -20,6 +22,9 @@ const meta: Meta = {
   title: 'Accordion',
   tags: ['autodocs'],
   parameters: {
+    actions: {
+      handles: ['toggle'],
+    },
     docs: {
       story: {
         autoplay: true,
@@ -75,7 +80,7 @@ const meta: Meta = {
       table: {
         type: {
           summary: 'method',
-          detail: '(event: "toggle", handler: (event: Event) => void) => void',
+          detail: '(event: "toggle", handler: (event: Event) => void): void',
         },
       },
     },

--- a/src/accordion.ts
+++ b/src/accordion.ts
@@ -12,7 +12,7 @@ declare global {
 }
 
 /**
- * @event toggle - `(event: "toggle", handler: (event: Event) => void) => void`.
+ * @event toggle - `(event: "toggle", handler: (event: Event) => void): void`.
  *
  * @slot - The content of the accordion.
  * @slot prefix-icon - An optional icon before the label.

--- a/src/button-group.stories.ts
+++ b/src/button-group.stories.ts
@@ -4,6 +4,7 @@ import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
 import { when } from 'lit/directives/when.js';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreButton from './button-group.button.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
@@ -11,6 +12,7 @@ const meta: Meta = {
   title: 'Button Group',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) => html`
       <script type="ignore">
         import '@crowdstrike/glide-core/button-group.js';
@@ -21,6 +23,9 @@ const meta: Meta = {
     `,
   ],
   parameters: {
+    actions: {
+      handles: ['selected'],
+    },
     docs: {
       story: {
         autoplay: true,
@@ -190,8 +195,7 @@ const meta: Meta = {
         category: 'Button Group Button',
         type: {
           summary: 'method',
-          detail:
-            '(event: "selected", handler: (event: Event) => void) => void',
+          detail: '(event: "selected", handler: (event: Event) => void): void',
         },
       },
     },

--- a/src/checkbox-group.stories.ts
+++ b/src/checkbox-group.stories.ts
@@ -3,6 +3,7 @@ import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreCheckboxGroup from './checkbox-group.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
@@ -10,6 +11,7 @@ const meta: Meta = {
   title: 'Checkbox Group',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) =>
       html`<form action="/" style="width: max-content;">
         <script type="ignore">
@@ -21,6 +23,9 @@ const meta: Meta = {
       </form>`,
   ],
   parameters: {
+    actions: {
+      handles: ['change', 'input', 'invalid'],
+    },
     docs: {
       story: {
         autoplay: true,
@@ -66,7 +71,7 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail:
-            '(event: "change" | "input" | "invalid", handler: (event: Event) => void) => void',
+            '(event: "change" | "input" | "invalid", handler: (event: Event) => void): void',
         },
       },
     },

--- a/src/checkbox.stories.ts
+++ b/src/checkbox.stories.ts
@@ -2,6 +2,7 @@ import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreCheckbox from './checkbox.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
@@ -9,6 +10,7 @@ const meta: Meta = {
   title: 'Checkbox',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) =>
       html`<form action="/">
         <script type="ignore">
@@ -19,6 +21,9 @@ const meta: Meta = {
       </form>`,
   ],
   parameters: {
+    actions: {
+      handles: ['change', 'input', 'invalid'],
+    },
     docs: {
       story: {
         autoplay: true,
@@ -51,7 +56,7 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail:
-            '(event: "change" | "input" | "invalid", handler: (event: Event) => void) => void',
+            '(event: "change" | "input" | "invalid", handler: (event: Event) => void): void',
         },
       },
     },

--- a/src/drawer.stories.ts
+++ b/src/drawer.stories.ts
@@ -5,24 +5,30 @@ import { addons } from '@storybook/preview-api';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreDrawer from './drawer.js';
 import ow from './library/ow.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
 const meta: Meta = {
   decorators: [
-    (story) =>
-      html`<div style="height: 12.5rem;">
+    withActions,
+    (story) => html`
+      <div style="height: 12.5rem;">
         <script type="ignore">
           import '@crowdstrike/glide-core/drawer.js';
         </script>
 
         ${story()}
-      </div>`,
+      </div>
+    `,
   ],
   title: 'Drawer',
   tags: ['autodocs'],
   parameters: {
+    actions: {
+      handles: ['close'],
+    },
     docs: {
       story: {
         autoplay: true,

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -4,6 +4,7 @@ import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreDropdown from './dropdown.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
@@ -11,6 +12,7 @@ const meta: Meta = {
   title: 'Dropdown',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) => {
       return html`<form action="/" style="padding-bottom: 1.5rem;">
         <script type="ignore">
@@ -23,6 +25,9 @@ const meta: Meta = {
     },
   ],
   parameters: {
+    actions: {
+      handles: ['change', 'input', 'invalid'],
+    },
     docs: {
       story: {
         autoplay: true,
@@ -98,7 +103,7 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail:
-            '(event: "change" | "input" | "invalid", handler: (event: Event) => void) => void',
+            '(event: "change" | "input" | "invalid", handler: (event: Event) => void): void',
         },
       },
     },

--- a/src/form-controls-layout.stories.ts
+++ b/src/form-controls-layout.stories.ts
@@ -4,6 +4,7 @@ import './radio-group.radio.js';
 import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreCheckboxGroup from './checkbox-group.js';
 import GlideCoreDropdown from './dropdown.js';
 import GlideCoreInput from './input.js';
@@ -14,6 +15,7 @@ const meta: Meta = {
   title: 'Form Controls Layout',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) =>
       html`<form action="/" style="height: 16rem;">
         <script type="ignore">
@@ -24,6 +26,9 @@ const meta: Meta = {
       </form>`,
   ],
   parameters: {
+    actions: {
+      handles: ['change', 'input', 'invalid'],
+    },
     docs: {
       story: {
         autoplay: true,

--- a/src/inline-alert.stories.ts
+++ b/src/inline-alert.stories.ts
@@ -1,11 +1,13 @@
 import './inline-alert.js';
 import { html } from 'lit';
+import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
 const meta: Meta = {
   title: 'Inline Alert',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) => html`
       <div style="height: 6rem;">
         <script type="ignore">
@@ -16,6 +18,11 @@ const meta: Meta = {
       </div>
     `,
   ],
+  parameters: {
+    actions: {
+      handles: ['remove'],
+    },
+  },
   args: {
     'slot="default"': 'Content',
     'addEventListener(event, handler)': '',
@@ -34,7 +41,7 @@ const meta: Meta = {
       table: {
         type: {
           summary: 'method',
-          detail: '(event: "remove", handler: (event: Event) => void) => void',
+          detail: '(event: "remove", handler: (event: Event) => void): void',
         },
       },
     },

--- a/src/input.stories.ts
+++ b/src/input.stories.ts
@@ -4,6 +4,7 @@ import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreInput, { SUPPORTED_TYPES } from './input.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
@@ -11,6 +12,7 @@ const meta: Meta = {
   title: 'Input',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) =>
       html`<form action="/" style="height: 4rem;">
         <script type="ignore">
@@ -21,6 +23,9 @@ const meta: Meta = {
       </form>`,
   ],
   parameters: {
+    actions: {
+      handles: ['change', 'input', 'invalid'],
+    },
     docs: {
       story: {
         autoplay: true,
@@ -130,7 +135,7 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail:
-            '(event: "change" | "input" | "invalid", handler: (event: Event) => void) => void',
+            '(event: "change" | "input" | "invalid", handler: (event: Event) => void): void',
         },
       },
     },

--- a/src/menu.stories.ts
+++ b/src/menu.stories.ts
@@ -7,6 +7,7 @@ import './menu.options.js';
 import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreMenu from './menu.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
@@ -14,6 +15,7 @@ const meta: Meta = {
   title: 'Menu',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) =>
       html`<script type="ignore">
           import '@crowdstrike/glide-core/menu.js';
@@ -25,6 +27,11 @@ const meta: Meta = {
         ${story()}`,
   ],
   parameters: {
+    actions: {
+      // Menu Button and Link are selected so "click" events from Menu's target
+      // aren't picked up, muddying the Actions tab.
+      handles: ['click glide-core-menu-button', 'click glide-core-menu-link'],
+    },
     docs: {
       story: {
         autoplay: true,

--- a/src/modal.stories.ts
+++ b/src/modal.stories.ts
@@ -1,17 +1,21 @@
 import './button.js';
 import './icons/storybook.js';
 import './modal.js';
-import './modal.js';
 import './modal.tertiary-icon.js';
 import './tooltip.js';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
 const meta: Meta = {
   title: 'Modal',
   tags: ['autodocs'],
+  decorators: [withActions],
   parameters: {
+    actions: {
+      handles: ['close'],
+    },
     docs: {
       story: {
         autoplay: true,
@@ -19,14 +23,20 @@ const meta: Meta = {
     },
   },
   play(context) {
-    const button =
-      context.canvasElement.querySelector<HTMLButtonElement>(
-        'glide-core-button',
-      );
+    context.canvasElement
+      .querySelector('glide-core-button')
+      ?.addEventListener('click', () => {
+        context.canvasElement.querySelector('glide-core-modal')?.showModal();
+      });
 
-    button?.addEventListener('click', () => {
-      context.canvasElement.querySelector('glide-core-modal')?.showModal();
-    });
+    context.canvasElement
+      .querySelector('glide-core-modal')
+      ?.addEventListener('close', () => {
+        // Storybook uses event delegation on `canvasElement`. And Modal's "close"
+        // event doesn't bubble. So the event is manually dispatched. The drawback
+        // of this approach is that the event's `event.target` is incorrect.
+        context.canvasElement.dispatchEvent(new Event('close'));
+      });
   },
   render(arguments_) {
     /* eslint-disable @typescript-eslint/no-unsafe-argument */

--- a/src/radio-group.stories.ts
+++ b/src/radio-group.stories.ts
@@ -3,6 +3,7 @@ import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreRadio from './radio-group.radio.js';
 import GlideCoreRadioGroup from './radio-group.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
@@ -11,6 +12,7 @@ const meta: Meta = {
   title: 'Radio Group',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) =>
       html`<form action="/">
         <script type="ignore">
@@ -22,6 +24,9 @@ const meta: Meta = {
       </form>`,
   ],
   parameters: {
+    actions: {
+      handles: ['change', 'input', 'invalid'],
+    },
     docs: {
       story: {
         autoplay: true,

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -12,7 +12,7 @@ declare global {
 
 /**
  *
- * @event selected - `(event: "selected", handler: (event: Event) => void) => void`.
+ * @event selected - `(event: "selected", handler: (event: Event) => void): void`.
  *
  * @slot - A label.
  * @slot icon - An optional icon.

--- a/src/tabs.stories.ts
+++ b/src/tabs.stories.ts
@@ -6,6 +6,7 @@ import { addons } from '@storybook/preview-api';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreTab from './tab.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
@@ -13,6 +14,7 @@ const meta: Meta = {
   title: 'Tab Group',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) => html`
       <script type="ignore">
         import '@crowdstrike/glide-core/tab.group.js';
@@ -24,6 +26,9 @@ const meta: Meta = {
     `,
   ],
   parameters: {
+    actions: {
+      handles: ['selected'],
+    },
     docs: {
       story: {
         autoplay: true,
@@ -241,8 +246,7 @@ const meta: Meta = {
         category: 'Tab',
         type: {
           summary: 'method',
-          detail:
-            '(event: "selected", handler: (event: Event) => void) => void',
+          detail: '(event: "selected", handler: (event: Event) => void): void',
         },
       },
     },

--- a/src/tag.stories.ts
+++ b/src/tag.stories.ts
@@ -1,12 +1,14 @@
 import './icons/storybook.js';
 import './tag.js';
 import { html, nothing } from 'lit';
+import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
 const meta: Meta = {
   title: 'Tag',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) => html`
       <script type="ignore">
         import '@crowdstrike/glide-core/tag.js';
@@ -15,6 +17,11 @@ const meta: Meta = {
       ${story()}
     `,
   ],
+  parameters: {
+    actions: {
+      handles: ['remove'],
+    },
+  },
   render(arguments_) {
     return html`
       <glide-core-tag
@@ -46,7 +53,7 @@ const meta: Meta = {
       table: {
         type: {
           summary: 'method',
-          detail: '(event: "remove", handler: (event: Event) => void) => void',
+          detail: '(event: "remove", handler: (event: Event) => void): void',
         },
       },
     },

--- a/src/textarea.stories.ts
+++ b/src/textarea.stories.ts
@@ -1,6 +1,7 @@
 import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreTextarea from './textarea.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
@@ -8,6 +9,7 @@ const meta: Meta = {
   title: 'Textarea',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) =>
       html`<form action="/" style="min-height: 6rem;">
         <script type="ignore">
@@ -18,6 +20,9 @@ const meta: Meta = {
       </form>`,
   ],
   parameters: {
+    actions: {
+      handles: ['change', 'input', 'invalid'],
+    },
     docs: {
       story: {
         autoplay: true,
@@ -91,7 +96,7 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail:
-            '(event: "change" | "input" | "invalid", handler: (event: Event) => void) => void',
+            '(event: "change" | "input" | "invalid", handler: (event: Event) => void): void',
         },
       },
     },

--- a/src/toggle.stories.ts
+++ b/src/toggle.stories.ts
@@ -2,6 +2,7 @@ import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreToggle from './toggle.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
@@ -9,6 +10,7 @@ const meta: Meta = {
   title: 'Toggle',
   tags: ['autodocs'],
   decorators: [
+    withActions,
     (story) =>
       html`<script type="ignore">
           import '@crowdstrike/glide-core/toggle.js';
@@ -17,6 +19,9 @@ const meta: Meta = {
         ${story()} `,
   ],
   parameters: {
+    actions: {
+      handles: ['change', 'input'],
+    },
     docs: {
       story: {
         autoplay: true,
@@ -46,7 +51,7 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail:
-            '(event: "change" | "input", handler: (event: Event) => void) => void',
+            '(event: "change" | "input", handler: (event: Event) => void): void',
         },
       },
       type: { name: 'function' },

--- a/src/tree.stories.ts
+++ b/src/tree.stories.ts
@@ -7,11 +7,13 @@ import './tree.js';
 import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html } from 'lit';
+import { withActions } from '@storybook/addon-actions/decorator';
 import GlideCoreTreeItem from './tree.item.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 
 const meta: Meta = {
   decorators: [
+    withActions,
     (story) =>
       html`<div style="max-width: 18.75rem; height: 10rem;">
         <script type="ignore">
@@ -26,6 +28,9 @@ const meta: Meta = {
       </div>`,
   ],
   parameters: {
+    actions: {
+      handles: ['selected'],
+    },
     docs: {
       story: {
         autoplay: true,
@@ -230,8 +235,7 @@ const meta: Meta = {
         category: 'Tree Item',
         type: {
           summary: 'method',
-          detail:
-            '(event: "selected", handler: (event: Event) => void) => void',
+          detail: '(event: "selected", handler: (event: Event) => void): void',
         },
       },
     },


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Event handler _actions_ are the Storybook approved way to handle notifying users of events. They're not as obvious as a toast behind a toggle—as [we discussed](https://github.com/CrowdStrike/glide-core/pull/562#issuecomment-2568039005)—so few users will discover them. 

But we can certainly point people to the Actions tab when questions come up. And adding actions is far less work than creating a custom addon. As a bonus, we can use the Actions tab when testing PRs instead of manually adding event listeners.


<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

Spotcheck a few components. Verify the actions tab is populated with events.

## 📸 Images/Videos of Functionality

<img width="1249" alt="image" src="https://github.com/user-attachments/assets/6f683c18-2de1-421a-b25b-2ab68febb4f4" />