### PR TITLE
Add `@final` decorator

### DIFF
--- a/src/library/final.test.ts
+++ b/src/library/final.test.ts
@@ -1,0 +1,41 @@
+import { LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { expect } from '@open-wc/testing';
+import sinon from 'sinon';
+import final from './final.js';
+
+@customElement('glide-core-final')
+@final
+class GlideCoreFinal extends LitElement {}
+
+@customElement('glide-core-extended')
+class GlideCoreExtended extends GlideCoreFinal {}
+
+it('throws when a class is extended', async () => {
+  const spy = sinon.spy();
+
+  try {
+    new GlideCoreExtended();
+  } catch (error) {
+    spy(error);
+  }
+
+  expect(spy.callCount).to.equal(1);
+  expect(spy.args.at(0)?.at(0) instanceof TypeError).to.be.true;
+
+  expect(spy.args.at(0)?.at(0).message).to.equal(
+    'GlideCoreFinal does not allow extension.',
+  );
+});
+
+it('does not throw when a class is not extended', () => {
+  const spy = sinon.spy();
+
+  try {
+    new GlideCoreFinal();
+  } catch (error) {
+    spy(error);
+  }
+
+  expect(spy.callCount).to.equal(0);
+});

--- a/src/library/final.ts
+++ b/src/library/final.ts
@@ -1,0 +1,16 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function <Type extends new (...arguments_: any[]) => object>(
+  constructor: Type,
+) {
+  return class Final extends constructor {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(...arguments_: any[]) {
+      if (new.target !== Final) {
+        throw new TypeError(`${constructor.name} does not allow extension.`);
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      super(...arguments_);
+    }
+  };
+}


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Design consistency is one of the primary goals of the overall project. Glide Core tries to do its part by:

- Closing component shadow roots.
- Preferring attributes to slots.
- Marking private properties and methods as such.

Consumers, however, are still free to extend our components and do whatever this wish. 

They can override `render()`, for example, reproduce most of our markup, and then add whatever markup they need. They can even override our private properties and methods. We've already had one case of someone doing the former.

So I've added a `@final` decorator that causes a class to throw when it's extended. I propose we decorate our components with it:

```ts
import final from './library/final.js';

@customElement('glide-core-accordion')
@final
export default class GlideCoreAccordion extends LitElement {}
```

Yeah? If this looks good I'll add it to each of our components in a followup PR.



## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

We're good if the two tests pass.

## 📸 Images/Videos of Functionality

N/A