### PR TITLE
Use `@property()` decorators instead of `@state()`

### DIFF
--- a/.changeset/tender-dancers-push.md
+++ b/.changeset/tender-dancers-push.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Tree's `focusedItem`, `privateTabIndex`, and `selectedItem` properties are now marked as `private`.
+- Tab Group's `selectedTab`, `isAfterFirstUpdated`, `isDisableOverflowStartButton`, `isDisableOverflowEndButton`, and `isShowOverflowButtons` properties are now marked as `private`.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -197,7 +197,6 @@ export default [
           order: [
             '[public-static-properties]',
             '[public-@property]',
-            '[public-@state]',
             '[public-properties]',
             '[public-accessors]',
             '[public-arrow-function-expressions]',
@@ -221,12 +220,6 @@ export default [
             'public-@property': [
               {
                 groupByDecorator: '/property/',
-                sort: 'alphabetical',
-              },
-            ],
-            'public-@state': [
-              {
-                groupByDecorator: '/state/',
                 sort: 'alphabetical',
               },
             ],

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -142,7 +142,7 @@ export default class GlideCoreCheckbox extends LitElement {
   }
 
   // Used by Checkbox Group.
-  @state()
+  @property({ type: Boolean })
   privateIsReportValidityOrSubmit = false;
 
   @property({ reflect: true })

--- a/src/dropdown.option.ts
+++ b/src/dropdown.option.ts
@@ -133,8 +133,14 @@ export default class GlideCoreDropdownOption extends LitElement {
 
   // An option is considered active when it's interacted with via keyboard or hovered.
   // Used by Dropdown.
-  @state()
+  @property({ type: Boolean })
   privateActive = false;
+
+  @property({ type: Boolean })
+  privateIsTooltipOpen = false;
+
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   @state()
   private get isMultiple() {
@@ -146,12 +152,6 @@ export default class GlideCoreDropdownOption extends LitElement {
       this.privateMultiple || this.closest('glide-core-dropdown')?.multiple
     );
   }
-
-  @state()
-  privateIsTooltipOpen = false;
-
-  @property({ reflect: true })
-  readonly version = packageJson.version;
 
   override click() {
     if (this.privateMultiple) {

--- a/src/menu.options.ts
+++ b/src/menu.options.ts
@@ -1,7 +1,7 @@
 import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { nanoid } from 'nanoid';
 import packageJson from '../package.json' with { type: 'json' };
 import { owSlot, owSlotType } from './library/ow.js';
@@ -33,7 +33,7 @@ export default class GlideCoreMenuOptions extends LitElement {
   @property({ attribute: 'aria-labelledby', reflect: true })
   ariaLabelledby = '';
 
-  @state()
+  @property()
   privateSize: 'small' | 'large' = 'large';
 
   @property({ reflect: true })

--- a/src/split-button.primary-button.ts
+++ b/src/split-button.primary-button.ts
@@ -1,6 +1,6 @@
 import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import packageJson from '../package.json' with { type: 'json' };
 import styles from './split-button.primary-button.styles.js';
@@ -47,10 +47,10 @@ export default class GlideCoreSplitButtonPrimaryButton extends LitElement {
   @property({ reflect: true })
   label?: string;
 
-  @state()
+  @property()
   privateSize: 'large' | 'small' = 'large';
 
-  @state()
+  @property()
   privateVariant: 'primary' | 'secondary' = 'primary';
 
   @property({ reflect: true })

--- a/src/split-button.primary-link.ts
+++ b/src/split-button.primary-link.ts
@@ -1,6 +1,6 @@
 import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import packageJson from '../package.json' with { type: 'json' };
 import styles from './split-button.primary-button.styles.js';
@@ -33,10 +33,10 @@ export default class GlideCoreSplitButtonPrimaryLink extends LitElement {
   @property({ reflect: true })
   url?: string;
 
-  @state()
+  @property()
   privateSize: 'large' | 'small' = 'large';
 
-  @state()
+  @property()
   privateVariant: 'primary' | 'secondary' = 'primary';
 
   @property({ reflect: true })

--- a/src/split-button.secondary-button.ts
+++ b/src/split-button.secondary-button.ts
@@ -2,7 +2,7 @@ import './menu.options.js';
 import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import packageJson from '../package.json' with { type: 'json' };
 import GlideCoreMenu from './menu.js';
@@ -43,13 +43,13 @@ export default class GlideCoreSplitButtonSecondaryButton extends LitElement {
   @property({ attribute: 'menu-placement', reflect: true })
   menuPlacement: 'bottom-end' | 'top-end' = 'bottom-end';
 
-  @state()
+  @property({ type: Boolean })
   privateActive = false;
 
-  @state()
+  @property()
   privateSize: 'large' | 'small' = 'large';
 
-  @state()
+  @property()
   privateVariant: 'primary' | 'secondary' = 'primary';
 
   @property({ reflect: true })

--- a/src/tab.group.test.basics.ts
+++ b/src/tab.group.test.basics.ts
@@ -45,8 +45,9 @@ it('renders correct markup and sets correct attributes for the default case', as
   await expect(component).to.be.accessible();
 
   const [firstTab] = component.querySelectorAll('glide-core-tab');
+  const selectedTab = component.querySelector('glide-core-tab[selected]');
 
-  expect(component.selectedTab).to.equal(firstTab);
+  expect(selectedTab).to.equal(firstTab);
 
   expect([...component.shadowRoot!.firstElementChild!.classList]).to.deep.equal(
     ['component'],

--- a/src/tab.group.ts
+++ b/src/tab.group.ts
@@ -38,30 +38,30 @@ export default class GlideCoreTabGroup extends LitElement {
 
   static override styles = styles;
 
-  @state()
-  get selectedTab() {
-    return this.#selectedTab;
-  }
-
-  set selectedTab(tab: GlideCoreTab | null) {
-    this.#previousSelectedTab = this.#selectedTab;
-    this.#selectedTab = tab;
-  }
+  @property({ reflect: true })
+  readonly version = packageJson.version;
 
   @state()
   isAfterFirstUpdated = false;
 
   @state()
-  isDisableOverflowStartButton = false;
+  isDisableOverflowEndButton = false;
 
   @state()
-  isDisableOverflowEndButton = false;
+  isDisableOverflowStartButton = false;
 
   @state()
   isShowOverflowButtons = false;
 
-  @property({ reflect: true })
-  readonly version = packageJson.version;
+  @state()
+  private get selectedTab() {
+    return this.#selectedTab;
+  }
+
+  private set selectedTab(tab: GlideCoreTab | null) {
+    this.#previousSelectedTab = this.#selectedTab;
+    this.#selectedTab = tab;
+  }
 
   override disconnectedCallback() {
     this.#resizeObserver?.disconnect();

--- a/src/tree.test.basics.ts
+++ b/src/tree.test.basics.ts
@@ -17,16 +17,6 @@ it('registers itself', async () => {
   expect(window.customElements.get('glide-core-tree')).to.equal(GlideCoreTree);
 });
 
-it('renders and sets default attributes', async () => {
-  const component = await fixture<GlideCoreTree>(html`
-    <glide-core-tree>
-      <glide-core-tree-item label="Child Item"></glide-core-tree-item>
-    </glide-core-tree>
-  `);
-
-  expect(component.selectedItem).to.equal(undefined);
-});
-
 it('can select child and grandchild items', async () => {
   const component = await fixture<GlideCoreTree>(html`
     <glide-core-tree>
@@ -46,16 +36,20 @@ it('can select child and grandchild items', async () => {
   );
 
   component.selectItem(childItems[0]);
+  let selectedItem = component.querySelector('glide-core-tree-item[selected]');
+
   expect(childItems[0].selected).to.be.true;
-  expect(component.selectedItem).to.equal(childItems[0]);
+  expect(selectedItem).to.equal(childItems[0]);
   expect(childItems[1].selected).to.be.false;
   expect(grandchildItems[0].selected).to.be.false;
 
   component.selectItem(grandchildItems[0]);
+  selectedItem = component.querySelector('glide-core-tree-item[selected]');
+
   expect(childItems[0].selected).to.be.false;
   expect(childItems[1].selected).to.be.false;
   expect(grandchildItems[0].selected).to.be.true;
-  expect(component.selectedItem).to.equal(grandchildItems[0]);
+  expect(selectedItem).to.equal(grandchildItems[0]);
 });
 
 it('can click child and grandchild items to expand or select them', async () => {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -24,12 +24,6 @@ export default class GlideCoreTree extends LitElement {
 
   static override styles = styles;
 
-  @state() selectedItem?: GlideCoreTreeItem;
-
-  @state() focusedItem?: GlideCoreTreeItem | null;
-
-  @state() privateTabIndex = 0;
-
   @property({ reflect: true })
   readonly version = packageJson.version;
 
@@ -90,6 +84,15 @@ export default class GlideCoreTree extends LitElement {
     this.addEventListener('focusin', this.#onHostFocusIn);
     this.addEventListener('focusout', this.#onHostFocusOut);
   }
+
+  @state()
+  private focusedItem?: GlideCoreTreeItem | null;
+
+  @state()
+  private privateTabIndex = 0;
+
+  @state()
+  private selectedItem?: GlideCoreTreeItem;
 
   #defaultSlotElementRef = createRef<HTMLSlotElement>();
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Just a small code quality change. 

We sometimes decorate properties with `@state()` when they're only used internally by a subcomponent's parent component. Though `@state()` does work the same as `@property()` for this purpose, `@property()` is the better choice because `@state()` is only meant for truly internal properties.

From Lit's [`@state()`](https://lit.dev/docs/api/decorators/#state) documentation:

> Properties declared [using `@state()`] must not be used from HTML or HTML templating systems, they're **solely for properties internal to the element**. These properties **may be renamed** by optimization tools like closure compiler.



<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

If the tests pass we should be good.

## 📸 Images/Videos of Functionality

N/A
