### PR TITLE
Radio group hotfix

### DIFF
--- a/.changeset/violet-boats-watch.md
+++ b/.changeset/violet-boats-watch.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Radio Group Radio labels no longer restrict their width.

--- a/src/radio-group.styles.ts
+++ b/src/radio-group.styles.ts
@@ -12,9 +12,9 @@ export default [
     }
 
     .radio-container {
-      display: flex;
+      display: inline-flex;
+      flex-direction: column;
       gap: 0.375rem;
-      inline-size: min-content;
 
       &.invalid {
         border: 1px solid var(--glide-core-status-error);
@@ -23,11 +23,6 @@ export default [
         margin-block-end: -0.0625rem;
         margin-inline-start: -0.0625rem;
         padding: var(--glide-core-spacing-xxs) 0.375rem;
-      }
-
-      &.vertical {
-        display: flex;
-        flex-direction: column;
       }
     }
 

--- a/src/radio-group.ts
+++ b/src/radio-group.ts
@@ -272,7 +272,6 @@ export default class GlideCoreRadioGroup
           <div
             class=${classMap({
               'radio-container': true,
-              vertical: true,
               invalid: this.#isShowValidationFeedback,
             })}
             role="radiogroup"


### PR DESCRIPTION
## 🚀 Description

Radio Group was setting `inline-size: min-content`, which forced the Radio Group Radio `label` to wrap prematurely. This fixes that.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

- Go to the [Form Controls Layout](https://glide-core.crowdstrike-ux.workers.dev/radio-group-hotfix?path=/story/form-controls-layout--form-controls-layout) or [Radio Group](https://glide-core.crowdstrike-ux.workers.dev/radio-group-hotfix?path=/story/radio-group--radio-group) story.
- Set the text of one radio item to something like "foo bar baz"
- Verify the text no longer prematurely wraps
- Verify clicking the whitespace to the right of the label does not trigger a click - only when you click the `label` text itself, should it select the radio

## 📸 Images/Videos of Functionality

| Before  | After |
| ------- | ----- |
|  <img width="999" alt="Screenshot 2025-02-04 at 11 29 37 AM" src="https://github.com/user-attachments/assets/77901aa8-541e-4050-8731-3916387dc0c6" />  | <img width="1000" alt="Screenshot 2025-02-04 at 11 29 58 AM" src="https://github.com/user-attachments/assets/768f2604-069a-43d4-be42-a2535685481c" /> |




