### PR TITLE
Add "add" Dropdown event documentation

### DIFF
--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -99,7 +99,7 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail:
-            '(event: "change" | "input" | "invalid" | "toggle", handler: (event: Event) => void): void',
+            '(event: "add" | "change" | "input" | "invalid" | "toggle", handler: (event: Event) => void): void',
         },
       },
     },


### PR DESCRIPTION
## 🚀 Description

I noticed we were missing `add` in our event listener docs for dropdown.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality
N/A