### PR TITLE
Remove `elementUpdated`

### DIFF
--- a/src/button-group.button.test.interactions.ts
+++ b/src/button-group.button.test.interactions.ts
@@ -1,4 +1,4 @@
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import GlideCoreButtonGroupButton from './button-group.button.js';
 
 GlideCoreButtonGroupButton.shadowRootOptions.mode = 'open';
@@ -11,7 +11,7 @@ it('sets `aria-checked` when selected programmatically', async () => {
   );
 
   component.selected = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const radio = component.shadowRoot?.querySelector('[role="radio"]');
   expect(radio?.getAttribute('aria-checked')).to.equal('true');
@@ -26,7 +26,7 @@ it('sets `aria-checked` when deselected programmatically', async () => {
   );
 
   component.selected = false;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const radio = component.shadowRoot?.querySelector('[role="radio"]');
   expect(radio?.getAttribute('aria-checked')).to.equal('false');
@@ -40,7 +40,7 @@ it('sets `aria-disabled` when disabled programmatically', async () => {
   );
 
   component.disabled = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const radio = component.shadowRoot?.querySelector('[role="radio"]');
   expect(radio?.getAttribute('aria-disabled')).to.equal('true');
@@ -55,7 +55,7 @@ it('sets `aria-disabled` when enabled programmatically', async () => {
   );
 
   component.disabled = false;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const radio = component.shadowRoot?.querySelector('[role="radio"]');
   expect(radio?.getAttribute('aria-disabled')).to.equal('false');

--- a/src/button-group.test.interactions.ts
+++ b/src/button-group.test.interactions.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreButtonGroupButton from './button-group.button.js';
 import { click } from './library/mouse.js';
@@ -10,7 +10,7 @@ GlideCoreButtonGroup.shadowRootOptions.mode = 'open';
 GlideCoreButtonGroupButton.shadowRootOptions.mode = 'open';
 
 it('selects a button on click', async () => {
-  const component = await fixture(
+  const component = await fixture<GlideCoreButtonGroup>(
     html`<glide-core-button-group>
       <glide-core-button-group-button
         label="One"
@@ -26,14 +26,14 @@ it('selects a button on click', async () => {
   const buttons = component.querySelectorAll('glide-core-button-group-button');
 
   await click(buttons[1]);
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(buttons[0].selected).to.be.false;
   expect(buttons[1].selected).to.be.true;
 });
 
 it('selects a button on `click()`', async () => {
-  const component = await fixture(
+  const component = await fixture<GlideCoreButtonGroup>(
     html`<glide-core-button-group>
       <glide-core-button-group-button
         label="One"
@@ -49,7 +49,7 @@ it('selects a button on `click()`', async () => {
   const buttons = component.querySelectorAll('glide-core-button-group-button');
 
   buttons[1].click();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(buttons[0].selected).to.be.false;
   expect(buttons[1].selected).to.be.true;

--- a/src/checkbox-group.test.forms.ts
+++ b/src/checkbox-group.test.forms.ts
@@ -1,13 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 import './checkbox.js';
-import {
-  assert,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import { click } from './library/mouse.js';
 import GlideCoreCheckboxGroup from './checkbox-group.js';
 
@@ -280,7 +274,7 @@ it('sets the checkbox as valid when `required` is set to `false` dynamically', a
   );
 
   component.required = false;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const checkbox = component.querySelector('glide-core-checkbox');
   expect(checkbox?.validity.valid).to.be.true;
@@ -297,7 +291,7 @@ it('sets the checkbox as invalid when `required` is set to `true` dynamically', 
   );
 
   component.required = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const checkbox = component.querySelector('glide-core-checkbox');
   expect(checkbox?.validity.valid).to.be.false;
@@ -320,7 +314,7 @@ it('sets the validity message with `setCustomValidity()`', async () => {
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -341,11 +335,11 @@ it('removes a validity message with an empty argument to `setCustomValidity()`',
   component.setCustomValidity('validity message');
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   component.setCustomValidity('');
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -367,7 +361,7 @@ it('is invalid when `setValidity()` is called', async () => {
 
   expect(component.validity.valid).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -379,7 +373,7 @@ it('is invalid when `setValidity()` is called', async () => {
 
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -401,14 +395,14 @@ it('is valid when `setValidity()` is called', async () => {
 
   component.setValidity({});
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity.valid).to.be.true;
   expect(component.validity.customError).to.be.false;
 
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -447,7 +441,7 @@ it('removes validity feedback but retains its validity state when `resetValidity
 
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -456,7 +450,7 @@ it('removes validity feedback but retains its validity state when `resetValidity
 
   component.resetValidityFeedback();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.shadowRoot?.querySelector('[data-test="validity-message"]'))
     .to.be.null;

--- a/src/checkbox-group.test.interactions.ts
+++ b/src/checkbox-group.test.interactions.ts
@@ -1,13 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 import './checkbox.js';
-import {
-  assert,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import { click } from './library/mouse.js';
 import GlideCoreCheckboxGroup from './checkbox-group.js';
 
@@ -57,7 +51,7 @@ it('updates `value` when the `value` of a checked Checkbox is changed programmat
   assert(checkbox);
   checkbox.value = 'three';
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.value).to.deep.equal(['three', 'two']);
   expect(component.getAttribute('value')).to.equal('["three","two"]');
@@ -84,7 +78,7 @@ it('updates `value` when the `value` of a checked Checkbox is emptied programmat
   assert(checkbox);
   checkbox.value = '';
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.value).to.deep.equal(['two']);
   expect(component.getAttribute('value')).to.equal('["two"]');
@@ -122,7 +116,7 @@ it('can be disabled dynamically', async () => {
   );
 
   component.disabled = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const checkboxes = component.querySelectorAll('glide-core-checkbox');
 

--- a/src/checkbox.test.forms.ts
+++ b/src/checkbox.test.forms.ts
@@ -1,4 +1,4 @@
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import GlideCoreCheckbox from './checkbox.js';
@@ -288,7 +288,7 @@ it('is valid when `value` is empty and `required` is updated to `false` programm
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -296,7 +296,7 @@ it('is valid when `value` is empty and `required` is updated to `false` programm
 
   component.required = false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity?.valid).to.be.true;
   expect(component.validity?.valueMissing).to.be.false;
@@ -319,7 +319,7 @@ it('sets the validity message with `setCustomValidity()`', async () => {
   expect(component.validity?.customError).to.be.true;
   expect(component.checkValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -329,7 +329,7 @@ it('sets the validity message with `setCustomValidity()`', async () => {
 
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -349,11 +349,11 @@ it('removes a validity message with an empty argument to `setCustomValidity()`',
   component.setCustomValidity('validity message');
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   component.setCustomValidity('');
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -370,7 +370,7 @@ it('is invalid when `setValidity()` is called', async () => {
 
   expect(component.validity.valid).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -382,7 +382,7 @@ it('is invalid when `setValidity()` is called', async () => {
 
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -403,14 +403,14 @@ it('is valid when `setValidity()` is called', async () => {
 
   component.setValidity({});
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity.valid).to.be.true;
   expect(component.validity.customError).to.be.false;
 
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -439,7 +439,7 @@ it('removes validity feedback but retains its validity state when `resetValidity
 
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -448,7 +448,7 @@ it('removes validity feedback but retains its validity state when `resetValidity
 
   component.resetValidityFeedback();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.shadowRoot?.querySelector('[data-test="validity-message"]'))
     .to.be.null;

--- a/src/checkbox.test.interactions.ts
+++ b/src/checkbox.test.interactions.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { click } from './library/mouse.js';
 import GlideCoreCheckbox from './checkbox.js';
 
@@ -12,7 +12,7 @@ it('is checked on click', async () => {
   );
 
   await click(component.shadowRoot?.querySelector('[data-test="input"]'));
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.checked).to.be.true;
   expect(component.hasAttribute('checked')).to.be.false;
@@ -24,7 +24,7 @@ it('is unchecked on click', async () => {
   );
 
   await click(component.shadowRoot?.querySelector('[data-test="input"]'));
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.checked).to.be.false;
   expect(component.hasAttribute('checked')).to.be.true;
@@ -39,7 +39,7 @@ it('is checked and not indeterminate on click when unchecked and indeterminate',
   );
 
   await click(component.shadowRoot?.querySelector('[data-test="input"]'));
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const input = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
@@ -62,7 +62,7 @@ it('is unchecked and not indeterminate on click when checked and indeterminate',
   );
 
   await click(component.shadowRoot?.querySelector('[data-test="input"]'));
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const input = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
@@ -85,7 +85,7 @@ it('is still checked on click when checked but disabled', async () => {
   );
 
   await click(component.shadowRoot?.querySelector('[data-test="input"]'));
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.checked).to.be.true;
   expect(component.hasAttribute('checked')).to.be.true;
@@ -97,7 +97,7 @@ it('is still unchecked on click when unchecked and disabled', async () => {
   );
 
   await click(component.shadowRoot?.querySelector('[data-test="input"]'));
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.hasAttribute('checked')).to.be.false;
   expect(component.checked).to.be.false;
@@ -114,7 +114,7 @@ it('is unchecked on click then forcibly unchecked via a "input" listener', async
   });
 
   await click(component.shadowRoot?.querySelector('[data-test="input"]'));
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.hasAttribute('checked')).to.be.false;
   expect(component.checked).to.be.false;
@@ -131,7 +131,7 @@ it('is unchecked on click then forcibly unchecked via an "change" listener', asy
   });
 
   await click(component.shadowRoot?.querySelector('[data-test="input"]'));
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.hasAttribute('checked')).to.be.false;
   expect(component.checked).to.be.false;
@@ -147,7 +147,7 @@ it('is still indeterminate on click when unchecked and disabled', async () => {
   );
 
   await click(component.shadowRoot?.querySelector('[data-test="input"]'));
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const input = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',

--- a/src/drawer.test.focus.ts
+++ b/src/drawer.test.focus.ts
@@ -1,4 +1,4 @@
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { emulateMedia } from '@web/test-runner-commands';
 import GlideCoreDrawer from './drawer.js';
 
@@ -12,7 +12,7 @@ it('focuses itself on open', async () => {
   );
 
   component.open = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.shadowRoot?.activeElement).to.equal(
     component.shadowRoot?.querySelector('[data-test="component"]'),

--- a/src/drawer.test.interactions.ts
+++ b/src/drawer.test.interactions.ts
@@ -1,12 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import {
-  assert,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import { emulateMedia, sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import GlideCoreDrawer from './drawer.js';
@@ -42,7 +36,7 @@ it('opens when not animated', async () => {
   );
 
   component.open = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const aside = component.shadowRoot?.querySelector('[data-test="component"]');
   expect(aside?.checkVisibility({ visibilityProperty: true })).to.be.true;
@@ -77,7 +71,7 @@ it('closes when not animated', async () => {
   );
 
   component.open = false;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const aside = component.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="component"]',
@@ -110,10 +104,10 @@ it('has `set open(isOpen: boolean)` coverage', async () => {
   );
 
   component.open = false;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   component.open = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const animationPromises = component.shadowRoot
     ?.querySelector('[data-test="component"]')

--- a/src/dropdown.option.test.events.ts
+++ b/src/dropdown.option.test.events.ts
@@ -1,12 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import {
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-  oneEvent,
-} from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import sinon from 'sinon';
 import GlideCoreDropdownOption from './dropdown.option.js';
 
@@ -71,7 +65,7 @@ it('does not allow its "toggle" event to propagate', async () => {
   component.addEventListener('toggle', spy);
 
   component.privateIsTooltipOpen = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(spy.callCount).to.equal(0);
 });

--- a/src/dropdown.option.test.interactions.multiple.ts
+++ b/src/dropdown.option.test.interactions.multiple.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { hover } from './library/mouse.js';
 import GlideCoreDropdownOption from './dropdown.option.js';
 
@@ -16,8 +16,7 @@ it('is selected when programmatically selected', async () => {
   );
 
   component.selected = true;
-
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const checkbox = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="checkbox"]',
@@ -38,8 +37,7 @@ it('is deselected when programmatically deselected', async () => {
   );
 
   component.selected = false;
-
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const checkbox = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="checkbox"]',

--- a/src/dropdown.option.test.interactions.single.ts
+++ b/src/dropdown.option.test.interactions.single.ts
@@ -1,12 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import {
-  aTimeout,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { aTimeout, expect, fixture, html } from '@open-wc/testing';
 import { hover } from './library/mouse.js';
 import GlideCoreDropdownOption from './dropdown.option.js';
 import GlideCoreTooltip from './tooltip.js';
@@ -22,7 +16,7 @@ it('is selected when programmatically selected', async () => {
   );
 
   component.selected = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.ariaSelected).to.equal('true');
 });

--- a/src/dropdown.option.test.interactions.ts
+++ b/src/dropdown.option.test.interactions.ts
@@ -1,4 +1,4 @@
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import GlideCoreDropdownOption from './dropdown.option.js';
 
 it('has the correct "role" when programatically disabled', async () => {
@@ -9,7 +9,7 @@ it('has the correct "role" when programatically disabled', async () => {
   );
 
   component.disabled = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.role).to.equal('none');
 });

--- a/src/dropdown.test.focus.multiple.ts
+++ b/src/dropdown.test.focus.multiple.ts
@@ -1,10 +1,4 @@
-import {
-  aTimeout,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { aTimeout, expect, fixture, html } from '@open-wc/testing';
 import GlideCoreDropdownOption from './dropdown.option.js';
 import GlideCoreDropdown from './dropdown.js';
 import type GlideCoreTag from './tag.js';
@@ -136,7 +130,7 @@ it('focuses the second tag when the first one is removed', async () => {
     component.shadowRoot?.querySelectorAll<GlideCoreTag>('[data-test="tag"]');
 
   tags?.[0].click();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Wait for the timeout in `#onTagRemove`.
   await aTimeout(0);
@@ -173,7 +167,7 @@ it('focuses the third tag when the second one is removed', async () => {
     component.shadowRoot?.querySelectorAll<GlideCoreTag>('[data-test="tag"]');
 
   tags?.[1].click();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Wait for the timeout in `#onTagRemove`.
   await aTimeout(0);
@@ -210,7 +204,7 @@ it('focuses the second tag when the third tag removed', async () => {
     component.shadowRoot?.querySelectorAll<GlideCoreTag>('[data-test="tag"]');
 
   tags?.[2].click();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Wait for the timeout in `#onTagRemove`.
   await aTimeout(0);
@@ -232,7 +226,7 @@ it('focuses itself when the last tag is removed', async () => {
     ?.querySelector<GlideCoreTag>('[data-test="tag"]')
     ?.click();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Wait for the timeout in `#onTagRemove`.
   await aTimeout(0);

--- a/src/dropdown.test.forms.multiple.ts
+++ b/src/dropdown.test.forms.multiple.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import GlideCoreDropdownOption from './dropdown.option.js';
 import GlideCoreDropdown from './dropdown.js';
 import GlideCoreTag from './tag.js';
@@ -40,7 +40,7 @@ it('can be reset', async () => {
 
   form.reset();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.value).to.deep.equal([]);
 

--- a/src/dropdown.test.forms.single.ts
+++ b/src/dropdown.test.forms.single.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import GlideCoreDropdownOption from './dropdown.option.js';
 import GlideCoreDropdown from './dropdown.js';
 
@@ -34,7 +34,7 @@ it('can be reset', async () => {
 
   form.reset();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const label = component.shadowRoot?.querySelector(
     '[data-test="internal-label"]',

--- a/src/dropdown.test.forms.ts
+++ b/src/dropdown.test.forms.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import GlideCoreDropdown from './dropdown.js';
@@ -186,7 +186,7 @@ it('sets the validity message with `setCustomValidity()`', async () => {
   expect(component.validity?.customError).to.be.true;
   expect(component.checkValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -196,7 +196,7 @@ it('sets the validity message with `setCustomValidity()`', async () => {
 
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -214,11 +214,11 @@ it('removes a validity message with an empty argument to `setCustomValidity()`',
   component.setCustomValidity('validity message');
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   component.setCustomValidity('');
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -237,7 +237,7 @@ it('is invalid when `setValidity()` is called', async () => {
 
   expect(component.validity.valid).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -249,7 +249,7 @@ it('is invalid when `setValidity()` is called', async () => {
 
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -268,14 +268,14 @@ it('is valid when `setValidity()` is called', async () => {
 
   component.setValidity({});
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity.valid).to.be.true;
   expect(component.validity.customError).to.be.false;
 
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -296,7 +296,7 @@ it('sets the validity message with `setCustomValidity()` when `filterable`', asy
   expect(component.validity?.customError).to.be.true;
   expect(component.checkValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -306,7 +306,7 @@ it('sets the validity message with `setCustomValidity()` when `filterable`', asy
 
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -324,11 +324,11 @@ it('removes a validity message with an empty argument to `setCustomValidity()` w
   component.setCustomValidity('validity message');
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   component.setCustomValidity('');
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -347,7 +347,7 @@ it('is invalid when `setValidity()` is called when `filterable`', async () => {
 
   expect(component.validity.valid).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -359,7 +359,7 @@ it('is invalid when `setValidity()` is called when `filterable`', async () => {
 
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -378,14 +378,14 @@ it('is valid when `setValidity()` is called when `filterable`', async () => {
 
   component.setValidity({});
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity.valid).to.be.true;
   expect(component.validity.customError).to.be.false;
 
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -418,7 +418,7 @@ it('removes validity feedback but retains its validity state when `resetValidity
 
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -427,7 +427,7 @@ it('removes validity feedback but retains its validity state when `resetValidity
 
   component.resetValidityFeedback();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.shadowRoot?.querySelector('[data-test="validity-message"]'))
     .to.be.null;

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -3,7 +3,6 @@
 import {
   assert,
   aTimeout,
-  elementUpdated,
   expect,
   fixture,
   html,
@@ -258,7 +257,7 @@ it('hides its magnifying glass icon when single-select and an option is selected
     '[data-test="magnifying-glass-icon"]',
   );
 
-  await elementUpdated(component);
+  await component.updateComplete;
   expect(icon?.checkVisibility()).to.be.not.ok;
 });
 
@@ -284,7 +283,7 @@ it('hides its magnifying glass icon when single-select and closed programmatical
   );
 
   component.open = false;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(icon?.checkVisibility()).to.not.be.ok;
 });
@@ -572,7 +571,7 @@ it('unhides every option after filtering when one is selected and Dropdown is re
   await sendKeys({ type: 'two' });
 
   component.blur();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   component.open = true;
 
@@ -633,7 +632,7 @@ it('updates the `value` of its `<input>` when `label` of a selected option is ch
   assert(option);
 
   option.label = 'Three';
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const input = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
@@ -669,7 +668,7 @@ it('sets the `value` of its `<input>` when made filterable', async () => {
   );
 
   component.filterable = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const input = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
@@ -698,7 +697,7 @@ it('clears the `value` of its `<input>` when `multiple` is set programmatically'
   );
 
   component.multiple = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const input = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
@@ -739,7 +738,7 @@ it('deselects the last selected option on Backspace', async () => {
   options[0].selected = true;
   options[1].selected = true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   component.focus();
 
@@ -767,7 +766,7 @@ it('deselects all options on Meta + Backspace', async () => {
   options[0].selected = true;
   options[1].selected = true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   component.focus();
 
@@ -841,7 +840,7 @@ it('does not clear its filter when a tag is removed', async () => {
       ?.shadowRoot?.querySelector('[data-test="removal-button"]'),
   );
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const input = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
@@ -859,7 +858,7 @@ it('uses `placeholder` as a placeholder when multiselect and no option is select
 
   component?.querySelector('glide-core-dropdown-option')?.click();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const input = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
@@ -1178,7 +1177,7 @@ it('sets `aria-activedescendant` when closed via click', async () => {
     ?.querySelector<HTMLButtonElement>('[data-test="primary-button"]')
     ?.click();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const input = component.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
@@ -1448,7 +1447,7 @@ it('shows an ellipsis when the label of the selected option overflows', async ()
   assert(option);
 
   option.selected = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const ellipsis = component.shadowRoot?.querySelector(
     '[data-test="ellipsis"]',
@@ -1477,7 +1476,7 @@ it('shows an ellipsis when the label of the selected option is changed programma
   // The "x" is arbitrary. 500 of them ensures the component is wider
   // than the viewport even if the viewport's width is increased.
   option.label = 'x'.repeat(500);
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const ellipsis = component.shadowRoot?.querySelector(
     '[data-test="ellipsis"]',

--- a/src/dropdown.test.interactions.multiple.ts
+++ b/src/dropdown.test.interactions.multiple.ts
@@ -4,7 +4,6 @@ import { LitElement } from 'lit';
 import {
   assert,
   aTimeout,
-  elementUpdated,
   expect,
   fixture,
   html,
@@ -170,7 +169,7 @@ it('selects options on Space', async () => {
   options[1]?.focus();
   await sendKeys({ press: ' ' });
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const labels = component.shadowRoot?.querySelectorAll(
     '[data-test="selected-option-label"]',
@@ -422,7 +421,7 @@ it('updates its tag when `label` of a selected option is changed programmaticall
   assert(option);
 
   option.label = 'Three';
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const tag =
     component.shadowRoot?.querySelector<GlideCoreTag>('[data-test="tag"]');
@@ -446,7 +445,7 @@ it('makes its tag editable when `editable` of a selected option is changed progr
   assert(option);
 
   option.editable = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const tag =
     component.shadowRoot?.querySelector<GlideCoreTag>('[data-test="tag"]');
@@ -673,7 +672,7 @@ it('updates `value` when multiselect is changed to `true` programmatically', asy
   expect(options[0].selected).to.be.false;
   expect(options[1].selected).to.be.true;
 
-  await elementUpdated(options[1]);
+  await options[1].updateComplete;
 
   const checkbox = options[1].shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="checkbox"]',
@@ -1278,7 +1277,7 @@ it('shows Select All when it is set programmatically', async () => {
   await aTimeout(0);
 
   component.selectAll = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const selectAll =
     component.shadowRoot?.querySelector<GlideCoreDropdownOption>(
@@ -1459,7 +1458,7 @@ it('closes when a tag is clicked', async () => {
   );
 
   await click(component.shadowRoot?.querySelector('[data-test="tag"]'), 'left');
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.open).to.be.false;
 });

--- a/src/dropdown.test.interactions.single.ts
+++ b/src/dropdown.test.interactions.single.ts
@@ -4,7 +4,6 @@ import { ArgumentError } from 'ow';
 import {
   assert,
   aTimeout,
-  elementUpdated,
   expect,
   fixture,
   html,
@@ -374,7 +373,7 @@ it('updates its internal label when `label` of the selected option is changed pr
   assert(option);
 
   option.label = 'Two';
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const label = component.shadowRoot?.querySelector(
     '[data-test="internal-label"]',
@@ -397,7 +396,7 @@ it('shows an Edit button when `editable` of the selected option is changed progr
   assert(option);
 
   option.editable = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const editButton = component.shadowRoot?.querySelector(
     '[data-test="edit-button"]',

--- a/src/inline-alert.test.basics.ts
+++ b/src/inline-alert.test.basics.ts
@@ -1,11 +1,5 @@
 import { ArgumentError } from 'ow';
-import {
-  aTimeout,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { aTimeout, expect, fixture, html } from '@open-wc/testing';
 import sinon from 'sinon';
 import GlideCoreInlineAlert from './inline-alert.js';
 
@@ -30,7 +24,7 @@ it('is accessible', async () => {
   await expect(component).to.be.accessible();
 
   component.removable = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   await expect(component).to.be.accessible();
 });

--- a/src/input.test.forms.ts
+++ b/src/input.test.forms.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import GlideCoreInput from './input.js';
@@ -133,7 +133,7 @@ it('is valid if empty but not required', async () => {
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -154,7 +154,7 @@ it('is valid after being filled in when empty and required', async () => {
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -172,7 +172,7 @@ it('is invalid if no value and required', async () => {
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -197,7 +197,7 @@ it('is invalid after value is cleared when required', async () => {
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -214,7 +214,7 @@ it('is valid if no value and required but disabled', async () => {
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -231,7 +231,7 @@ it('updates validity when `required` and `value` is changed programmatically', a
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -239,14 +239,14 @@ it('updates validity when `required` and `value` is changed programmatically', a
 
   component.value = 'text';
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity?.valid).to.be.true;
   expect(component.validity?.valueMissing).to.be.false;
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -256,7 +256,7 @@ it('updates validity when `required` and `value` is changed programmatically', a
   // back to an invalid state
   component.value = '';
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity?.valid).to.be.false;
   expect(component.validity?.valueMissing).to.be.true;
@@ -278,7 +278,7 @@ it('is invalid when `value` is empty and `required` is set to `true` programmati
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -286,7 +286,7 @@ it('is invalid when `value` is empty and `required` is set to `true` programmati
 
   component.required = true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity?.valid).to.be.false;
   expect(component.validity?.valueMissing).to.be.true;
@@ -308,7 +308,7 @@ it('is valid when `value` is empty and `required` is updated to `false` programm
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -316,7 +316,7 @@ it('is valid when `value` is empty and `required` is updated to `false` programm
 
   component.required = false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity?.valid).to.be.true;
   expect(component.validity?.valueMissing).to.be.false;
@@ -357,7 +357,7 @@ it('is valid when `value` matches `pattern` after being set programmatically', a
 
   component.value = 'value';
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity?.valid).to.be.true;
   expect(component.validity?.patternMismatch).to.be.false;
@@ -383,7 +383,7 @@ it('is invalid when `value` does not match `pattern`', async () => {
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -405,7 +405,7 @@ it('is invalid when a programmatically set `value` does not match `pattern`', as
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -436,7 +436,7 @@ it('is valid when `pattern` is programmatically removed', async () => {
 
   component.pattern = undefined;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity?.valid).to.be.true;
   expect(component.validity?.patternMismatch).to.be.false;
@@ -459,7 +459,7 @@ it('sets the validity message with `setCustomValidity()`', async () => {
   expect(component.validity?.customError).to.be.true;
   expect(component.checkValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -469,7 +469,7 @@ it('sets the validity message with `setCustomValidity()`', async () => {
 
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -489,11 +489,11 @@ it('removes a validity message with an empty argument to `setCustomValidity()`',
   component.setCustomValidity('validity message');
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   component.setCustomValidity('');
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -510,7 +510,7 @@ it('is invalid when `setValidity()` is called', async () => {
 
   expect(component.validity.valid).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -522,7 +522,7 @@ it('is invalid when `setValidity()` is called', async () => {
 
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('input')?.getAttribute('aria-invalid'),
@@ -543,14 +543,14 @@ it('is valid when `setValidity()` is called', async () => {
 
   component.setValidity({});
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity.valid).to.be.true;
   expect(component.validity.customError).to.be.false;
 
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -584,7 +584,7 @@ it('removes validity feedback but retains its validity state when `resetValidity
 
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -593,7 +593,7 @@ it('removes validity feedback but retains its validity state when `resetValidity
 
   component.resetValidityFeedback();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.shadowRoot?.querySelector('[data-test="validity-message"]'))
     .to.be.null;

--- a/src/menu.test.focus.ts
+++ b/src/menu.test.focus.ts
@@ -2,14 +2,7 @@
 
 import './menu.link.js';
 import './menu.options.js';
-import {
-  assert,
-  aTimeout,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreMenu from './menu.js';
 
@@ -116,7 +109,7 @@ it('sets an inactive option as active when focused', async () => {
   const options = component.querySelector('glide-core-menu-options');
 
   link?.focus();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(link?.privateActive).to.be.true;
   expect(button?.privateActive).to.be.false;
@@ -147,7 +140,7 @@ it('sets an already active option as active when focused', async () => {
   const options = component.querySelector('glide-core-menu-options');
 
   button?.focus();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(button?.privateActive).to.be.true;
   expect(link?.privateActive).to.be.false;

--- a/src/menu.test.interactions.ts
+++ b/src/menu.test.interactions.ts
@@ -3,14 +3,7 @@
 import './menu.button.js';
 import './menu.options.js';
 import { LitElement } from 'lit';
-import {
-  assert,
-  aTimeout,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import { sendKeys } from '@web/test-runner-commands';
 import { click, hover } from './library/mouse.js';
@@ -271,7 +264,7 @@ it('closes when `open` is set programmatically', async () => {
   await aTimeout(0);
 
   component.open = false;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const defaultSlot =
     component?.shadowRoot?.querySelector<HTMLSlotElement>('slot:not([name])');
@@ -1414,7 +1407,7 @@ it('sets the first enabled option as active when optionless and options are dyna
   component.querySelector('glide-core-menu-options')?.append(firstOption);
   component.querySelector('glide-core-menu-options')?.append(secondOption);
   component.querySelector('glide-core-menu-options')?.append(thirdOption);
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(firstOption?.privateActive).to.be.false;
   expect(secondOption?.privateActive).to.be.true;
@@ -1490,7 +1483,7 @@ it('retains its active option when an option is dynamically added', async () => 
   button.label = 'Three';
 
   component.querySelector('glide-core-menu-options')?.append(button);
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const options = component.querySelectorAll('glide-core-menu-button');
 

--- a/src/modal.test.interactions.ts
+++ b/src/modal.test.interactions.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import { click } from './library/mouse.js';
 import GlideCoreModal from './modal.js';
@@ -13,7 +13,7 @@ it('opens', async () => {
   );
 
   component.open = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const dialog = component.shadowRoot?.querySelector('[data-test="component"]');
   expect(dialog?.checkVisibility()).to.be.true;
@@ -25,7 +25,7 @@ it('closes', async () => {
   );
 
   component.open = false;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const dialog = component.shadowRoot?.querySelector('[data-test="component"]');
   expect(dialog?.checkVisibility()).to.be.false;
@@ -112,7 +112,7 @@ it('unlocks scroll on close', async () => {
   );
 
   component.open = false;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     document.documentElement.classList.contains(

--- a/src/radio-group.radio.test.basics.ts
+++ b/src/radio-group.radio.test.basics.ts
@@ -1,4 +1,4 @@
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import GlideCoreRadioGroupRadio from './radio-group.radio.js';
 
 GlideCoreRadioGroupRadio.shadowRootOptions.mode = 'open';
@@ -22,7 +22,7 @@ it('renders the provided `label`', async () => {
     <glide-core-radio-group-radio label="One"></glide-core-radio-group-radio>
   `);
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot

--- a/src/radio-group.test.basics.ts
+++ b/src/radio-group.test.basics.ts
@@ -1,12 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import {
-  assert,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import GlideCoreRadioGroup from './radio-group.js';
 import GlideCoreRadioGroupRadio from './radio-group.radio.js';
 import expectArgumentError from './library/expect-argument-error.js';
@@ -211,14 +205,14 @@ it('renders Radios as disabled when `disabled` is programmatically set and remov
   expect(radio.shadowRoot?.querySelector('.disabled')).to.be.null;
 
   component.disabled = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(radio.hasAttribute('disabled')).to.be.true;
   expect(radio.getAttribute('aria-disabled')).to.equal('true');
   expect(radio.shadowRoot?.querySelector('.disabled')).to.be.not.null;
 
   component.disabled = false;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(radio).to.not.have.attribute('disabled');
   expect(radio.getAttribute('aria-disabled')).to.equal('false');
@@ -431,7 +425,7 @@ it('updates the tabbable state of each Radio based on programmatic updates to `c
   radios[0].checked = true;
   radios[1].checked = false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(radios[0].getAttribute('tabindex')).to.equal('0');
   expect(radios[1].getAttribute('tabindex')).to.equal('-1');
@@ -467,7 +461,7 @@ it('updates the tabbable state of each Radio based on programmatic updates to `v
 
   component.value = 'two';
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(radios[0].getAttribute('tabindex')).to.equal('-1');
   expect(radios[1].getAttribute('tabindex')).to.equal('0');

--- a/src/radio-group.test.focus.ts
+++ b/src/radio-group.test.focus.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import GlideCoreRadioGroup from './radio-group.js';
 import GlideCoreRadioGroupRadio from './radio-group.radio.js';
@@ -192,7 +192,7 @@ it('focuses the checked Radio using `value` on the group when `focus()` is calle
     </glide-core-radio-group>`,
   );
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   component.focus();
 

--- a/src/radio-group.test.forms.ts
+++ b/src/radio-group.test.forms.ts
@@ -1,12 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import {
-  assert,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { click } from './library/mouse.js';
@@ -58,11 +52,11 @@ it('can reset when `value` is programmatically changed', async () => {
 
   component.value = 'two';
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   form.reset();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.value).to.equal('one');
 });
@@ -100,7 +94,7 @@ it('can reset when the checked Radios are changed via click', async () => {
 
   form.reset();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(radios[0].getAttribute('checked')).to.be.null;
   expect(radios[1].hasAttribute('checked')).to.be.true;
@@ -135,7 +129,7 @@ it('can reset when the checked Radios are changed programmatically', async () =>
   radios[1].checked = false;
   radios[0].checked = true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(radios[0].hasAttribute('checked')).to.be.true;
   expect(radios[1]).to.not.have.attribute('checked');
@@ -143,7 +137,7 @@ it('can reset when the checked Radios are changed programmatically', async () =>
 
   form.reset();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(radios[0].getAttribute('checked')).to.be.null;
   expect(radios[1].hasAttribute('checked')).to.be.true;
@@ -381,7 +375,7 @@ it('resets `value` to an empty string when no Radios were initially selected', a
 
   form.reset();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.value).to.equal('');
 });
@@ -406,7 +400,7 @@ it('is valid if not required and radios are unchecked', async () => {
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const radios = component.querySelectorAll('glide-core-radio-group-radio');
   expect(radios[0].privateInvalid).to.be.false;
@@ -436,7 +430,7 @@ it('is valid if required and a radio is checked', async () => {
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const radios = component.querySelectorAll('glide-core-radio-group-radio');
   expect(radios[0].privateInvalid).to.be.false;
@@ -528,7 +522,7 @@ it('adds an error class after submit when invalid and required', async () => {
   );
 
   form.requestSubmit();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const isComponentErrorClass = component.shadowRoot
     ?.querySelector('.radio-container')
@@ -556,7 +550,7 @@ it('adds an error class after `reportValidity` is called when invalid and requir
   );
 
   component.reportValidity();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const isComponentErrorClass = component.shadowRoot
     ?.querySelector('.radio-container')
@@ -591,7 +585,7 @@ it('does not add an error class by default', async () => {
   );
 
   component.checkValidity();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const isComponentErrorClass = component.shadowRoot
     ?.querySelector('.radio-container')
@@ -638,7 +632,7 @@ it('does not add an error class after `reportValidity` is called when not requir
   );
 
   component.reportValidity();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const isComponentErrorClass = component.shadowRoot
     ?.querySelector('.radio-container')
@@ -686,7 +680,7 @@ it('does not add an error class after `reportValidity` is called when required a
   );
 
   component.reportValidity();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const isComponentErrorClass = component.shadowRoot
     ?.querySelector('.radio-container')
@@ -734,7 +728,7 @@ it('does not add an error class after `reportValidity` is called when required b
   );
 
   component.reportValidity();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const isComponentErrorClass = component.shadowRoot
     ?.querySelector('.radio-container')
@@ -781,7 +775,7 @@ it('does not add an error class after `checkValidity` is called when required', 
   );
 
   component.checkValidity();
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const isComponentErrorClass = component.shadowRoot
     ?.querySelector('.radio-container')
@@ -828,7 +822,7 @@ it('sets the group as valid when `required` is set to `false` dynamically', asyn
   );
 
   component.required = false;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   const radios = component.querySelectorAll('glide-core-radio-group-radio');
 
@@ -862,7 +856,7 @@ it('sets the group as invalid when `required` is set to `true` dynamically when 
   );
 
   component.required = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity.valid).to.be.false;
   expect(component.validity?.valueMissing).to.be.true;
@@ -909,7 +903,7 @@ it('sets the validity message with `setCustomValidity()`', async () => {
   expect(component.validity?.customError).to.be.true;
   expect(component.checkValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -919,7 +913,7 @@ it('sets the validity message with `setCustomValidity()`', async () => {
 
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -941,11 +935,11 @@ it('removes a validity message with an empty argument to `setCustomValidity()`',
   component.setCustomValidity('validity message');
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   component.setCustomValidity('');
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -967,7 +961,7 @@ it('is invalid when `setValidity()` is called', async () => {
 
   expect(component.validity.valid).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -979,7 +973,7 @@ it('is invalid when `setValidity()` is called', async () => {
 
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -1002,14 +996,14 @@ it('is valid when `setValidity()` is called', async () => {
 
   component.setValidity({});
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity.valid).to.be.true;
   expect(component.validity.customError).to.be.false;
 
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -1072,7 +1066,7 @@ it('removes validity feedback but retains its validity state when `resetValidity
 
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -1082,7 +1076,7 @@ it('removes validity feedback but retains its validity state when `resetValidity
 
   component.resetValidityFeedback();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.shadowRoot?.querySelector('[data-test="validity-message"]'))
     .to.be.null;

--- a/src/radio-group.test.interactions.ts
+++ b/src/radio-group.test.interactions.ts
@@ -1,13 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 import './radio-group.radio.js';
-import {
-  assert,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import { click } from './library/mouse.js';
 import GlideCoreRadioGroup from './radio-group.js';
@@ -237,7 +231,7 @@ it('updates `value` when the `checked` attribute of Radios are changed programma
   radios[0].checked = false;
   radios[1].checked = true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.value).to.equal('two');
 });
@@ -264,7 +258,7 @@ it('updates `value` when the `value` of a checked Radio is changed programmatica
 
   radio.value = 'three';
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.value).to.equal('three');
 });
@@ -291,7 +285,7 @@ it('updates `value` when the `value` of a checked Radio is emptied programmatica
 
   radio.value = '';
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.value).to.equal('');
 });

--- a/src/split-button.primary-button.test.basics.ts
+++ b/src/split-button.primary-button.test.basics.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import GlideCoreSplitButtonPrimaryButton from './split-button.primary-button.js';
 
 GlideCoreSplitButtonPrimaryButton.shadowRootOptions.mode = 'open';
@@ -21,7 +21,7 @@ it('is accessible', async () => {
   await expect(component).to.be.accessible();
 
   component.disabled = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   await expect(component).to.be.accessible();
 });

--- a/src/split-button.primary-link.test.basics.ts
+++ b/src/split-button.primary-link.test.basics.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import GlideCoreSplitButtonPrimaryLink from './split-button.primary-link.js';
 
 GlideCoreSplitButtonPrimaryLink.shadowRootOptions.mode = 'open';
@@ -22,7 +22,7 @@ it('is accessible', async () => {
   await expect(component).to.be.accessible();
 
   component.disabled = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   await expect(component).to.be.accessible();
 });

--- a/src/split-button.secondary-button.test.basics.ts
+++ b/src/split-button.secondary-button.test.basics.ts
@@ -1,12 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import {
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-  waitUntil,
-} from '@open-wc/testing';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
 import sinon from 'sinon';
 import GlideCoreMenuButton from './menu.button.js';
 import GlideCoreSplitButtonSecondaryButton from './split-button.secondary-button.js';
@@ -31,7 +25,7 @@ it('is accessible', async () => {
   await expect(component).to.be.accessible();
 
   component.disabled = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   await expect(component).to.be.accessible();
 });

--- a/src/tag.test.basics.ts
+++ b/src/tag.test.basics.ts
@@ -1,12 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import {
-  aTimeout,
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-} from '@open-wc/testing';
+import { aTimeout, expect, fixture, html } from '@open-wc/testing';
 import GlideCoreTag from './tag.js';
 
 GlideCoreTag.shadowRootOptions.mode = 'open';
@@ -26,7 +20,7 @@ it('is accessible', async () => {
   await expect(component).to.be.accessible();
 
   component.removable = true;
-  await elementUpdated(component);
+  await component.updateComplete;
 
   await expect(component).to.be.accessible();
 });

--- a/src/textarea.test.forms.ts
+++ b/src/textarea.test.forms.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import GlideCoreTextarea from './textarea.js';
@@ -134,7 +134,7 @@ it('is valid by default', async () => {
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -157,7 +157,7 @@ it('is valid after being filled in and required', async () => {
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -178,7 +178,7 @@ it('is invalid if no value and required', async () => {
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -198,7 +198,7 @@ it('is valid if no value but required and disabled', async () => {
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -217,7 +217,7 @@ it('updates validity when `required` and `value` is changed programmatically', a
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -227,14 +227,14 @@ it('updates validity when `required` and `value` is changed programmatically', a
 
   component.value = 'text';
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity?.valid).to.be.true;
   expect(component.validity?.valueMissing).to.be.false;
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -246,7 +246,7 @@ it('updates validity when `required` and `value` is changed programmatically', a
   // back to an invalid state
   component.value = '';
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity?.valid).to.be.false;
   expect(component.validity?.valueMissing).to.be.true;
@@ -270,7 +270,7 @@ it('is invalid when `value` is empty and `required` is set to `true` programmati
   expect(component.checkValidity()).to.be.true;
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -280,7 +280,7 @@ it('is invalid when `value` is empty and `required` is set to `true` programmati
 
   component.required = true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity?.valid).to.be.false;
   expect(component.validity?.valueMissing).to.be.true;
@@ -304,7 +304,7 @@ it('is valid when `value` is empty and `required` is set to `false` programmatic
   expect(component.checkValidity()).to.be.false;
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -314,7 +314,7 @@ it('is valid when `value` is empty and `required` is set to `false` programmatic
 
   component.required = false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity?.valid).to.be.true;
   expect(component.validity?.valueMissing).to.be.false;
@@ -360,7 +360,7 @@ it('sets the validity message with `setCustomValidity()`', async () => {
   expect(component.validity?.customError).to.be.true;
   expect(component.checkValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -370,7 +370,7 @@ it('sets the validity message with `setCustomValidity()`', async () => {
 
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -392,11 +392,11 @@ it('removes a validity message with an empty argument to `setCustomValidity()`',
   component.setCustomValidity('validity message');
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   component.setCustomValidity('');
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -413,7 +413,7 @@ it('is invalid when `setValidity()` is called', async () => {
 
   expect(component.validity.valid).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   // Like native, the validity message shouldn't display until `reportValidity()` is called.
   expect(
@@ -425,7 +425,7 @@ it('is invalid when `setValidity()` is called', async () => {
 
   component.reportValidity();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot
@@ -448,14 +448,14 @@ it('is valid when `setValidity()` is called', async () => {
 
   component.setValidity({});
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.validity.valid).to.be.true;
   expect(component.validity.customError).to.be.false;
 
   expect(component.reportValidity()).to.be.true;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -507,7 +507,7 @@ it('removes validity feedback but retains its validity state when `resetValidity
 
   expect(component.reportValidity()).to.be.false;
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(
     component.shadowRoot?.querySelector('[data-test="validity-message"]')
@@ -516,7 +516,7 @@ it('removes validity feedback but retains its validity state when `resetValidity
 
   component.resetValidityFeedback();
 
-  await elementUpdated(component);
+  await component.updateComplete;
 
   expect(component.shadowRoot?.querySelector('[data-test="validity-message"]'))
     .to.be.null;


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Open WC's `elementUpdated()` is useful when working with multiple web component libraries because it [abstracts](https://github.com/open-wc/open-wc/blob/master/packages/testing-helpers/src/elementUpdated.js) Lit's `updateComplete`, Stencil's `componentOnReady`, and Shady DOM's `ShadyDOM.flush()` with a single function.

But it's just an indirection in our case. We're only using Lit. And we don't expect consumers to polyfill custom elements using Shady DOM. So we can more simply and directly use await Lit's `updateComplete` throughout tests—just like we already do in component code. 

As a bonus, we'll be using one less helper from `@open-wc/testing`. Which will help free us up to remove it as a dependency when we move to Vitest one day. 

Vitest will force us to replace `oneEvent` with `sinon.spy` and `expect` with its own `expect`—leaving just `aTimeout` and `fixture` from `@open-wc/testing`.  And `aTimeout` and `fixture` are simple enough that we can replace them with our own implementations.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

If the tests pass we should be good.

## 📸 Images/Videos of Functionality

N/A