### PR TITLE
Add `type="time"` support to Input

### DIFF
--- a/.changeset/strong-months-chew.md
+++ b/.changeset/strong-months-chew.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Input now supports `type="time"`.

--- a/src/input.ts
+++ b/src/input.ts
@@ -37,6 +37,7 @@ export const SUPPORTED_TYPES = [
   'search',
   'tel',
   'text',
+  'time',
   'url',
 ] as const;
 


### PR DESCRIPTION
## 🚀 Description

Add `type="time"` support to Input

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

- Visit [Input type='time'](https://glide-core.crowdstrike-ux.workers.dev/input-type-time?path=/story/input--input&args=type:time)
- Verify it displays a time input
- Click the clock icon
- Verify the browser time picker popover appears
- Select a time and verify the `value` updates

## 📸 Images/Videos of Functionality

https://github.com/user-attachments/assets/3925cabc-1187-41b7-aa32-376f747ff876



