### PR TITLE
Add a minimum width to filterable Dropdown's input field

### DIFF
--- a/.changeset/curvy-geckos-lie.md
+++ b/.changeset/curvy-geckos-lie.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Filterable Dropdown's input field now has a minimum width of 60 pixels.

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -351,6 +351,7 @@ export default [
       font-family: var(--glide-core-font-sans);
       font-size: inherit;
       inline-size: 100%;
+      min-inline-size: 3.75rem;
       padding-block-end: 0;
       padding-inline: 0;
 


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

A very subtle change given Dropdown itself also has a minimum width. But Design asked us to give Dropdown's input field a minimum width that's the same as Input's.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

Nothing really to test. I did check with one of our consumers to make sure the slight increase to Dropdown's overall width didn't cause overflow in the sidebar. Looked good.

## 📸 Images/Videos of Functionality



| Before  | After |
| ------- | ----- |
| <img width="288" alt="image" src="https://github.com/user-attachments/assets/f255d89c-b856-4786-927a-d8ef5eb89c35" />  | <img width="288" alt="image" src="https://github.com/user-attachments/assets/6a7c9653-491d-4c76-a43b-8ebeb36bbcb8" /> |


