### PR TITLE
Fix Dropdown Select All duplicate value bug

### DIFF
--- a/.changeset/lovely-forks-appear.md
+++ b/.changeset/lovely-forks-appear.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown no longer adds duplicate values to its `value` when an option is already selected and Select All is clicked.

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -148,7 +148,7 @@ export default [
       }
     }
 
-    .options-slot {
+    .default-slot {
       display: block;
       padding: var(--glide-core-spacing-xxxs);
     }

--- a/src/dropdown.test.interactions.multiple.ts
+++ b/src/dropdown.test.interactions.multiple.ts
@@ -93,8 +93,15 @@ it('selects options on click', async () => {
       open
       multiple
     >
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -114,6 +121,47 @@ it('selects options on click', async () => {
   expect(labels?.length).to.equal(2);
   expect(labels?.[0]?.textContent?.trim()).to.equal('One,');
   expect(labels?.[1]?.textContent?.trim()).to.equal('Two,');
+  expect(component.value).to.deep.equal(['one', 'two']);
+});
+
+it('deselects options on click', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      open
+      multiple
+    >
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  const options = component.querySelectorAll('glide-core-dropdown-option');
+
+  await click(options[0]);
+  await click(options[1]);
+
+  const labels = component.shadowRoot?.querySelectorAll(
+    '[data-test="selected-option-label"]',
+  );
+
+  expect(options[0]?.selected).to.be.false;
+  expect(options[1]?.selected).to.be.false;
+  expect(labels?.length).to.equal(0);
+  expect(component.value).to.deep.equal([]);
 });
 
 it('does not select a disabled option on click', async () => {
@@ -126,6 +174,7 @@ it('does not select a disabled option on click', async () => {
     >
       <glide-core-dropdown-option
         label="One"
+        value="one"
         disabled
       ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
@@ -144,6 +193,7 @@ it('does not select a disabled option on click', async () => {
 
   expect(option?.selected).to.be.false;
   expect(labels?.length).to.equal(0);
+  expect(component.value).to.deep.equal([]);
 });
 
 it('selects options on Space', async () => {
@@ -154,8 +204,15 @@ it('selects options on Space', async () => {
       multiple
       open
     >
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -181,6 +238,52 @@ it('selects options on Space', async () => {
   expect(labels?.length).to.equal(2);
   expect(labels?.[0]?.textContent?.trim()).to.equal('One,');
   expect(labels?.[1]?.textContent?.trim()).to.equal('Two,');
+  expect(component.value).to.deep.equal(['one', 'two']);
+});
+
+it('deselects options on Space', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      multiple
+      open
+    >
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  const options = component.querySelectorAll('glide-core-dropdown-option');
+
+  options[0]?.focus();
+  await sendKeys({ press: ' ' });
+
+  options[1]?.focus();
+  await sendKeys({ press: ' ' });
+
+  await elementUpdated(component);
+
+  const labels = component.shadowRoot?.querySelectorAll(
+    '[data-test="selected-option-label"]',
+  );
+
+  expect(options[0]?.selected).to.be.false;
+  expect(options[1]?.selected).to.be.false;
+  expect(labels?.length).to.equal(0);
+  expect(component.value).to.deep.equal([]);
 });
 
 it('selects options on Enter', async () => {
@@ -191,8 +294,15 @@ it('selects options on Enter', async () => {
       multiple
       open
     >
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -216,6 +326,50 @@ it('selects options on Enter', async () => {
   expect(labels?.length).to.equal(2);
   expect(labels?.[0]?.textContent?.trim()).to.equal('One,');
   expect(labels?.[1]?.textContent?.trim()).to.equal('Two,');
+  expect(component.value).to.deep.equal(['one', 'two']);
+});
+
+it('deselects options on Enter', async () => {
+  const component = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown
+      label="Label"
+      placeholder="Placeholder"
+      multiple
+      open
+    >
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  const options = component.querySelectorAll('glide-core-dropdown-option');
+
+  options[0]?.focus();
+  await sendKeys({ press: 'Enter' });
+
+  options[1]?.focus();
+  await sendKeys({ press: 'Enter' });
+
+  const labels = component.shadowRoot?.querySelectorAll(
+    '[data-test="selected-option-label"]',
+  );
+
+  expect(options[0]?.selected).to.be.false;
+  expect(options[1]?.selected).to.be.false;
+  expect(labels?.length).to.equal(0);
+  expect(component.value).to.deep.equal([]);
 });
 
 it('activates Select All by default', async () => {
@@ -506,45 +660,6 @@ it('selects no options when `value` is changed programmatically to an empty stri
   expect(options[2].selected).to.be.false;
 });
 
-it('updates `value` when an option is selected or deselected via click', async () => {
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown
-      label="Label"
-      placeholder="Placeholder"
-      open
-      multiple
-    >
-      <glide-core-dropdown-option
-        label="One"
-        value="one"
-        selected
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option
-        label="Two"
-        value="two"
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  const options = component.querySelectorAll('glide-core-dropdown-option');
-
-  await click(options[1]);
-
-  expect(component.value).to.deep.equal(['one', 'two']);
-
-  await click(options[1]);
-  expect(component.value).to.deep.equal(['one']);
-
-  await click(options[2]);
-  expect(component.value).to.deep.equal(['one']);
-});
-
 it('does not update `value` when a disabled option is selected via click', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown
@@ -567,86 +682,6 @@ it('does not update `value` when a disabled option is selected via click', async
   await click(component.querySelector('glide-core-dropdown-option'));
 
   expect(component.value).to.deep.equal([]);
-});
-
-it('updates `value` when a option is selected or deselected via Enter', async () => {
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown
-      label="Label"
-      placeholder="Placeholder"
-      open
-      multiple
-    >
-      <glide-core-dropdown-option
-        label="One"
-        value="one"
-        selected
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option
-        label="Two"
-        value="two"
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  component.focus();
-
-  await sendKeys({ press: 'ArrowDown' });
-  await sendKeys({ press: 'Enter' });
-  expect(component.value).to.deep.equal(['one', 'two']);
-
-  await sendKeys({ press: 'Enter' });
-  expect(component.value).to.deep.equal(['one']);
-
-  await sendKeys({ press: 'ArrowDown' });
-  await sendKeys({ press: 'Enter' });
-  expect(component.value).to.deep.equal(['one']);
-});
-
-it('updates `value` when an option is selected or deselected via Space', async () => {
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown
-      label="Label"
-      placeholder="Placeholder"
-      open
-      multiple
-    >
-      <glide-core-dropdown-option
-        label="One"
-        value="one"
-        selected
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option
-        label="Two"
-        value="two"
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  component.focus();
-
-  await sendKeys({ press: 'ArrowDown' });
-  await sendKeys({ press: ' ' });
-  expect(component.value).to.deep.equal(['one', 'two']);
-
-  await sendKeys({ press: ' ' });
-  expect(component.value).to.deep.equal(['one']);
-
-  await sendKeys({ press: 'ArrowDown' });
-  await sendKeys({ press: ' ' });
-  expect(component.value).to.deep.equal(['one']);
 });
 
 it('updates `value` when multiselect is changed to `true` programmatically', async () => {
@@ -736,35 +771,6 @@ it('updates `value` when the `value` of a selected option is emptied programmati
   const option = component.querySelector('glide-core-dropdown-option');
   assert(option);
   option.value = '';
-
-  expect(component.value).to.deep.equal(['two']);
-});
-
-it('updates `value` when a tag is removed', async () => {
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown
-      label="Label"
-      placeholder="Placeholder"
-      open
-      multiple
-    >
-      <glide-core-dropdown-option
-        label="One"
-        value="one"
-        selected
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option
-        label="Two"
-        value="two"
-        selected
-      ></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  component.shadowRoot
-    ?.querySelector<GlideCoreTag>('[data-test="tag"]')
-    ?.click();
 
   expect(component.value).to.deep.equal(['two']);
 });
@@ -898,7 +904,7 @@ it('has overflow text when its tags are overflowing', async () => {
   expect(tagOverflow?.textContent?.trim()).to.equal('2');
 });
 
-it('deselects the option when its tag is removed', async () => {
+it('deselects an option when its tag is removed', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown
       label="Label"
@@ -908,10 +914,15 @@ it('deselects the option when its tag is removed', async () => {
     >
       <glide-core-dropdown-option
         label="One"
+        value="one"
         selected
       ></glide-core-dropdown-option>
 
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -919,8 +930,11 @@ it('deselects the option when its tag is removed', async () => {
     ?.querySelector<GlideCoreTag>('[data-test="tag"]')
     ?.click();
 
-  const option = component.querySelector('glide-core-dropdown-option');
-  expect(option?.selected).to.be.false;
+  const options = component.querySelectorAll('glide-core-dropdown-option');
+
+  expect(options[0].selected).to.be.false;
+  expect(options[1].selected).to.be.true;
+  expect(component.value).to.deep.equal(['two']);
 });
 
 it('deselects all but the last selected option when `multiple` is changed to `false` programmatically', async () => {
@@ -933,22 +947,32 @@ it('deselects all but the last selected option when `multiple` is changed to `fa
     >
       <glide-core-dropdown-option
         label="One"
+        value="one"
         selected
       ></glide-core-dropdown-option>
 
       <glide-core-dropdown-option
         label="Two"
+        value="two"
         selected
       ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
   component.multiple = false;
+  await component.updateComplete;
 
   const options = component.querySelectorAll('glide-core-dropdown-option');
 
+  const labels = component.shadowRoot?.querySelectorAll(
+    '[data-test="selected-option-label"]',
+  );
+
   expect(options[0].selected).be.false;
   expect(options[1].selected).be.true;
+  expect(labels?.length).to.equal(1);
+  expect(labels?.[0]?.textContent?.trim()).to.equal('Two,');
+  expect(component.value).to.deep.equal(['two']);
 });
 
 it('selects all enabled options when none are selected and Select All is selected via click', async () => {
@@ -965,8 +989,15 @@ it('selects all enabled options when none are selected and Select All is selecte
         disabled
       ></glide-core-dropdown-option>
 
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -980,6 +1011,7 @@ it('selects all enabled options when none are selected and Select All is selecte
   expect(options[0].selected).to.be.false;
   expect(options[1].selected).to.be.true;
   expect(options[2].selected).to.be.true;
+  expect(component.value).to.deep.equal(['two', 'three']);
 });
 
 it('selects all enabled options when some are selected and Select All is selected via click', async () => {
@@ -993,16 +1025,25 @@ it('selects all enabled options when some are selected and Select All is selecte
     >
       <glide-core-dropdown-option
         label="One"
+        value="one"
         selected
       ></glide-core-dropdown-option>
 
       <glide-core-dropdown-option
         label="Two"
+        value="two"
         disabled
       ></glide-core-dropdown-option>
 
-      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Four"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Four"
+        value="four"
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -1017,6 +1058,7 @@ it('selects all enabled options when some are selected and Select All is selecte
   expect(options[1].selected).to.be.false;
   expect(options[2].selected).to.be.true;
   expect(options[3].selected).to.be.true;
+  expect(component.value).to.deep.equal(['one', 'three', 'four']);
 });
 
 it('deselects all options when all are selected and Select All is selected via click', async () => {
@@ -1053,6 +1095,7 @@ it('deselects all options when all are selected and Select All is selected via c
 
   expect(options[0].selected).to.be.false;
   expect(options[1].selected).to.be.false;
+  expect(component.value).to.deep.equal([]);
 });
 
 it('selects all enabled options when none are selected and Select All is selected via Space', async () => {
@@ -1066,11 +1109,19 @@ it('selects all enabled options when none are selected and Select All is selecte
     >
       <glide-core-dropdown-option
         label="One"
+        value="one"
         disabled
       ></glide-core-dropdown-option>
 
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -1085,6 +1136,7 @@ it('selects all enabled options when none are selected and Select All is selecte
   expect(options[0].selected).to.be.false;
   expect(options[1].selected).to.be.true;
   expect(options[2].selected).to.be.true;
+  expect(component.value).to.deep.equal(['two', 'three']);
 });
 
 it('selects all options when some are selected and Select All is selected via Space', async () => {
@@ -1098,10 +1150,14 @@ it('selects all options when some are selected and Select All is selected via Sp
     >
       <glide-core-dropdown-option
         label="One"
+        value="one"
         selected
       ></glide-core-dropdown-option>
 
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -1116,6 +1172,7 @@ it('selects all options when some are selected and Select All is selected via Sp
 
   expect(options[0].selected).to.be.true;
   expect(options[1].selected).to.be.true;
+  expect(component.value).to.deep.equal(['one', 'two']);
 });
 
 it('deselects all options when all are selected and Select All is selected via Space', async () => {
@@ -1129,11 +1186,13 @@ it('deselects all options when all are selected and Select All is selected via S
     >
       <glide-core-dropdown-option
         label="One"
+        value="one"
         selected
       ></glide-core-dropdown-option>
 
       <glide-core-dropdown-option
         label="Two"
+        value="two"
         selected
       ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
@@ -1150,6 +1209,7 @@ it('deselects all options when all are selected and Select All is selected via S
 
   expect(options[0].selected).to.be.false;
   expect(options[1].selected).to.be.false;
+  expect(component.value).to.deep.equal([]);
 });
 
 it('selects all enabled options when none are selected and Select All is selected via Enter', async () => {
@@ -1163,11 +1223,19 @@ it('selects all enabled options when none are selected and Select All is selecte
     >
       <glide-core-dropdown-option
         label="One"
+        value="one"
         disabled
       ></glide-core-dropdown-option>
 
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -1182,9 +1250,10 @@ it('selects all enabled options when none are selected and Select All is selecte
   expect(options[0].selected).to.be.false;
   expect(options[1].selected).to.be.true;
   expect(options[2].selected).to.be.true;
+  expect(component.value).to.deep.equal(['two', 'three']);
 });
 
-it('selects all options when some are selected and Select All is selected via Enter', async () => {
+it('selects all enabled options when some are selected and Select All is selected via Enter', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown
       label="Label"
@@ -1195,16 +1264,25 @@ it('selects all options when some are selected and Select All is selected via En
     >
       <glide-core-dropdown-option
         label="One"
+        value="one"
         selected
       ></glide-core-dropdown-option>
 
       <glide-core-dropdown-option
         label="Two"
+        value="two"
         disabled
       ></glide-core-dropdown-option>
 
-      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Four"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Four"
+        value="four"
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -1221,6 +1299,7 @@ it('selects all options when some are selected and Select All is selected via En
   expect(options[1].selected).to.be.false;
   expect(options[2].selected).to.be.true;
   expect(options[3].selected).to.be.true;
+  expect(component.value).to.deep.equal(['one', 'three', 'four']);
 });
 
 it('deselects all options when all are selected and Select All is selected via Enter', async () => {
@@ -1234,11 +1313,13 @@ it('deselects all options when all are selected and Select All is selected via E
     >
       <glide-core-dropdown-option
         label="One"
+        value="one"
         selected
       ></glide-core-dropdown-option>
 
       <glide-core-dropdown-option
         label="Two"
+        value="two"
         selected
       ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
@@ -1255,6 +1336,7 @@ it('deselects all options when all are selected and Select All is selected via E
 
   expect(options[0].selected).to.be.false;
   expect(options[1].selected).to.be.false;
+  expect(component.value).to.deep.equal([]);
 });
 
 it('shows Select All when it is set programmatically', async () => {

--- a/src/dropdown.test.interactions.single.ts
+++ b/src/dropdown.test.interactions.single.ts
@@ -57,7 +57,10 @@ it('toggles open and closed when the primary button is clicked', async () => {
 it('selects an option on click', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -75,6 +78,7 @@ it('selects an option on click', async () => {
   expect(option?.selected).to.be.true;
   expect(labels?.length).to.equal(1);
   expect(labels?.[0]?.textContent?.trim()).to.equal('One,');
+  expect(component.value).to.deep.equal(['one']);
 });
 
 it('does not select a disabled option on click', async () => {
@@ -82,6 +86,7 @@ it('does not select a disabled option on click', async () => {
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
       <glide-core-dropdown-option
         label="One"
+        value="one"
         disabled
       ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
@@ -100,6 +105,7 @@ it('does not select a disabled option on click', async () => {
 
   expect(option?.selected).to.be.false;
   expect(labels?.length).to.equal(0);
+  expect(component.value).to.deep.equal([]);
 });
 
 it('selects an option on Space', async () => {
@@ -120,7 +126,14 @@ it('selects an option on Space', async () => {
   option?.focus();
   await sendKeys({ press: ' ' });
 
+  const labels = component.shadowRoot?.querySelectorAll(
+    '[data-test="selected-option-label"]',
+  );
+
   expect(option?.selected).to.be.true;
+  expect(labels?.length).to.equal(1);
+  expect(labels?.[0]?.textContent?.trim()).to.equal('One,');
+  expect(component.value).to.deep.equal(['one']);
 });
 
 it('selects an option when its icon is clicked', async () => {
@@ -155,7 +168,14 @@ it('selects an option when its icon is clicked', async () => {
 
   await click(option?.querySelector('[slot="icon"]'));
 
+  const labels = component.shadowRoot?.querySelectorAll(
+    '[data-test="selected-option-label"]',
+  );
+
   expect(option?.selected).to.be.true;
+  expect(labels?.length).to.equal(1);
+  expect(labels?.[0]?.textContent?.trim()).to.equal('One,');
+  expect(component.value).to.deep.equal(['one']);
 });
 
 it('does not deselect options on Space', async () => {
@@ -176,13 +196,24 @@ it('does not deselect options on Space', async () => {
   await sendKeys({ press: ' ' });
 
   const option = component.querySelector('glide-core-dropdown-option');
+
+  const labels = component.shadowRoot?.querySelectorAll(
+    '[data-test="selected-option-label"]',
+  );
+
   expect(option?.selected).to.be.true;
+  expect(labels?.length).to.equal(1);
+  expect(labels?.[0]?.textContent?.trim()).to.equal('One,');
+  expect(component.value).to.deep.equal(['one']);
 });
 
 it('selects an option on Enter', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -193,14 +224,20 @@ it('selects an option on Enter', async () => {
   option?.focus();
   await sendKeys({ press: 'Enter' });
 
+  const labels = component.shadowRoot?.querySelectorAll(
+    '[data-test="selected-option-label"]',
+  );
+
   expect(option?.selected).to.be.true;
+  expect(labels?.length).to.equal(1);
+  expect(labels?.[0]?.textContent?.trim()).to.equal('One,');
+  expect(component.value).to.deep.equal(['one']);
 });
 
 it('deactivates all other options when an option is hovered', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
@@ -340,11 +377,19 @@ it('deselects all other options when one is newly selected', async () => {
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
       <glide-core-dropdown-option
         label="One"
+        value="two"
         selected
       ></glide-core-dropdown-option>
 
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
@@ -358,6 +403,7 @@ it('deselects all other options when one is newly selected', async () => {
   expect(options[0].selected).to.be.false;
   expect(options[1].selected).to.be.true;
   expect(options[2].selected).to.be.false;
+  expect(component.value).to.deep.equal(['two']);
 });
 
 it('updates its internal label when `label` of the selected option is changed programmatically', async () => {
@@ -476,54 +522,6 @@ it('updates `value` when an option `value` is changed programmatically', async (
   expect(component.value).to.deep.equal(['two']);
 });
 
-it('updates `value` when an option is selected via click', async () => {
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
-      <glide-core-dropdown-option
-        label="One"
-        value="one"
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option
-        label="Two"
-        value="two"
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  const options = component.querySelectorAll('glide-core-dropdown-option');
-
-  await click(options[1]);
-  expect(component.value).to.deep.equal(['two']);
-
-  // Reopen it.
-  await click(
-    component.shadowRoot?.querySelector('[data-test="primary-button"]'),
-  );
-
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  await click(options[1]);
-  expect(component.value).to.deep.equal(['two']);
-
-  // Reopen it.
-  await click(
-    component.shadowRoot?.querySelector('[data-test="primary-button"]'),
-  );
-
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  await click(options[2]);
-  expect(component.value).to.deep.equal([]);
-});
-
 it('does not update `value` when a disabled option is selected via click', async () => {
   const component = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" placeholder="Placeholder" open>
@@ -539,94 +537,6 @@ it('does not update `value` when a disabled option is selected via click', async
   await aTimeout(0);
 
   await click(component.querySelector('glide-core-dropdown-option'));
-
-  expect(component.value).to.deep.equal([]);
-});
-
-it('updates `value` when an option is selected via Enter', async () => {
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown open>
-      <glide-core-dropdown-option
-        label="One"
-        value="one"
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option
-        label="Two"
-        value="two"
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  const options = component.querySelectorAll('glide-core-dropdown-option');
-
-  options[0].focus();
-  await sendKeys({ press: 'Enter' });
-  expect(component.value).to.deep.equal(['one']);
-
-  // Reopen it.
-  component.focus();
-  await sendKeys({ press: ' ' });
-
-  options[1].focus();
-  await sendKeys({ press: 'Enter' });
-  expect(component.value).to.deep.equal(['two']);
-
-  // Reopen it.
-  component.focus();
-  await sendKeys({ press: ' ' });
-
-  options[2].focus();
-  await sendKeys({ press: 'Enter' });
-  expect(component.value).to.deep.equal([]);
-});
-
-it('updates `value` when an option is selected via Space', async () => {
-  const component = await fixture<GlideCoreDropdown>(
-    html`<glide-core-dropdown open>
-      <glide-core-dropdown-option
-        label="One"
-        value="one"
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option
-        label="Two"
-        value="two"
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  const options = component.querySelectorAll('glide-core-dropdown-option');
-
-  options[0].focus();
-  await sendKeys({ press: ' ' });
-  expect(component.value).to.deep.equal(['one']);
-
-  // Reopen it.
-  component.focus();
-  await sendKeys({ press: ' ' });
-
-  options[1].focus();
-  await sendKeys({ press: ' ' });
-
-  expect(component.value).to.deep.equal(['two']);
-
-  // Reopen it.
-  component.focus();
-  await sendKeys({ press: ' ' });
-
-  options[2].focus();
-  await sendKeys({ press: ' ' });
 
   expect(component.value).to.deep.equal([]);
 });

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -865,7 +865,7 @@ export default class GlideCoreDropdown extends LitElement {
               ></glide-core-dropdown-option>
 
               <slot
-                class="options-slot"
+                class="default-slot"
                 @slotchange=${this.#onDefaultSlotChange}
                 ${ref(this.#defaultSlotElementRef)}
               ></slot>
@@ -2294,8 +2294,15 @@ export default class GlideCoreDropdown extends LitElement {
     this.#isSelectionChangeFromSelectAll = true;
 
     for (const option of this.#optionElements) {
-      option.selected =
-        this.#selectAllElementRef.value.selected && !option.disabled;
+      if (
+        this.#selectAllElementRef.value.selected &&
+        !option.selected &&
+        !option.disabled
+      ) {
+        option.selected = true;
+      } else if (!this.#selectAllElementRef.value.selected && option.selected) {
+        option.selected = false;
+      }
     }
 
     this.#isSelectionChangeFromSelectAll = false;


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Dropdown no longer adds duplicate values to its `value` when an option is already selected and Select All is clicked.


<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to multiselect Dropdown with Select All in Storybook.
2. Select an option.
3. Select Select All.
4. Verify Dropdown's `value` only contains one of every value.

## 📸 Images/Videos of Functionality

N/A