### PR TITLE
Update for Modal's internal Icon Button use

### DIFF
--- a/.changeset/odd-rules-hug.md
+++ b/.changeset/odd-rules-hug.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Update internal usages of Glide Core Modal Icon Buttons to pass accessibility checks.

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -147,9 +147,9 @@ export default class GlideCoreModal extends LitElement {
             this.backButton,
             () =>
               html`<glide-core-modal-icon-button
-                aria-label=${this.#localize.term('dismiss')}
                 class="back-button"
                 data-test="back-button"
+                label=${this.#localize.term('dismiss')}
                 @click=${this.#onCloseButtonClick}
                 ${ref(this.#backButtonElementRef)}
               >
@@ -167,9 +167,9 @@ export default class GlideCoreModal extends LitElement {
           ></slot>
 
           <glide-core-modal-icon-button
-            aria-label=${this.#localize.term('close')}
             class="close-button"
             data-test="close-button"
+            label=${this.#localize.term('close')}
             @click=${this.#onCloseButtonClick}
             ${ref(this.#closeButtonElementRef)}
           >


### PR DESCRIPTION
## 🚀 Description

Modal's internal Modal Icon Button was using `aria-label` rather than `label`.  This fixes that.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A
