### PR TITLE
Add version field to components

### DIFF
--- a/.changeset/clever-news-sin.md
+++ b/.changeset/clever-news-sin.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Added a read-only `version` attribute to every component to help with debugging.

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,7 @@
 /** @type { import('@storybook/web-components-vite').StorybookConfig } */
 
 import { mergeConfig } from 'vite';
+import packageJson from '../package.json';
 
 const config = {
   stories: ['../src/*.stories.ts'],
@@ -18,6 +19,17 @@ const config = {
     defaultName: 'Overview',
   },
   staticDirs: ['./assets'],
+  env(config) {
+    return {
+      ...config,
+      // We can't import `package.json` directly into stories because Storybook's
+      // Babel doesn't support import attributes. So, instead, each story picks
+      // up the version from `import.meta.env.VITE_CORE_VERSION`. For security,
+      // Vite requires variables to be prefixed with "VITE" before it'll expose
+      // them to the browser.
+      VITE_CORE_VERSION: packageJson.version,
+    };
+  },
   viteFinal(config) {
     return mergeConfig(config, {
       build: {

--- a/src/accordion.stories.ts
+++ b/src/accordion.stories.ts
@@ -63,6 +63,7 @@ const meta: Meta = {
     open: false,
     'slot="prefix-icon"': '',
     'slot="suffix-icons"': '',
+    version: '',
   },
   argTypes: {
     label: {
@@ -107,6 +108,15 @@ const meta: Meta = {
         type: {
           summary: 'Element',
         },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/accordion.ts
+++ b/src/accordion.ts
@@ -2,6 +2,7 @@ import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { owSlot } from './library/ow.js';
 import chevronIcon from './icons/chevron.js';
 import styles from './accordion.styles.js';
@@ -129,6 +130,9 @@ export default class GlideCoreAccordion extends LitElement {
       }
     }
   }
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override click() {
     this.#summaryElementRef.value?.click();

--- a/src/button-group.button.ts
+++ b/src/button-group.button.ts
@@ -2,6 +2,7 @@ import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import packageJson from '../package.json' with { type: 'json' };
 import ow, { owSlot } from './library/ow.js';
 import styles from './button-group.button.styles.js';
 
@@ -52,6 +53,9 @@ export default class GlideCoreButtonGroupButton extends LitElement {
   // Private because it's only meant to be used by Button Group.
   @property()
   privateVariant?: 'icon-only';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override click() {
     this.#componentElementRef.value?.click();

--- a/src/button-group.stories.ts
+++ b/src/button-group.stories.ts
@@ -143,12 +143,14 @@ const meta: Meta = {
     'slot="default"': '',
     orientation: 'horizontal',
     variant: '',
+    version: '',
     '<glide-core-button-group-button>.label': 'One',
     '<glide-core-button-group-button>.addEventListener(event, handler)': '',
     '<glide-core-button-group-button>.disabled': false,
     '<glide-core-button-group-button>.one.selected': true,
     '<glide-core-button-group-button>[slot="icon"]': '',
     '<glide-core-button-group-button>.value': '',
+    '<glide-core-button-group-button>.version': '',
     '<glide-core-button-group-button>.two.selected': false,
     '<glide-core-button-group-button>.three.selected': false,
   },
@@ -179,6 +181,15 @@ const meta: Meta = {
       options: ['', 'icon-only'],
       table: {
         type: { summary: '"icon-only"' },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
     '<glide-core-button-group-button>.label': {
@@ -230,6 +241,17 @@ const meta: Meta = {
           detail:
             '// Set `value` when you need something other than `label` to identify the selected button',
         },
+      },
+    },
+    '<glide-core-button-group-button>.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Button Group Button',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
     '<glide-core-button-group-button>.two.selected': {

--- a/src/button-group.ts
+++ b/src/button-group.ts
@@ -2,6 +2,7 @@ import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
+import packageJson from '../package.json' with { type: 'json' };
 import GlideCoreButtonGroupButton from './button-group.button.js';
 import ow, { owSlot, owSlotType } from './library/ow.js';
 import styles from './button-group.styles.js';
@@ -54,6 +55,9 @@ export default class GlideCoreButtonGroup extends LitElement {
 
     this.#orientation = orientation;
   }
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override firstUpdated() {
     owSlot(this.#slotElementRef.value);

--- a/src/button.stories.ts
+++ b/src/button.stories.ts
@@ -52,6 +52,7 @@ const meta: Meta = {
     type: 'button',
     value: '',
     variant: 'primary',
+    version: '',
   },
   argTypes: {
     label: {
@@ -132,6 +133,15 @@ const meta: Meta = {
           summary: '"primary"',
         },
         type: { summary: '"primary" | "secondary" | "tertiary"' },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/button.ts
+++ b/src/button.ts
@@ -2,6 +2,7 @@ import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
+import packageJson from '../package.json' with { type: 'json' };
 import styles from './button.styles.js';
 
 declare global {
@@ -42,6 +43,9 @@ export default class GlideCoreButton extends LitElement {
 
   @property({ reflect: true })
   variant: 'primary' | 'secondary' | 'tertiary' = 'primary';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   get form() {
     return this.#internals.form;

--- a/src/checkbox-group.stories.ts
+++ b/src/checkbox-group.stories.ts
@@ -47,6 +47,7 @@ const meta: Meta = {
     'slot="description"': '',
     'slot="tooltip"': '',
     value: [],
+    version: '',
     '<glide-core-checkbox>.one.checked': false,
     '<glide-core-checkbox>.two.checked': false,
     '<glide-core-checkbox>.three.checked': false,
@@ -151,6 +152,15 @@ const meta: Meta = {
         type: {
           summary: 'string[]',
         },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
     '<glide-core-checkbox>.one.checked': {

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -6,6 +6,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { owSlot, owSlotType } from './library/ow.js';
 import GlideCoreCheckbox from './checkbox.js';
 import styles from './checkbox-group.styles.js';
@@ -132,6 +133,9 @@ export default class GlideCoreCheckboxGroup extends LitElement {
       }
     }
   }
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   checkValidity() {
     this.isCheckingValidity = true;

--- a/src/checkbox.stories.ts
+++ b/src/checkbox.stories.ts
@@ -48,6 +48,7 @@ const meta: Meta = {
     'slot="tooltip"': '',
     summary: '',
     value: '',
+    version: '',
   },
   argTypes: {
     'addEventListener(event, handler)': {
@@ -171,6 +172,15 @@ const meta: Meta = {
       table: {
         defaultValue: { summary: '""' },
         type: { summary: 'string' },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -8,6 +8,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import packageJson from '../package.json' with { type: 'json' };
 import checkedIcon from './icons/checked.js';
 import styles from './checkbox.styles.js';
 
@@ -143,6 +144,9 @@ export default class GlideCoreCheckbox extends LitElement {
   // Used by Checkbox Group.
   @state()
   privateIsReportValidityOrSubmit = false;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   get form() {
     return this.#internals.form;

--- a/src/drawer.stories.ts
+++ b/src/drawer.stories.ts
@@ -102,6 +102,7 @@ const meta: Meta = {
     'addEventListener(event, handler)': '',
     open: false,
     pinned: false,
+    version: '',
     '--width': '',
   },
   argTypes: {
@@ -139,6 +140,15 @@ const meta: Meta = {
       table: {
         defaultValue: { summary: 'false' },
         type: { summary: 'boolean' },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
     '--width': {

--- a/src/drawer.ts
+++ b/src/drawer.ts
@@ -3,6 +3,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { owSlot } from './library/ow.js';
 import styles from './drawer.styles.js';
 
@@ -115,6 +116,9 @@ export default class GlideCoreDrawer extends LitElement {
       });
     }
   }
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override firstUpdated() {
     owSlot(this.#defaultSlotElementRef.value);

--- a/src/dropdown.option.ts
+++ b/src/dropdown.option.ts
@@ -6,6 +6,7 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { nanoid } from 'nanoid';
 import { when } from 'lit/directives/when.js';
+import packageJson from '../package.json' with { type: 'json' };
 import checkedIcon from './icons/checked.js';
 import pencilIcon from './icons/pencil.js';
 import styles from './dropdown.option.styles.js';
@@ -148,6 +149,9 @@ export default class GlideCoreDropdownOption extends LitElement {
 
   @state()
   privateIsTooltipOpen = false;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override click() {
     if (this.privateMultiple) {

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -61,6 +61,7 @@ const meta: Meta = {
     'slot="tooltip"': '',
     value: [],
     variant: '',
+    version: '',
     '<glide-core-dropdown-option>.label': 'One',
     '<glide-core-dropdown-option>.addEventListener(event, handler)': false,
     '<glide-core-dropdown-option>.disabled': false,
@@ -72,6 +73,7 @@ const meta: Meta = {
     '<glide-core-dropdown-option>.one.value': 'one',
     '<glide-core-dropdown-option>.two.value': 'two',
     '<glide-core-dropdown-option>.three.value': 'three',
+    '<glide-core-dropdown-option>.one.version': '',
   },
   argTypes: {
     label: {
@@ -281,6 +283,15 @@ async (query: string): Promise<GlideCoreDropdownOption[]> {
         type: { summary: '"quiet"', detail: '// Unsupported with `multiple`' },
       },
     },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
     '<glide-core-dropdown-option>.label': {
       name: 'label',
       table: {
@@ -361,6 +372,17 @@ async (query: string): Promise<GlideCoreDropdownOption[]> {
     '<glide-core-dropdown-option>.three.value': {
       table: {
         disable: true,
+      },
+    },
+    '<glide-core-dropdown-option>.one.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Dropdown Option',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -12,6 +12,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
+import packageJson from '../package.json' with { type: 'json' };
 import GlideCoreDropdownOption from './dropdown.option.js';
 import { LocalizeController } from './library/localize.js';
 import GlideCoreTag from './tag.js';
@@ -251,6 +252,9 @@ export default class GlideCoreDropdown extends LitElement {
   */
   @property({ reflect: true })
   variant?: 'quiet';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   private get activeOption() {
     return this.#optionElementsIncludingSelectAll?.find(

--- a/src/form-controls-layout.stories.ts
+++ b/src/form-controls-layout.stories.ts
@@ -38,6 +38,7 @@ const meta: Meta = {
   args: {
     'slot="default"': '',
     split: 'left',
+    version: '',
     '<glide-core-checkbox-group>.value': [],
     '<glide-core-dropdown>.open': false,
     '<glide-core-dropdown>.value': [],
@@ -60,6 +61,15 @@ const meta: Meta = {
       table: {
         defaultValue: { summary: '"left"' },
         type: { summary: '"left" | "middle"' },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
     '<glide-core-checkbox-group>.value': {

--- a/src/form-controls-layout.ts
+++ b/src/form-controls-layout.ts
@@ -3,6 +3,7 @@ import './label.js';
 import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
+import packageJson from '../package.json' with { type: 'json' };
 import GlideCoreCheckbox from './checkbox.js';
 import GlideCoreCheckboxGroup from './checkbox-group.js';
 import GlideCoreDropdown from './dropdown.js';
@@ -45,6 +46,9 @@ export default class GlideCoreFormControlsLayout extends LitElement {
       }
     }
   }
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override firstUpdated() {
     owSlot(this.#slotElementRef.value);

--- a/src/icon-button.stories.ts
+++ b/src/icon-button.stories.ts
@@ -40,6 +40,7 @@ const meta: Meta = {
     'addEventListener(event, handler)': '',
     disabled: false,
     variant: 'primary',
+    version: '',
   },
   argTypes: {
     label: {
@@ -81,6 +82,15 @@ const meta: Meta = {
           summary: '"primary"',
         },
         type: { summary: '"primary" | "secondary" | "tertiary"' },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/icon-button.ts
+++ b/src/icon-button.ts
@@ -3,6 +3,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { owSlot } from './library/ow.js';
 import styles from './icon-button.styles.js';
 
@@ -49,6 +50,9 @@ export default class GlideCoreIconButton extends LitElement {
 
   @property({ reflect: true })
   variant: 'primary' | 'secondary' | 'tertiary' = 'primary';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override click() {
     this.#buttonElementRef.value?.click();

--- a/src/inline-alert.stories.ts
+++ b/src/inline-alert.stories.ts
@@ -28,6 +28,7 @@ const meta: Meta = {
     'addEventListener(event, handler)': '',
     removable: false,
     variant: 'informational',
+    version: '',
   },
   argTypes: {
     'slot="default"': {
@@ -61,6 +62,15 @@ const meta: Meta = {
         type: {
           summary: `"informational" | "medium" | "high" | "critical"`,
         },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/inline-alert.ts
+++ b/src/inline-alert.ts
@@ -5,6 +5,7 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { owSlot } from './library/ow.js';
 import { LocalizeController } from './library/localize.js';
 import styles from './inline-alert.styles.js';
@@ -35,6 +36,9 @@ export default class GlideCoreInlineAlert extends LitElement {
 
   @property({ reflect: true, type: Boolean })
   removable? = false;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override firstUpdated() {
     owSlot(this.#defaultSlotElementRef.value);

--- a/src/input.stories.ts
+++ b/src/input.stories.ts
@@ -58,6 +58,7 @@ const meta: Meta = {
     spellcheck: 'false',
     type: 'text',
     value: '',
+    version: '',
   },
   play(context) {
     const input = context.canvasElement.querySelector('glide-core-input');
@@ -319,6 +320,15 @@ const meta: Meta = {
       table: {
         defaultValue: { summary: '""' },
         type: { summary: 'string' },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/input.ts
+++ b/src/input.ts
@@ -8,6 +8,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { LocalizeController } from './library/localize.js';
 import magnifyingGlassIcon from './icons/magnifying-glass.js';
 import ow from './library/ow.js';
@@ -129,6 +130,9 @@ export default class GlideCoreInput extends LitElement {
     reflect: true,
   })
   maxlength?: number;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   get form() {
     return this.#internals.form;

--- a/src/menu.button.ts
+++ b/src/menu.button.ts
@@ -3,6 +3,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { nanoid } from 'nanoid';
+import packageJson from '../package.json' with { type: 'json' };
 import styles from './menu.button.styles.js';
 
 declare global {
@@ -43,6 +44,9 @@ export default class GlideCoreMenuButton extends LitElement {
   // Private because it's only meant to be used by Menu.
   @property({ type: Boolean })
   privateActive = false;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override click() {
     this.#componentElementRef.value?.click();

--- a/src/menu.link.ts
+++ b/src/menu.link.ts
@@ -4,6 +4,7 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { nanoid } from 'nanoid';
+import packageJson from '../package.json' with { type: 'json' };
 import styles from './menu.link.styles.js';
 
 declare global {
@@ -47,6 +48,9 @@ export default class GlideCoreMenuLink extends LitElement {
   // Private because it's only meant to be used by Menu.
   @property({ type: Boolean })
   privateActive = false;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override click() {
     // Menu sets `#isDisabledLinkClick` in its default slot's "mouseup" handler so

--- a/src/menu.options.ts
+++ b/src/menu.options.ts
@@ -3,6 +3,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { nanoid } from 'nanoid';
+import packageJson from '../package.json' with { type: 'json' };
 import { owSlot, owSlotType } from './library/ow.js';
 import GlideCoreMenuButton from './menu.button.js';
 import GlideCoreMenuLink from './menu.link.js';
@@ -34,6 +35,9 @@ export default class GlideCoreMenuOptions extends LitElement {
 
   @state()
   privateSize: 'small' | 'large' = 'large';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override connectedCallback() {
     super.connectedCallback();

--- a/src/menu.stories.ts
+++ b/src/menu.stories.ts
@@ -49,12 +49,16 @@ const meta: Meta = {
     open: false,
     placement: 'bottom-start',
     size: 'large',
+    version: '',
     '<glide-core-menu-options>[slot="default"]': '',
+    '<glide-core-menu-options>.version': '',
     '<glide-core-menu-button>.label': 'One',
     '<glide-core-menu-button>.disabled': false,
+    '<glide-core-menu-button>.version': '',
     '<glide-core-menu-link>.label': 'Three',
     '<glide-core-menu-link>.disabled': false,
     '<glide-core-menu-link>.url': '/',
+    '<glide-core-menu-link>.version': '',
   },
   argTypes: {
     'slot="default"': {
@@ -127,6 +131,15 @@ const meta: Meta = {
         type: { summary: '"small" | "large"' },
       },
     },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
     '<glide-core-menu-options>[slot="default"]': {
       name: 'slot="default"',
       control: false,
@@ -137,6 +150,17 @@ const meta: Meta = {
         },
       },
       type: { name: 'function', required: true },
+    },
+    '<glide-core-menu-options>.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Menu Options',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
     },
     '<glide-core-menu-button>.label': {
       name: 'label',
@@ -152,6 +176,17 @@ const meta: Meta = {
         category: 'Menu Button',
         defaultValue: { summary: 'false' },
         type: { summary: 'boolean' },
+      },
+    },
+    '<glide-core-menu-button>.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Menu Button',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
     '<glide-core-menu-link>.label': {
@@ -175,6 +210,17 @@ const meta: Meta = {
       table: {
         category: 'Menu Link',
         type: { summary: 'string' },
+      },
+    },
+    '<glide-core-menu-link>.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Menu Link',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -9,6 +9,7 @@ import {
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { nanoid } from 'nanoid';
+import packageJson from '../package.json' with { type: 'json' };
 import GlideCoreMenuButton from './menu.button.js';
 import GlideCoreMenuLink from './menu.link.js';
 import GlideCoreMenuOptions from './menu.options.js';
@@ -94,6 +95,9 @@ export default class GlideCoreMenu extends LitElement {
       this.#optionsElement.privateSize = size;
     }
   }
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override connectedCallback() {
     super.connectedCallback();

--- a/src/modal.icon-button.ts
+++ b/src/modal.icon-button.ts
@@ -3,6 +3,7 @@ import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { owSlot } from './library/ow.js';
 import styles from './modal.icon-button.styles.js';
 
@@ -27,6 +28,9 @@ export default class GlideCoreModalIconButton extends LitElement {
 
   @property()
   label? = '';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override firstUpdated() {
     owSlot(this.#defaultSlotElementRef.value);

--- a/src/modal.stories.ts
+++ b/src/modal.stories.ts
@@ -99,6 +99,14 @@ const meta: Meta = {
     'slot="primary"': '',
     'slot="secondary"': '',
     'slot="tertiary"': '',
+    version: '',
+    '<glide-core-modal-icon-button>.label': 'Edit',
+    '<glide-core-modal-icon-button>[slot="default"]': '',
+    '<glide-core-modal-icon-button>.version': '',
+    '<glide-core-modal-tertiary-icon>.label': 'Information',
+    '<glide-core-modal-tertiary-icon>[slot="default"]': '',
+    '<glide-core-modal-tertiary-icon>.tooltip-placement': 'bottom',
+    '<glide-core-modal-tertiary-icon>.version': '',
   },
   argTypes: {
     label: {
@@ -174,6 +182,85 @@ const meta: Meta = {
         },
       },
     },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
+    '<glide-core-modal-icon-button>.label': {
+      name: 'label',
+      table: {
+        category: 'Modal Icon Button',
+        type: { summary: 'string' },
+      },
+      type: { name: 'string', required: true },
+    },
+    '<glide-core-modal-icon-button>[slot="default"]': {
+      name: 'slot="default"',
+      control: false,
+      table: {
+        category: 'Modal Icon Button',
+        type: { summary: 'Element', detail: 'An icon' },
+      },
+      type: { name: 'string', required: true },
+    },
+    '<glide-core-modal-icon-button>.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Modal Icon Button',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
+    '<glide-core-modal-tertiary-icon>.label': {
+      name: 'label',
+      table: {
+        category: 'Modal Tertiary Icon',
+        type: { summary: 'string' },
+      },
+      type: { name: 'string', required: true },
+    },
+    '<glide-core-modal-tertiary-icon>[slot="default"]': {
+      name: 'slot="default"',
+      control: false,
+      table: {
+        category: 'Modal Tertiary Icon',
+        type: { summary: 'Element', detail: 'An icon' },
+      },
+      type: { name: 'string', required: true },
+    },
+    '<glide-core-modal-tertiary-icon>.tooltip-placement': {
+      name: 'tooltip-placement',
+      control: { type: 'radio' },
+      options: ['top', 'right', 'bottom', 'left'],
+      table: {
+        category: 'Modal Tertiary Icon',
+        defaultValue: { summary: '"bottom"' },
+        type: {
+          summary: '"top" | "right" | "bottom" | "left"',
+          detail:
+            '// The tooltip will try to move itself to the opposite of this value if not doing so would result in\n// overflow. For example, if "bottom" results in overflow the tooltip will try "top" but not "right"\n// or "left".',
+        },
+      },
+    },
+    '<glide-core-modal-tertiary-icon>.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Modal Tertiary Icon',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
   },
 };
 
@@ -205,7 +292,10 @@ export const WithHeaderActions: StoryObj = {
         ></glide-core-button>
 
         <!-- Only "glide-core-modal-icon-button" components should be used with header-actions -->
-        <glide-core-modal-icon-button slot="header-actions" label="Edit">
+        <glide-core-modal-icon-button
+          slot="header-actions"
+          label=${arguments_['<glide-core-modal-icon-button>.label']}
+        >
           <glide-core-example-icon name="edit"></glide-core-example-icon>
         </glide-core-modal-icon-button>
 
@@ -273,9 +363,11 @@ export const WithTertiaryIconAndButton: StoryObj = {
         ></glide-core-button>
 
         <glide-core-modal-tertiary-icon
-          label="Information"
+          label=${arguments_['<glide-core-modal-tertiary-icon>.label']}
           slot="tertiary"
-          tooltip-placement="right"
+          tooltip-placement=${arguments_[
+            '<glide-core-modal-tertiary-icon>.tooltip-placement'
+          ]}
         >
           <glide-core-example-icon name="info"></glide-core-example-icon>
         </glide-core-modal-tertiary-icon>

--- a/src/modal.tertiary-icon.ts
+++ b/src/modal.tertiary-icon.ts
@@ -2,6 +2,7 @@ import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import packageJson from '../package.json' with { type: 'json' };
 import GlideCoreTooltip from './tooltip.js';
 import { owSlot } from './library/ow.js';
 
@@ -26,6 +27,9 @@ export default class GlideCoreModalTertiaryIcon extends LitElement {
 
   @property({ attribute: 'tooltip-placement' })
   tooltipPlacement: 'bottom' | 'left' | 'right' | 'top' = 'bottom';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override firstUpdated() {
     owSlot(this.#defaultSlotElementRef.value);

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -4,6 +4,7 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { LocalizeController } from './library/localize.js';
 import GlideCoreModalIconButton from './modal.icon-button.js';
 import GlideCoreButton from './button.js';
@@ -78,6 +79,9 @@ export default class GlideCoreModal extends LitElement {
 
   @property({ reflect: true })
   size?: 'small' | 'medium' | 'large' | 'xlarge' = 'medium';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override connectedCallback() {
     super.connectedCallback();

--- a/src/popover.stories.ts
+++ b/src/popover.stories.ts
@@ -67,6 +67,7 @@ const meta: Meta = {
     offset: 4,
     open: false,
     placement: 'bottom',
+    version: '',
   },
   argTypes: {
     'slot="default"': {
@@ -132,6 +133,15 @@ const meta: Meta = {
           detail:
             '// The popover will try to move itself to the opposite of this value if not doing so would result in\n// overflow. For example, if "bottom" results in overflow Popover will try "top" but not "right"\n// or "left".',
         },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -13,6 +13,7 @@ import { choose } from 'lit/directives/choose.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
+import packageJson from '../package.json' with { type: 'json' };
 import ow, { owSlot } from './library/ow.js';
 import styles from './popover.styles.js';
 
@@ -101,6 +102,9 @@ export default class GlideCorePopover extends LitElement {
   */
   @property()
   placement?: 'bottom' | 'left' | 'right' | 'top';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override connectedCallback() {
     super.connectedCallback();

--- a/src/radio-group.radio.ts
+++ b/src/radio-group.radio.ts
@@ -1,6 +1,7 @@
 import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property } from 'lit/decorators.js';
+import packageJson from '../package.json' with { type: 'json' };
 import styles from './radio-group.radio.styles.js';
 
 declare global {
@@ -115,6 +116,9 @@ export default class GlideCoreRadio extends LitElement {
       }),
     );
   }
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override firstUpdated() {
     this.ariaChecked = this.checked.toString();

--- a/src/radio-group.stories.ts
+++ b/src/radio-group.stories.ts
@@ -128,10 +128,12 @@ const meta: Meta = {
     'slot="description"': '',
     'slot="tooltip"': '',
     value: 'one',
+    version: '',
     '<glide-core-radio>.label': 'One',
     '<glide-core-radio>.one.checked': true,
     '<glide-core-radio>.one.disabled': false,
     '<glide-core-radio>.value': 'one',
+    '<glide-core-radio>.version': '',
     '<glide-core-radio>.two.checked': false,
     '<glide-core-radio>.three.checked': false,
   },
@@ -229,6 +231,15 @@ const meta: Meta = {
         type: { summary: 'string' },
       },
     },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
     '<glide-core-radio>.label': {
       name: 'label',
       table: {
@@ -259,6 +270,17 @@ const meta: Meta = {
         category: 'Radio',
         defaultValue: { summary: '' },
         type: { summary: 'string' },
+      },
+    },
+    '<glide-core-radio>.version': {
+      name: 'version',
+      control: false,
+      table: {
+        category: 'Radio',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
     '<glide-core-radio>.two.checked': {

--- a/src/radio-group.ts
+++ b/src/radio-group.ts
@@ -7,6 +7,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { owSlot, owSlotType } from './library/ow.js';
 import GlideCoreRadio from './radio-group.radio.js';
 import styles from './radio-group.styles.js';
@@ -112,6 +113,9 @@ export default class GlideCoreRadioGroup extends LitElement {
       }
     }
   }
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   checkValidity() {
     this.isCheckingValidity = true;

--- a/src/split-button.primary-button.ts
+++ b/src/split-button.primary-button.ts
@@ -2,6 +2,7 @@ import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import packageJson from '../package.json' with { type: 'json' };
 import styles from './split-button.primary-button.styles.js';
 
 declare global {
@@ -51,6 +52,9 @@ export default class GlideCoreSplitButtonPrimaryButton extends LitElement {
 
   @state()
   privateVariant: 'primary' | 'secondary' = 'primary';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override render() {
     return html`<button

--- a/src/split-button.primary-link.ts
+++ b/src/split-button.primary-link.ts
@@ -2,6 +2,7 @@ import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import packageJson from '../package.json' with { type: 'json' };
 import styles from './split-button.primary-button.styles.js';
 
 declare global {
@@ -37,6 +38,9 @@ export default class GlideCoreSplitButtonPrimaryLink extends LitElement {
 
   @state()
   privateVariant: 'primary' | 'secondary' = 'primary';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override render() {
     if (this.disabled) {

--- a/src/split-button.secondary-button.ts
+++ b/src/split-button.secondary-button.ts
@@ -4,6 +4,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import packageJson from '../package.json' with { type: 'json' };
 import GlideCoreMenu from './menu.js';
 import GlideCoreMenuButton from './menu.button.js';
 import GlideCoreMenuLink from './menu.link.js';
@@ -50,6 +51,9 @@ export default class GlideCoreSplitButtonSecondaryButton extends LitElement {
 
   @state()
   privateVariant: 'primary' | 'secondary' = 'primary';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override click() {
     this.#buttonElementRef.value?.click();

--- a/src/split-button.stories.ts
+++ b/src/split-button.stories.ts
@@ -131,20 +131,24 @@ const meta: Meta = {
     'slot="secondary-button"': '',
     size: 'large',
     variant: 'primary',
+    version: '',
     '<glide-core-split-button-primary-button>.label': 'Label',
     '<glide-core-split-button-primary-button>.addEventListener(event, handler)':
       '',
     '<glide-core-split-button-primary-button>.disabled': false,
     '<glide-core-split-button-primary-button>[slot="icon"]': '',
+    '<glide-core-split-button-primary-button>.version': '',
     '<glide-core-split-button-primary-link>.label': 'Label',
     '<glide-core-split-button-primary-link>.url': '/',
     '<glide-core-split-button-primary-link>.disabled': false,
     '<glide-core-split-button-primary-link>[slot="icon"]': '',
+    '<glide-core-split-button-primary-link>.version': '',
     '<glide-core-split-button-secondary-button>.label': 'Label',
     '<glide-core-split-button-secondary-button>[slot="default"]': '',
     '<glide-core-split-button-secondary-button>.disabled': false,
     '<glide-core-split-button-secondary-button>.menu-open': false,
     '<glide-core-split-button-secondary-button>.menu-placement': 'bottom-end',
+    '<glide-core-split-button-secondary-button>.version': '',
   },
   argTypes: {
     'slot="default"': {
@@ -184,6 +188,15 @@ const meta: Meta = {
         type: { summary: '"primary" | "secondary"' },
       },
     },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
     '<glide-core-split-button-primary-button>.label': {
       name: 'label',
       type: { name: 'string', required: true },
@@ -221,6 +234,17 @@ const meta: Meta = {
         type: { summary: 'Element' },
       },
     },
+    '<glide-core-split-button-primary-button>.version': {
+      name: 'version',
+      control: false,
+      table: {
+        category: 'Split Button Primary Button',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
     '<glide-core-split-button-primary-link>.label': {
       name: 'label',
       type: { name: 'string', required: true },
@@ -251,6 +275,17 @@ const meta: Meta = {
       table: {
         category: 'Split Button Primary Link',
         type: { summary: 'Element' },
+      },
+    },
+    '<glide-core-split-button-primary-link>.version': {
+      name: 'version',
+      control: false,
+      table: {
+        category: 'Split Button Primary Link',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
     '<glide-core-split-button-secondary-button>.label': {
@@ -300,6 +335,17 @@ const meta: Meta = {
         type: {
           summary: '"bottom-end" | "top-end"',
         },
+      },
+    },
+    '<glide-core-split-button-secondary-button>.version': {
+      name: 'version',
+      control: false,
+      table: {
+        category: 'Split Button Secondary Button',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/split-button.ts
+++ b/src/split-button.ts
@@ -1,6 +1,7 @@
 import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { owSlot, owSlotType } from './library/ow.js';
 import GlideCoreSplitButtonPrimaryButton from './split-button.primary-button.js';
 import GlideCoreSplitButtonPrimaryLink from './split-button.primary-link.js';
@@ -61,6 +62,9 @@ export default class GlideCoreSplitButton extends LitElement {
       this.secondaryButtonElement.privateVariant = variant;
     }
   }
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override firstUpdated() {
     owSlot(this.#defaultSlotElementRef.value);

--- a/src/tab.group.ts
+++ b/src/tab.group.ts
@@ -2,8 +2,9 @@ import './icon-button.js';
 import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { LocalizeController } from './library/localize.js';
 import GlideCoreTab from './tab.js';
 import GlideCoreTabPanel from './tab.panel.js';
@@ -58,6 +59,9 @@ export default class GlideCoreTabGroup extends LitElement {
 
   @state()
   isShowOverflowButtons = false;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override disconnectedCallback() {
     this.#resizeObserver?.disconnect();

--- a/src/tab.panel.ts
+++ b/src/tab.panel.ts
@@ -2,6 +2,7 @@ import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property } from 'lit/decorators.js';
 import { nanoid } from 'nanoid';
+import packageJson from '../package.json' with { type: 'json' };
 import styles from './tab.panel.styles.js';
 
 declare global {
@@ -39,6 +40,9 @@ export default class GlideCoreTabPanel extends LitElement {
     this.setAttribute('aria-hidden', isSelected ? 'false' : 'true');
     this.#isSelected = isSelected;
   }
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   protected override firstUpdated() {
     this.setAttribute('role', 'tabpanel');

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -2,6 +2,7 @@ import { html, LitElement, type PropertyValues } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property } from 'lit/decorators.js';
 import { nanoid } from 'nanoid';
+import packageJson from '../package.json' with { type: 'json' };
 import styles from './tab.styles.js';
 
 declare global {
@@ -30,6 +31,9 @@ export default class GlideCoreTab extends LitElement {
   @property({ type: Boolean, reflect: true }) disabled = false;
 
   @property({ type: Boolean, reflect: true }) selected = false;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   protected override firstUpdated() {
     this.setAttribute('role', 'tab');

--- a/src/tabs.stories.ts
+++ b/src/tabs.stories.ts
@@ -38,6 +38,7 @@ const meta: Meta = {
   args: {
     'slot="default"': '',
     'slot="nav"': '',
+    version: '',
     '--panel-padding-inline-end': '',
     '--panel-padding-inline-start': '',
     '--tabs-padding-block-end': '',
@@ -59,8 +60,10 @@ const meta: Meta = {
     '<glide-core-tab>.8.selected': false,
     '<glide-core-tab>.9.selected': false,
     '<glide-core-tab>.10.selected': false,
+    '<glide-core-tab>.version': false,
     '<glide-core-tab-panel>.name': '',
     '<glide-core-tab-panel>[slot="default"]': 'Panel',
+    '<glide-core-tab-panel>.version': '',
   },
   play(context) {
     const tabs = context.canvasElement.querySelectorAll('glide-core-tab');
@@ -143,6 +146,15 @@ const meta: Meta = {
         type: { summary: 'GlideCoreTab' },
       },
       type: { name: 'function', required: true },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
     },
     '--panel-padding-inline-end': {
       table: {
@@ -284,6 +296,17 @@ const meta: Meta = {
         disable: true,
       },
     },
+    '<glide-core-tab>.version': {
+      name: 'version',
+      control: false,
+      table: {
+        category: 'Tab',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
     '<glide-core-tab-panel>.name': {
       name: 'name',
       control: false,
@@ -301,6 +324,17 @@ const meta: Meta = {
         type: { summary: 'Element | string' },
       },
       type: { name: 'function', required: true },
+    },
+    '<glide-core-tab-panel>.version': {
+      name: 'version',
+      control: false,
+      table: {
+        category: 'Tab Panel',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
     },
   },
 };

--- a/src/tag.stories.ts
+++ b/src/tag.stories.ts
@@ -41,6 +41,7 @@ const meta: Meta = {
     removable: false,
     size: 'medium',
     'slot="icon"': '',
+    version: '',
   },
   argTypes: {
     label: {
@@ -89,6 +90,15 @@ const meta: Meta = {
         type: {
           summary: 'Element',
         },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -3,6 +3,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { LocalizeController } from './library/localize.js';
 import pencilIcon from './icons/pencil.js';
 import styles from './tag.styles.js';
@@ -44,6 +45,9 @@ export default class GlideCoreTag extends LitElement {
 
   @property({ reflect: true })
   size: 'small' | 'medium' | 'large' = 'medium';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override click() {
     this.#removalButtonElementRef.value?.click();

--- a/src/textarea.stories.ts
+++ b/src/textarea.stories.ts
@@ -82,6 +82,7 @@ const meta: Meta = {
     'slot="tooltip"': '',
     spellcheck: 'false',
     value: '',
+    version: '',
   },
   argTypes: {
     label: {
@@ -241,6 +242,15 @@ const meta: Meta = {
       table: {
         defaultValue: { summary: '""' },
         type: { summary: 'string' },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -6,6 +6,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { LocalizeController } from './library/localize.js';
 import ow from './library/ow.js';
 import styles from './textarea.styles.js';
@@ -95,6 +96,9 @@ export default class GlideCoreTextarea extends LitElement {
   // Private because it's only meant to be used by Form Controls Layout.
   @property()
   privateSplit?: 'left' | 'middle';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override blur() {
     this.#textareaElementRef.value?.blur();

--- a/src/toasts.stories.ts
+++ b/src/toasts.stories.ts
@@ -16,6 +16,10 @@ const meta: Meta = {
 
         ${story()} `,
   ],
+  args: {
+    'add(toast)': '',
+    version: '',
+  },
   argTypes: {
     'add(toast)': {
       control: false,
@@ -31,6 +35,15 @@ const meta: Meta = {
   }
 ) => void`,
         },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/toasts.ts
+++ b/src/toasts.ts
@@ -1,7 +1,8 @@
 import './toasts.toast.js';
 import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { LocalizeController } from './library/localize.js';
 import ow from './library/ow.js';
 import styles from './toasts.styles.js';
@@ -27,6 +28,9 @@ export default class GlideCoreToasts extends LitElement {
   };
 
   static override styles = styles;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   /**
    * @param {number} [toast.duration=5000]

--- a/src/toggle.stories.ts
+++ b/src/toggle.stories.ts
@@ -38,6 +38,7 @@ const meta: Meta = {
     'slot="description"': '',
     'slot="tooltip"': '',
     summary: '',
+    version: '',
   },
   argTypes: {
     label: {
@@ -91,6 +92,15 @@ const meta: Meta = {
     summary: {
       table: {
         type: { summary: 'string' },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/toggle.ts
+++ b/src/toggle.ts
@@ -3,6 +3,7 @@ import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import packageJson from '../package.json' with { type: 'json' };
 import styles from './toggle.styles.js';
 
 declare global {
@@ -51,6 +52,9 @@ export default class GlideCoreToggle extends LitElement {
 
   @property({ reflect: true })
   summary?: string;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override click() {
     this.#inputElementRef.value?.click();

--- a/src/tooltip.stories.ts
+++ b/src/tooltip.stories.ts
@@ -61,6 +61,7 @@ const meta: Meta = {
     open: false,
     placement: 'bottom',
     shortcut: [],
+    version: '',
   },
   argTypes: {
     'slot="default"': {
@@ -133,6 +134,15 @@ const meta: Meta = {
         type: {
           summary: 'string[]',
         },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -15,6 +15,7 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { map } from 'lit/directives/map.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { LocalizeController } from './library/localize.js';
 import ow, { owSlot } from './library/ow.js';
 import styles from './tooltip.styles.js';
@@ -107,6 +108,9 @@ export default class GlideCoreTooltip extends LitElement {
 
   @property({ reflect: true, type: Array })
   shortcut: string[] = [];
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override disconnectedCallback() {
     super.disconnectedCallback();

--- a/src/tree.item.icon-button.ts
+++ b/src/tree.item.icon-button.ts
@@ -2,6 +2,7 @@ import './icon-button.js';
 import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { owSlot } from './library/ow.js';
 import styles from './tree.item.icon-button.styles.js';
 
@@ -25,6 +26,9 @@ export default class GlideCoreTreeItemIconButton extends LitElement {
 
   @property()
   label = '';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override firstUpdated() {
     owSlot(this.#defaultSlotElementRef.value);

--- a/src/tree.item.menu.ts
+++ b/src/tree.item.menu.ts
@@ -6,6 +6,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
 import type { Placement } from '@floating-ui/dom';
+import packageJson from '../package.json' with { type: 'json' };
 import styles from './tree.item.menu.styles.js';
 import GlideCoreIconButton from './icon-button.js';
 import ow, { owSlot, owSlotType } from './library/ow.js';
@@ -37,6 +38,9 @@ export default class GlideCoreTreeItemMenu extends LitElement {
 
   @property()
   label = '';
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override click() {
     ow(

--- a/src/tree.item.ts
+++ b/src/tree.item.ts
@@ -5,6 +5,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { LocalizeController } from './library/localize.js';
 import GlideCoreTreeItemMenu from './tree.item.menu.js';
 import GlideCoreIconButton from './icon-button.js';
@@ -47,6 +48,9 @@ export default class GlideCoreTreeItem extends LitElement {
 
   @property({ reflect: true, type: Boolean, attribute: 'non-collapsible' })
   nonCollapsible = false;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override focus(options?: FocusOptions) {
     this.#labelContainerElementRef.value?.focus(options);

--- a/src/tree.stories.ts
+++ b/src/tree.stories.ts
@@ -47,6 +47,7 @@ const meta: Meta = {
   tags: ['autodocs'],
   args: {
     'slot="default"': '',
+    version: '',
     '<glide-core-tree-item>.label': 'Branch',
     '<glide-core-tree-item>.addEventListener(event, handler)': '',
     '<glide-core-tree-item>.two.expanded': true,
@@ -63,10 +64,13 @@ const meta: Meta = {
     '<glide-core-tree-item>.five.selected': false,
     '<glide-core-tree-item>.six.expanded': false,
     '<glide-core-tree-item>.six.selected': false,
+    '<glide-core-tree-item>.version': '',
     '<glide-core-tree-item-icon-button>.label': 'Settings',
+    '<glide-core-tree-item-icon-button>.version': '',
     '<glide-core-tree-item-menu>[slot="default"]': '',
     '<glide-core-tree-item-menu>.placement': 'bottom-start',
     '<glide-core-tree-item-menu>[slot="icon"]': '',
+    '<glide-core-tree-item-menu>.version': '',
   },
   play(context) {
     const observer = new MutationObserver((records) => {
@@ -232,6 +236,15 @@ const meta: Meta = {
       },
       type: { name: 'function', required: true },
     },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
     '<glide-core-tree-item>.label': {
       name: 'label',
       table: {
@@ -239,6 +252,17 @@ const meta: Meta = {
         type: { summary: 'string' },
       },
       type: { name: 'string', required: true },
+    },
+    '<glide-core-tree-item>.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Tree Item',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
     },
     '<glide-core-tree-item>.addEventListener(event, handler)': {
       control: false,
@@ -346,6 +370,17 @@ const meta: Meta = {
       },
       type: { name: 'string', required: true },
     },
+    '<glide-core-tree-item-icon-button>.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Tree Item Icon Button',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
     '<glide-core-tree-item-menu>[slot="default"]': {
       name: 'slot="default"',
       control: false,
@@ -390,6 +425,17 @@ const meta: Meta = {
         type: {
           summary: 'Element',
         },
+      },
+    },
+    '<glide-core-tree-item-menu>.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Tree Item Menu',
+        defaultValue: {
+          summary: import.meta.env.VITE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
       },
     },
   },

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,6 +1,7 @@
 import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
+import packageJson from '../package.json' with { type: 'json' };
 import { owSlot, owSlotType } from './library/ow.js';
 import GlideCoreTreeItem from './tree.item.js';
 import styles from './tree.styles.js';
@@ -28,6 +29,9 @@ export default class GlideCoreTree extends LitElement {
   @state() focusedItem?: GlideCoreTreeItem | null;
 
   @state() privateTabIndex = 0;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   override disconnectedCallback() {
     super.disconnectedCallback();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,12 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "ESNext",
+    // So our import of `package.json` in various files doesn't cause our
+    // `./src` files in `./dist` to be nested under `./dist/src`.
+    "rootDir": "./src",
     "useDefineForClassFields": false, // https://lit.dev/docs/components/decorators#decorators-typescript
     "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
     "plugins": [
       {
         "name": "ts-lit-plugin",

--- a/vite.d.ts
+++ b/vite.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+// eslint-disable-next-line unicorn/prevent-abbreviations
+interface ImportMetaEnv {
+  readonly VITE_CORE_VERSION: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Adds a read-only `version` attribute to every component to help with debugging. We've gotten some requests for this. And it would have personally come in handy a few times in the past when helping teams debug.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

Spotcheck a few stories. Verify each story's controls table and verify that the attribute is present on the component itself.

## 📸 Images/Videos of Functionality

N/A
