### PR TITLE
Always clear filterable Dropdown on close

### DIFF
--- a/.changeset/fast-bikes-dream.md
+++ b/.changeset/fast-bikes-dream.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Filterable Dropdown's input field is now cleared when Dropdown is closed.

--- a/src/dropdown.test.focus.filterable.ts
+++ b/src/dropdown.test.focus.filterable.ts
@@ -179,16 +179,21 @@ it('sets the `value` of its `<input>` to the selected option when focus is lost'
 
 it('selects the filter text on focus', async () => {
   const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown label="Label" placeholder="Placeholder">
-      ${defaultSlot}
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      filterable
+    >
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
   component.focus();
-  await sendKeys({ type: 'one' });
 
-  component.blur();
-  component.focus();
-
-  expect(window.getSelection()?.toString()).to.equal('one');
+  expect(window.getSelection()?.toString()).to.equal('One');
 });

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -15,11 +15,12 @@ import sinon from 'sinon';
 import { click, hover } from './library/mouse.js';
 import GlideCoreDropdown from './dropdown.js';
 import GlideCoreDropdownOption from './dropdown.option.js';
+import GlideCoreTag from './tag.js';
 import GlideCoreTooltip from './tooltip.js';
-import type GlideCoreTag from './tag.js';
 
 GlideCoreDropdown.shadowRootOptions.mode = 'open';
 GlideCoreDropdownOption.shadowRootOptions.mode = 'open';
+GlideCoreTag.shadowRootOptions.mode = 'open';
 GlideCoreTooltip.shadowRootOptions.mode = 'open';
 
 const defaultSlot = html`
@@ -313,6 +314,7 @@ it('hides its magnifying glass icon when multiselect and not filtering', async (
   );
 
   component.focus();
+
   await sendKeys({ type: 'o' });
   await sendKeys({ press: 'Backspace' });
 
@@ -321,6 +323,96 @@ it('hides its magnifying glass icon when multiselect and not filtering', async (
   );
 
   expect(icon?.checkVisibility()).to.be.not.ok;
+});
+
+it('clears its filter on close when single-select and no option is selected', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      filterable
+      open
+    >
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  component.focus();
+
+  await sendKeys({ type: 'o' });
+  await click(document.body);
+
+  const input = component.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(input?.value).to.equal('');
+});
+
+it('clears its filter on close when multiselect and no option is selected', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      filterable
+      multiple
+      open
+    >
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  component.focus();
+
+  await sendKeys({ type: 'o' });
+  await click(document.body);
+
+  const input = component.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(input?.value).to.equal('');
+});
+
+it('clears its filter on close when multiselect and an option is selected', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      filterable
+      multiple
+      open
+    >
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  component.focus();
+
+  await sendKeys({ type: 'o' });
+  await click(document.body);
+
+  const input = component.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(input?.value).to.equal('');
 });
 
 it('does not clear its filter when a tag is removed via Backspace', async () => {
@@ -736,16 +828,18 @@ it('does not clear its filter when a tag is removed', async () => {
   );
 
   const option = component.querySelector('glide-core-dropdown-option');
-  assert(option);
 
+  assert(option);
   option.selected = true;
 
   component.focus();
   await sendKeys({ type: 'one' });
 
-  component.shadowRoot
-    ?.querySelector<GlideCoreTag>('[data-test="tag"]')
-    ?.click();
+  await click(
+    component.shadowRoot
+      ?.querySelector('[data-test="tag"]')
+      ?.shadowRoot?.querySelector('[data-test="removal-button"]'),
+  );
 
   await elementUpdated(component);
 
@@ -1190,16 +1284,23 @@ it('sets the `value` of its `<input>` back to the label of selected option when 
 
 it('selects the filter text when `click()` is called', async () => {
   const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown label="Label" placeholder="Placeholder">
-      ${defaultSlot}
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      filterable
+    >
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  component.focus();
-  await sendKeys({ type: 'one' });
   component.click();
 
-  expect(window.getSelection()?.toString()).to.equal('one');
+  expect(window.getSelection()?.toString()).to.equal('One');
 });
 
 it('clicks the `<input>` when `click()` is called', async () => {

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -125,17 +125,24 @@ export default class GlideCoreDropdown extends LitElement {
       ) {
         this.#inputElementRef.value.value = this.selectedOptions[0].label;
         this.inputValue = this.selectedOptions[0].label;
-        this.isFiltering = false;
-        this.isNoResults = false;
+      } else if (
+        !this.multiple &&
+        this.#inputElementRef.value &&
+        this.selectedOptions.length === 0
+      ) {
+        this.#inputElementRef.value.value = '';
+        this.inputValue = '';
+      } else if (this.multiple && this.#inputElementRef.value) {
+        this.#inputElementRef.value.value = '';
+        this.inputValue = '';
+      }
 
-        this.isShowSingleSelectIcon =
-          !this.multiple &&
-          this.selectedOptions.length > 0 &&
-          Boolean(this.selectedOptions.at(0)?.value);
+      this.isFiltering = false;
+      this.isNoResults = false;
+      this.isShowSingleSelectIcon = Boolean(this.selectedOptions.at(0)?.value);
 
-        for (const option of this.#optionElements) {
-          option.hidden = false;
-        }
+      for (const option of this.#optionElements) {
+        option.hidden = false;
       }
 
       this.#hide();


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Design has asked us to clear Dropdown's input field whenever Dropdown is closed.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to [filterable Dropdown](https://glide-core.crowdstrike-ux.workers.dev/always-clear-filterable-dropdown?path=/story/dropdown--dropdown&args=filterable:!true) in Storybook.
2. Add some text to the input field.
3. Close Dropdown.
4. Verify the input field is clear.
5. Rinse and repeat for multiselect Dropdown.



## 📸 Images/Videos of Functionality

N/A