### PR TITLE
Clear single-select Dropdown's input field when `value` is emptied

### DIFF
--- a/.changeset/giant-seas-sit.md
+++ b/.changeset/giant-seas-sit.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Single-select Dropdown's input field is now cleared when Dropdown's `value` is emptied programmatically.

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -559,7 +559,7 @@ it('sets the first unfiltered option as active when the previously active option
   expect(input?.getAttribute('aria-activedescendant')).to.equal(option?.id);
 });
 
-it('updates the `value` of its `<input> when `label` of a selected option is set programmatically', async () => {
+it('updates its input field when the `label` of its selected option is set programmatically', async () => {
   const host = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option
@@ -584,7 +584,7 @@ it('updates the `value` of its `<input> when `label` of a selected option is set
   expect(input?.value).to.equal('Three');
 });
 
-it('updates `value` when an option `value` is set programmatically', async () => {
+it('updates its `value` when the `value` of an option is set programmatically', async () => {
   const host = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -599,7 +599,7 @@ it('updates `value` when an option `value` is set programmatically', async () =>
   expect(host.value).to.deep.equal(['two']);
 });
 
-it('sets the `value` of its `<input> when made filterable', async () => {
+it('updates its input field when made filterable', async () => {
   const host = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option
@@ -624,7 +624,7 @@ it('sets the `value` of its `<input> when made filterable', async () => {
   expect(input?.value).to.equal('One');
 });
 
-it('clears the `value` of its `<input> when `multiple` is set programmatically', async () => {
+it('clears its input field when `multiple` is set programmatically', async () => {
   const host = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option
@@ -717,7 +717,7 @@ it('deselects all options on Meta + Backspace', async () => {
   expect(options[0].selected).to.be.false;
 });
 
-it('sets the `value` of its `<input> to the label of its selected option when not `multiple`', async () => {
+it('sets its input field to the `label` of its selected option when not `multiple`', async () => {
   const host = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -735,7 +735,28 @@ it('sets the `value` of its `<input> to the label of its selected option when no
   expect(input?.value).to.equal(option?.label);
 });
 
-it('clears the `value` of its `<input> when multiselect and an option is selected', async () => {
+it('clears its input field when single-select and `value` is emptied programmatically', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" filterable>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  host.value = [];
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(input?.value).to.be.empty.string;
+});
+
+it('clears its input field when multiselect and an option is selected', async () => {
   const host = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" filterable multiple>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1166,7 +1187,7 @@ it('cannot be tabbed to when disabled', async () => {
   expect(document.activeElement).to.equal(document.body);
 });
 
-it('sets the `value` of its `<input> back to the label of the selected option when something other than it is clicked', async () => {
+it('sets its input field back to the `label` of the selected option when something outside the host is clicked', async () => {
   const host = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -284,6 +284,14 @@ export default class GlideCoreDropdown
     }
 
     this.#isSettingValueProgrammatically = false;
+
+    if (
+      !this.multiple &&
+      this.value.length === 0 &&
+      this.#inputElementRef.value
+    ) {
+      this.#inputElementRef.value.value = '';
+    }
   }
 
   /*


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description


Single-select Dropdown's input field is now cleared when Dropdown's `value` attribute is emptied programmatically.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Navigate to Dropdown in Storybook.
2. Set `filterable` to `true`.
3. Select an option.
4. Set Dropdown's `value` to `[]`.
5. Verify Dropdown's input field is empty.

## 📸 Images/Videos of Functionality

N/A