### PR TITLE
Tree Item: Prevent prefix icon from shrinking at narrow widths

### DIFF
--- a/.changeset/friendly-carpets-fail.md
+++ b/.changeset/friendly-carpets-fail.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+SVGs placed in the `prefix` slot of a Tree Item will no longer shrink at narrow widths.

--- a/src/tree.item.styles.ts
+++ b/src/tree.item.styles.ts
@@ -56,6 +56,11 @@ export default [
       }
     }
 
+    .prefix-slot {
+      align-items: center;
+      display: flex;
+    }
+
     .label-and-children {
       display: flex;
       flex-direction: column;

--- a/src/tree.item.ts
+++ b/src/tree.item.ts
@@ -122,6 +122,7 @@ export default class GlideCoreTreeItem extends LitElement {
 
         <slot
           name="prefix"
+          class="prefix-slot"
           ${ref(this.#prefixSlotElementRef)}
           @slotchange=${this.#onPrefixSlotChange}
         ></slot>


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Wraps the Tree Item prefix icon slot in a flex container, to prevent slotted SVGs from shrinking at narrow widths

## Before

![image](https://github.com/user-attachments/assets/52de0a82-a381-4730-98f8-41f9635ff4f4)

## After

![image](https://github.com/user-attachments/assets/118f794f-669f-4845-b4d4-eebe9c5059e6)


## 🔬 How to Test

- Visit Tree story: https://glide-core.crowdstrike-ux.workers.dev/prevent-tree-svg-shrinking?path=/docs/tree--overview
- Narrow the viewport, and validate the circle icon doesn't shrink (change the new `.prefix-container` element to `display: contents;` to test the failing case)
