### PR TITLE
Add JSDoc comments for multi-word property names

### DIFF
--- a/.changeset/itchy-moles-talk.md
+++ b/.changeset/itchy-moles-talk.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Added JSDoc `@attribute` information so that tools like [lit-analyzer](https://github.com/runem/lit-analyzer) will properly parse multi-word property names.

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -21,6 +21,8 @@ declare global {
 }
 
 /**
+ * @attribute {Boolean} hide-label
+ *
  * @event change
  * @event input
  * @event invalid

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -22,6 +22,8 @@ declare global {
 }
 
 /**
+ * @attribute {Boolean} hide-label
+ *
  * @event change
  * @event input
  * @event invalid

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -33,6 +33,10 @@ declare global {
 }
 
 /**
+ * @attribute {String} add-button-label
+ * @attribute {Boolean} hide-label
+ * @attribute {Boolean} select-all
+ *
  * @event change
  * @event input
  * @event invalid

--- a/src/input.ts
+++ b/src/input.ts
@@ -42,6 +42,9 @@ export const SUPPORTED_TYPES = [
 type SupportedTypes = (typeof SUPPORTED_TYPES)[number];
 
 /**
+ * @attribute {Boolean} hide-label
+ * @attribute {Boolean} password-toggle
+ *
  * @event change
  * @event input
  * @event invalid

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -31,6 +31,8 @@ globalStylesheet.insertRule(`
 `);
 
 /**
+ * @attribute {Boolean} back-button
+ *
  * @event toggle
  *
  * @slot - The primary content of the modal.

--- a/src/radio-group.ts
+++ b/src/radio-group.ts
@@ -22,6 +22,8 @@ declare global {
 }
 
 /**
+ * @attribute {Boolean} hide-label
+ *
  * @event change
  * @event input
  * @event invalid

--- a/src/split-button.secondary-button.ts
+++ b/src/split-button.secondary-button.ts
@@ -21,6 +21,9 @@ declare global {
 }
 
 /**
+ * @attribute {Boolean} menu-open
+ * @attribute {'bottom-end' | 'top-end'} menu-placement
+ *
  * @slot - One or more of `<glide-core-menu-button>` or `<glide-core-menu-link>`.
  */
 @customElement('glide-core-split-button-secondary-button')

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -20,6 +20,8 @@ declare global {
 }
 
 /**
+ * @attribute {Boolean} hide-label
+ *
  * @event change
  * @event input
  * @event invalid

--- a/src/toggle.ts
+++ b/src/toggle.ts
@@ -15,6 +15,8 @@ declare global {
 }
 
 /**
+ * @attribute {Boolean} hide-label
+ *
  * @event change
  * @event input
  *

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -27,6 +27,8 @@ declare global {
 }
 
 /**
+ * @attribute {Boolean} screenreader-hidden
+ *
  * @event toggle
  *
  * @slot target - The element to which the tooltip will anchor.

--- a/src/tree.item.ts
+++ b/src/tree.item.ts
@@ -22,6 +22,9 @@ declare global {
 }
 
 /**
+ * @attribute {Boolean} remove-indentation
+ * @attribute {Boolean} non-collapsible
+ *
  * @slot - Zero or more of `<glide-core-tree-item>`.
  * @slot prefix - An optional icon before the label.
  * @slot suffix - An optional icon after the label.


### PR DESCRIPTION
## 🚀 Description

It was found that this helps tools like lit-analyzer. I intentionally did not add docs for aria-attributes as those appear to be picked up just fine without any changes.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality
N/A