### PR TITLE
Compose "change" events

### DIFF
--- a/.changeset/early-waves-relate.md
+++ b/.changeset/early-waves-relate.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+"change" events are now composed for every component.
+This is unlikely a breaking change for you but may be if you're using event delegation with a "change" listener.

--- a/src/checkbox-group.test.events.ts
+++ b/src/checkbox-group.test.events.ts
@@ -32,8 +32,10 @@ it('dispatches a "change" event when clicked', async () => {
   click(component.querySelector('glide-core-checkbox'));
 
   const event = await oneEvent(component, 'change');
+
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
 });
 
 it('dispatches an "input" event when clicked', async () => {

--- a/src/checkbox.test.events.ts
+++ b/src/checkbox.test.events.ts
@@ -27,8 +27,10 @@ it('dispatches a "change" event when clicked', async () => {
   click(component.shadowRoot?.querySelector('[data-test="input"]'));
 
   const event = await oneEvent(component, 'change');
+
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
 });
 
 it('dispatches an "input" event when clicked', async () => {
@@ -39,8 +41,10 @@ it('dispatches an "input" event when clicked', async () => {
   click(component.shadowRoot?.querySelector('[data-test="input"]'));
 
   const event = await oneEvent(component, 'input');
+
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
 });
 
 it('dispatches a "private-value-change" event when its `value` is changed programmatically', async () => {

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -558,7 +558,9 @@ export default class GlideCoreCheckbox extends LitElement {
     if (event.type === 'change') {
       // Unlike "input" events, "change" events aren't composed. So we have to
       // manually dispatch them.
-      this.dispatchEvent(new Event(event.type, event));
+      this.dispatchEvent(
+        new Event(event.type, { bubbles: true, composed: true }),
+      );
     }
   }
 

--- a/src/dropdown.test.events.multiple.ts
+++ b/src/dropdown.test.events.multiple.ts
@@ -51,6 +51,7 @@ it('dispatches one "change" event when an option is selected via click', async (
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
   expect(spy.callCount).to.equal(1);
 });
 
@@ -126,6 +127,7 @@ it('dispatches one "change" event when an option is selected via Enter', async (
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
   expect(spy.callCount).to.equal(1);
 });
 
@@ -163,6 +165,7 @@ it('dispatches one "change" event when an option is selected via Space', async (
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
   expect(spy.callCount).to.equal(1);
 });
 

--- a/src/dropdown.test.events.single.ts
+++ b/src/dropdown.test.events.single.ts
@@ -40,6 +40,7 @@ it('dispatches one "change" event when an option is selected via click', async (
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
   expect(spy.callCount).to.equal(1);
 });
 
@@ -73,6 +74,7 @@ it('dispatches one "change" event when an option is selected via Enter', async (
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
   expect(spy.callCount).to.equal(1);
 });
 
@@ -105,6 +107,7 @@ it('dispatches one "change" event when an option is selected via Space', async (
   const event = await oneEvent(component, 'change');
 
   expect(event instanceof Event).to.be.true;
+  expect(event.composed).to.be.true;
   expect(event.bubbles).to.be.true;
   expect(spy.callCount).to.equal(1);
 });

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -813,8 +813,8 @@ export default class GlideCoreDropdown extends LitElement {
               id="options"
               role="listbox"
               tabindex="-1"
+              @change=${this.#onOptionsChange}
               @click=${this.#onOptionsClick}
-              @input=${this.#onOptionsInput}
               @focusin=${this.#onOptionsFocusin}
               @mousedown=${this.#onOptionsMousedown}
               @mouseover=${this.#onOptionsMouseover}
@@ -1485,7 +1485,9 @@ export default class GlideCoreDropdown extends LitElement {
             new Event('input', { bubbles: true, composed: true }),
           );
 
-          this.dispatchEvent(new Event('change', { bubbles: true }));
+          this.dispatchEvent(
+            new Event('change', { bubbles: true, composed: true }),
+          );
 
           return;
         }
@@ -1894,6 +1896,18 @@ export default class GlideCoreDropdown extends LitElement {
     }
   }
 
+  #onOptionsChange(event: Event) {
+    if (event.target instanceof GlideCoreDropdownOption) {
+      event.target.selected = !event.target.selected;
+    }
+
+    if (event.target === this.#selectAllElementRef.value) {
+      this.#selectAllOrNone();
+    }
+
+    this.#unfilter();
+  }
+
   #onOptionsClick(event: PointerEvent) {
     if (event.target instanceof Element) {
       const option = event.target.closest('glide-core-dropdown-option');
@@ -1927,7 +1941,9 @@ export default class GlideCoreDropdown extends LitElement {
           new Event('input', { bubbles: true, composed: true }),
         );
 
-        this.dispatchEvent(new Event('change', { bubbles: true }));
+        this.dispatchEvent(
+          new Event('change', { bubbles: true, composed: true }),
+        );
 
         return;
       }
@@ -1962,23 +1978,6 @@ export default class GlideCoreDropdown extends LitElement {
   }
 
   // "input" is handled instead of the usual "change" because, for historical reasons,
-  //  "change" isn't composed and so won't escape Dropdown Option's shadow DOM.
-  #onOptionsInput(event: Event) {
-    // So we don't emit duplicate events: one internally and one from the checkbox.
-    event.stopPropagation();
-
-    if (event.target instanceof GlideCoreDropdownOption) {
-      event.target.selected = !event.target.selected;
-    }
-
-    if (event.target === this.#selectAllElementRef.value) {
-      this.#selectAllOrNone();
-    }
-
-    this.#unfilter();
-    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
-    this.dispatchEvent(new Event('change', { bubbles: true }));
-  }
 
   #onOptionsLabelChange() {
     if (this.selectedOptions.length > 0) {
@@ -2242,7 +2241,7 @@ export default class GlideCoreDropdown extends LitElement {
     }
 
     this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
-    this.dispatchEvent(new Event('change', { bubbles: true }));
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
   }
 
   #selectAllOrNone() {

--- a/src/input.test.events.ts
+++ b/src/input.test.events.ts
@@ -22,6 +22,7 @@ it('dispatches a "change" event when typed in', async () => {
   const event = await oneEvent(component, 'change');
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
 });
 
 it('dispatches an "input" event when typed in', async () => {

--- a/src/input.ts
+++ b/src/input.ts
@@ -532,7 +532,9 @@ export default class GlideCoreInput extends LitElement {
 
     // Unlike "input" events, "change" events aren't composed. So we have to
     // manually dispatch them.
-    this.dispatchEvent(new Event(event.type, event));
+    this.dispatchEvent(
+      new Event(event.type, { bubbles: true, composed: true }),
+    );
   }
 
   #onInputFocus() {

--- a/src/radio-group.ts
+++ b/src/radio-group.ts
@@ -420,9 +420,8 @@ export default class GlideCoreRadioGroup extends LitElement {
     this.value = radio.value;
 
     radio.focus();
-
     radio.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
-    radio.dispatchEvent(new Event('change', { bubbles: true }));
+    radio.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
   }
 
   #onComponentClick(event: MouseEvent) {

--- a/src/textarea.test.events.ts
+++ b/src/textarea.test.events.ts
@@ -39,6 +39,7 @@ it('dispatches an `change` event when typed in', async () => {
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
 });
 
 it('dispatches an `invalid` event on submit when required and no value', async () => {

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -394,7 +394,9 @@ export default class GlideCoreTextarea extends LitElement {
 
     // Unlike "input" events, "change" events aren't composed. So we have to
     // manually dispatch them.
-    this.dispatchEvent(new Event(event.type, event));
+    this.dispatchEvent(
+      new Event(event.type, { bubbles: true, composed: true }),
+    );
   }
 
   #onTextareaInput() {

--- a/src/toggle.test.events.ts
+++ b/src/toggle.test.events.ts
@@ -29,6 +29,7 @@ it('dispatches a "change" event when clicked', async () => {
   const event = await oneEvent(component, 'change');
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
 });
 
 it('dispatches an "input" event when clicked', async () => {

--- a/src/toggle.ts
+++ b/src/toggle.ts
@@ -144,7 +144,9 @@ export default class GlideCoreToggle extends LitElement {
     if (event.type === 'change') {
       // Unlike "input" events, "change" events aren't composed. So we have to
       // manually dispatch them.
-      this.dispatchEvent(new Event(event.type, event));
+      this.dispatchEvent(
+        new Event(event.type, { bubbles: true, composed: true }),
+      );
     }
   }
 }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

From [#589](https://github.com/CrowdStrike/glide-core/pull/589#discussion_r1909471885):

> The only remaining event of ours that's not composed is "change". Native doesn't compose it for historical reasons.
> 
> But it's always felt awkward to me that we dispatch both "change" and "input" events—yet only "input" traverses shadow roots. I wonder if it's not time to compose "change" as well as a followup.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

Use the Actions tab to verify that "change" is composed for Checkbox, Checkbox Group, Dropdown, Input, Radio Group, Textarea, and Toggle.

## 📸 Images/Videos of Functionality

N/A