### PR TITLE
Restore Dropdown story options

### DIFF
--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -472,7 +472,7 @@ async (query: string): Promise<GlideCoreDropdownOption[]> {
     }
   },
   render(arguments_) {
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
+    /* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access  */
     return html`<glide-core-dropdown
       add-button-label=${arguments_['add-button-label'] || nothing}
       label=${arguments_.label || nothing}
@@ -492,6 +492,32 @@ async (query: string): Promise<GlideCoreDropdownOption[]> {
       ?select-all=${arguments_['select-all']}
       .value=${arguments_.value}
     >
+      <glide-core-dropdown-option
+        label=${arguments_['<glide-core-dropdown-option>.label'] || nothing}
+        value=${arguments_['<glide-core-dropdown-option>.one.value'] || nothing}
+        ?disabled=${arguments_['<glide-core-dropdown-option>.disabled']}
+        ?editable=${arguments_['<glide-core-dropdown-option>.editable']}
+        ?selected=${arguments_.value.includes(
+          arguments_['<glide-core-dropdown-option>.one.value'],
+        )}
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        ?selected=${arguments_.value.includes(
+          arguments_['<glide-core-dropdown-option>.two.value'],
+        )}
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+        ?selected=${arguments_.value.includes(
+          arguments_['<glide-core-dropdown-option>.three.value'],
+        )}
+      ></glide-core-dropdown-option>
+
       ${arguments_['slot="description"']
         ? html`<div slot="description">
             ${unsafeHTML(arguments_['slot="description"'])}


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

From [#614](https://github.com/CrowdStrike/glide-core/pull/614/files#r1920708921):

<img width="785" alt="image" src="https://github.com/user-attachments/assets/3f846326-38c1-47af-93be-b14f70fd5d6d" />

> Narrator: He did not revert that file before merging.


<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Dropdown in Storybook.
2. Verify it has options.

## 📸 Images/Videos of Functionality

N/A