### PR TITLE
Fix Safari SVG error

### DIFF
--- a/.changeset/metal-plums-deliver.md
+++ b/.changeset/metal-plums-deliver.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Safari no longer logs an error about an invalid attribute on a `<rect>` in Accordion, Dropdown, Split Button Secondary Button, Tab Group, or Tree Item.

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -590,7 +590,7 @@ const icons = {
       fill="none"
       class="indeterminate-icon"
     >
-      <rect x="0.5" y="0.5" width="0.8125rem" height="0.8125rem" rx="3.5" />
+      <rect x="0.5" y="0.5" width="13" height="13" rx="3.5" />
       <path
         d="M3 5C3 3.89543 3.89543 3 5 3H9.79289C10.2383 3 10.4614 3.53857 10.1464 3.85355L3.85355 10.1464C3.53857 10.4614 3 10.2383 3 9.79289V5Z"
         fill="currentColor"


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Safari doesn't like REMs on `<rect>`s.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Accordion or Dropdown in Storybook.
2. Verify no error is logged.

## 📸 Images/Videos of Functionality

<img width="698" alt="image" src="https://github.com/user-attachments/assets/4736005b-594b-457c-a4e5-75855ecfba00" />

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed. Before and after images are ideal when adjusting styling.

Use a markdown table to display changes side-by-side for easier comparison.

| Before  | After |
| ------- | ----- |
|  Image  | Image |

-->
