### PR TITLE
Update Drawer's background-color and blur properties

### DIFF
--- a/.changeset/swift-cats-marry.md
+++ b/.changeset/swift-cats-marry.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Updated Drawer to ensure that higher contrast content behind it no longer bleeds through.

--- a/src/drawer.styles.ts
+++ b/src/drawer.styles.ts
@@ -3,7 +3,7 @@ import { css } from 'lit';
 export default [
   css`
     .component {
-      background-color: var(--glide-core-surface-base-lightest);
+      background-color: var(--glide-core-surface-base-xlightest);
       block-size: 0;
       border-end-start-radius: 0.625rem;
       border-start-start-radius: 0.625rem;
@@ -28,7 +28,7 @@ export default [
     }
 
     .open {
-      backdrop-filter: blur(25px);
+      backdrop-filter: blur(50px);
       block-size: auto;
       inline-size: var(--width, 27.375rem);
       inset: 0 0 0 auto;


### PR DESCRIPTION
## 🚀 Description

It was reported that higher contrast backing content was bleeding through Drawer when it was `open`. Design suggested we change these properties [again](https://github.com/CrowdStrike/glide-core/pull/504/files) to ensure this won't happen.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

Viewing Drawer in Storybook should be enough.  I tested these changes in a consuming app and it appears to be an improvement.

## 📸 Images/Videos of Functionality

N/A
