### PR TITLE
Remove AWS CLI installation

### DIFF
--- a/.github/workflows/on-merge-branch-changeset-release-main.yml
+++ b/.github/workflows/on-merge-branch-changeset-release-main.yml
@@ -69,10 +69,6 @@ jobs:
       - release
     steps:
       - uses: actions/download-artifact@v4
-      - name: Install AWS CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli
       - name: Configure AWS CLI
         env:
           CLOUDFLARE_R2_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}

--- a/.github/workflows/on-pull-request-closed.yml
+++ b/.github/workflows/on-pull-request-closed.yml
@@ -9,10 +9,6 @@ jobs:
     name: Remove Cloudflare Artifacts
     runs-on: ubuntu-latest
     steps:
-      - name: Install AWS CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli
       - name: Configure AWS CLI
         env:
           CLOUDFLARE_R2_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}

--- a/.github/workflows/on-pull-request-opened-and-synchronize.yml
+++ b/.github/workflows/on-pull-request-opened-and-synchronize.yml
@@ -105,10 +105,6 @@ jobs:
       - build
     steps:
       - uses: actions/download-artifact@v4
-      - name: Install AWS CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli
       - name: Configure AWS CLI
         env:
           CLOUDFLARE_R2_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}

--- a/.github/workflows/on-push-branch-main.yml
+++ b/.github/workflows/on-push-branch-main.yml
@@ -64,10 +64,6 @@ jobs:
       - build
     steps:
       - uses: actions/download-artifact@v4
-      - name: Install AWS CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli
       - name: Configure AWS CLI
         env:
           CLOUDFLARE_R2_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

GitHub upgraded `ubuntu-latest` to Ubuntu 24.04 from 22.04—causing our builds to fail.

The reason seems to be that we're installing the AWS CLI ourselves and it's already included in the 24.02 image. Though the [same](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#cli-tools) was true of 22.04. So it [may](https://github.com/CrowdStrike/glide-core/actions/runs/12653944757/job/35262911428#step:3:47) have simply been removed from 24.02's package lists.

Either way, the build is good now.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A