### PR TITLE
Statically position filterable Dropdown's ellipsis

### DIFF
--- a/.changeset/tough-penguins-hope.md
+++ b/.changeset/tough-penguins-hope.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Filterable Dropdown's truncation ellipsis now blends in better with Dropdown's background when in dark mode.

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -62,7 +62,8 @@ const meta: Meta = {
     value: [],
     variant: '',
     version: '',
-    '<glide-core-dropdown-option>.label': 'One',
+    '<glide-core-dropdown-option>.label':
+      'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
     '<glide-core-dropdown-option>.addEventListener(event, handler)': false,
     '<glide-core-dropdown-option>.disabled': false,
     '<glide-core-dropdown-option>.editable': false,

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -336,6 +336,7 @@ export default [
     }
 
     .input-container {
+      align-items: baseline;
       display: flex;
       flex-grow: 1;
     }
@@ -368,19 +369,6 @@ export default [
         color: var(--glide-core-text-placeholder);
         font-family: var(--glide-core-font-sans);
       }
-    }
-
-    .ellipsis {
-      background-color: var(--glide-core-surface-page);
-      inset-block-end: 0;
-      inset-inline-end: 0;
-
-      /*
-        0.125rem so the value is vertically aligned with the value of ".input", which
-        has the same padding so it's centered vertically.
-      */
-      padding-block-start: 0.125rem;
-      position: absolute;
     }
 
     .description {

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -413,8 +413,13 @@ export default class GlideCoreDropdown extends LitElement {
     if (this.#inputElementRef.value) {
       const observer = new ResizeObserver(() => {
         if (this.#inputElementRef.value) {
+          // One is subtracted to account for an apparent Chrome bug when the viewport
+          // is reduced in size and the `<input>` is overflowing, then increased in size
+          // so its not overflowing. If you log `scrollWidth` and `clientWidth` you'll
+          // see the bug. In Safari and Firefox the two are equal upon increasing the
+          // size of the viewport.
           this.isInputOverflow =
-            this.#inputElementRef.value.scrollWidth >
+            this.#inputElementRef.value.scrollWidth - 1 >
             this.#inputElementRef.value.clientWidth;
         }
       });
@@ -678,11 +683,7 @@ export default class GlideCoreDropdown extends LitElement {
                     this.isInputOverflow &&
                     this.inputValue === this.selectedOptions.at(-1)?.label,
                   () => {
-                    return html`<span
-                      aria-hidden="true"
-                      class="ellipsis"
-                      data-test="ellipsis"
-                    >
+                    return html`<span aria-hidden="true" data-test="ellipsis">
                       …
                     </span>`;
                   },


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Statically positioning filterable Dropdown's ellipsis let me get rid of the ellipsis's background color so it blends in in dark mode.
<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to filterable Dropdown in Storybook.
2. Select the first option.
3. Shrink the viewport until Dropdown truncates the first option's label.
4. Verify that the ellipsis blends in.

## 📸 Images/Videos of Functionality

It's barely noticeable in Storybook below. But it's pretty apparent on a lighter but still dark background.

| Before  | After |
| ------- | ----- |
|  <img width="586" alt="image" src="https://github.com/user-attachments/assets/077d19ea-af53-4393-bb1a-6c46a641ffa9" />  | <img width="587" alt="image" src="https://github.com/user-attachments/assets/847392fb-0ed2-46f2-af24-994fa1ae248a" /> |


