### PR TITLE
Remove the minimum width on Dropdown's input field

### DIFF
--- a/.changeset/neat-pigs-protect.md
+++ b/.changeset/neat-pigs-protect.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown's input field no longer has a minimum width, allowing it contract when its container is sized-constrained.
+Dropdown as a whole still has a total minimum width of 150 pixels.

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -348,7 +348,7 @@ export default [
       flex-grow: 1;
       font-family: var(--glide-core-font-sans);
       font-size: inherit;
-      min-inline-size: var(--min-inline-size);
+      inline-size: 100%;
       padding-block-end: 0;
       padding-inline: 0;
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Dropdown's input field no longer has a minimum width, allowing it contract when its container is sized-constrained.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to [filterable Dropdown](https://glide-core.crowdstrike-ux.workers.dev/remove-dropdown-input-minimum-width?path=/story/dropdown--dropdown&args=filterable:!true) in Storybook.
2. Reduce the size of the viewport to its smallest size.
3. Verify Dropdown's input field shrinks down to 100 pixels.

## 📸 Images/Videos of Functionality

N/A