### PR TITLE
Move test-only rules to their own block

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,18 +38,12 @@ export default [
     rules: {
       '@crowdstrike/glide-core/consistent-reference-element-declarations':
         'error',
-      '@crowdstrike/glide-core/consistent-test-fixture-variable-declarator':
-        'error',
       '@crowdstrike/glide-core/no-glide-core-prefixed-event-name': 'error',
       '@crowdstrike/glide-core/no-nested-template-literals': 'error',
-      '@crowdstrike/glide-core/no-only-tests': 'error',
       '@crowdstrike/glide-core/no-redundant-property-attribute': 'error',
       '@crowdstrike/glide-core/no-redundant-property-string-type': 'error',
-      '@crowdstrike/glide-core/no-skip-tests': 'error',
       '@crowdstrike/glide-core/no-space-press': 'error',
-      '@crowdstrike/glide-core/no-to-have-attribute': 'error',
       '@crowdstrike/glide-core/prefer-shadow-root-mode': 'error',
-      '@crowdstrike/glide-core/prefer-to-be-true-or-false': 'error',
       '@crowdstrike/glide-core/prefixed-lit-element-class-declaration': 'error',
 
       // Enabling this rule would force us to `await` any function that returns a promise.
@@ -306,6 +300,13 @@ export default [
       // One-off components in tests can do whatever they need to with their shadow
       // roots. Though most will stick with Lit's default, which is open.
       '@crowdstrike/glide-core/prefer-shadow-root-mode': 'off',
+
+      '@crowdstrike/glide-core/consistent-test-fixture-variable-declarator':
+        'error',
+      '@crowdstrike/glide-core/no-only-tests': 'error',
+      '@crowdstrike/glide-core/no-skip-tests': 'error',
+      '@crowdstrike/glide-core/no-to-have-attribute': 'error',
+      '@crowdstrike/glide-core/prefer-to-be-true-or-false': 'error',
     },
   },
 ];


### PR DESCRIPTION
## 🚀 Description

A little optimization to only run test-specific lint rules against test files and not "source" files. Also helps a bit with organization.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A