### PR TITLE
Submit Textarea's form on Command + Enter

### DIFF
--- a/.changeset/curvy-wolves-dress.md
+++ b/.changeset/curvy-wolves-dress.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Textarea now submits its form on Command + Enter or Control + Enter.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -432,10 +432,10 @@ However, built-in form control elements do not reflect attributes that serve as 
 ```ts
 // ✅ -- GOOD
 @property({ reflect: true })
-label?: string
+label?: string;
 
 @property()
-value?: string
+value = '';
 ```
 
 ```ts
@@ -444,7 +444,7 @@ value?: string
 label?: string
 
 @property({ reflect: true })
-value?: string
+value = '';
 ```
 
 ### Prefer separate test files

--- a/src/button-group.button.ts
+++ b/src/button-group.button.ts
@@ -43,7 +43,7 @@ export default class GlideCoreButtonGroupButton extends LitElement {
   // `value` is used by consumers to identify selections based on something other
   // than the label.
   @property({ reflect: true })
-  value? = '';
+  value = '';
 
   // Private because it's only meant to be used by Button Group.
   @property()

--- a/src/button-group.stories.ts
+++ b/src/button-group.stories.ts
@@ -225,6 +225,9 @@ const meta: Meta = {
       name: 'value',
       table: {
         category: 'Button Group Button',
+        defaultValue: {
+          summary: '""',
+        },
         type: {
           summary: 'string',
           detail:

--- a/src/textarea.test.forms.ts
+++ b/src/textarea.test.forms.ts
@@ -2,11 +2,12 @@
 
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import GlideCoreTextarea from './textarea.js';
 
 GlideCoreTextarea.shadowRootOptions.mode = 'open';
 
-it('can be reset to initial value', async () => {
+it('can be reset if it has an initial value', async () => {
   const form = document.createElement('form');
 
   const component = await fixture<GlideCoreTextarea>(
@@ -25,7 +26,7 @@ it('can be reset to initial value', async () => {
   expect(component.value).to.equal('testing');
 });
 
-it('can be reset if there was no initial value', async () => {
+it('can be reset if it has no initial value', async () => {
   const form = document.createElement('form');
 
   const component = await fixture<GlideCoreTextarea>(
@@ -472,4 +473,27 @@ it('retains existing validity state when `setCustomValidity()` is called', async
   expect(component.validity?.valid).to.be.false;
   expect(component.validity?.customError).to.be.true;
   expect(component.validity?.valueMissing).to.be.true;
+});
+
+it('submits its form on Meta + Enter', async () => {
+  const form = document.createElement('form');
+
+  const component = await fixture<GlideCoreTextarea>(
+    html`<glide-core-textarea label="label"></glide-core-textarea>`,
+    { parentNode: form },
+  );
+
+  const spy = sinon.spy();
+
+  form.addEventListener('submit', (event) => {
+    event?.preventDefault();
+    spy();
+  });
+
+  component?.focus();
+  await sendKeys({ down: 'Meta' });
+  await sendKeys({ press: 'Enter' });
+  await sendKeys({ up: 'Meta' });
+
+  expect(spy.callCount).to.be.equal(1);
 });

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -196,9 +196,10 @@ export default class GlideCoreTextarea extends LitElement {
           ?readonly=${this.readonly}
           ?disabled=${this.disabled}
           ${ref(this.#textareaElementRef)}
-          @input=${this.#onTextareaInput}
-          @change=${this.#onTextareaChange}
           @blur=${this.#onTextareaBlur}
+          @change=${this.#onTextareaChange}
+          @input=${this.#onTextareaInput}
+          @keydown=${this.#onTextareaKeydown}
         >
         </textarea>
       </div>
@@ -406,5 +407,11 @@ export default class GlideCoreTextarea extends LitElement {
     );
 
     this.value = this.#textareaElementRef.value.value;
+  }
+
+  #onTextareaKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      this.form?.requestSubmit();
+    }
   }
 }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Command + Enter is a common shortcut for submitting a form when inside a `<textarea>`. Slack supports it. GitHub and Jira do too. I'm thinking we should as well considering how easy it is to implement.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Textarea in Storybook.
2. Press Command + Enter.
3. Verify the form was submitted.
4. Do the same for Control + Enter.

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

N/A
