### PR TITLE
Make Dropdown's `placeholder` attribute optional

### DIFF
--- a/.changeset/late-forks-eat.md
+++ b/.changeset/late-forks-eat.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown's `placeholder` attribute is now optional.

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -35,7 +35,6 @@ const meta: Meta = {
   },
   args: {
     label: 'Label',
-    placeholder: 'Placeholder',
     'slot="default"': '',
     'add-button-label': '',
     'addEventListener(event, handler)': '',
@@ -48,6 +47,7 @@ const meta: Meta = {
     name: '',
     open: false,
     orientation: 'horizontal',
+    placeholder: '',
     readonly: false,
     'reportValidity()': '',
     required: false,
@@ -77,12 +77,6 @@ const meta: Meta = {
   },
   argTypes: {
     label: {
-      table: {
-        type: { summary: 'string' },
-      },
-      type: { name: 'string', required: true },
-    },
-    placeholder: {
       table: {
         type: { summary: 'string' },
       },
@@ -187,6 +181,11 @@ async (query: string): Promise<GlideCoreDropdownOption[]> {
       table: {
         defaultValue: { summary: '"horizontal"' },
         type: { summary: '"horizontal" | "vertical"' },
+      },
+    },
+    placeholder: {
+      table: {
+        type: { summary: 'string' },
       },
     },
     readonly: {

--- a/src/input.stories.ts
+++ b/src/input.stories.ts
@@ -44,7 +44,7 @@ const meta: Meta = {
     orientation: 'horizontal',
     'password-toggle': false,
     pattern: '',
-    placeholder: 'Placeholder',
+    placeholder: '',
     readonly: false,
     'reportValidity()': '',
     required: false,

--- a/src/textarea.stories.ts
+++ b/src/textarea.stories.ts
@@ -70,7 +70,7 @@ const meta: Meta = {
     maxlength: '',
     name: '',
     orientation: 'horizontal',
-    placeholder: 'Placeholder',
+    placeholder: '',
     readonly: false,
     'reportValidity()': '',
     required: false,


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Talked to Design. Dropdown's `placeholder` attribute is optional. So I've updated Storybook to show that. 

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

Just a quick Storybook spotcheck.

## 📸 Images/Videos of Functionality

N/A