### PR TITLE
Tweak Web Test Runner configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "lint:production:lit-analyzer": "lit-analyzer **/*.ts",
     "lint:production:stylelint": "tsc --noCheck --outDir ./dist && stylelint '**/*.styles.ts' --custom-syntax postcss-lit --no-color",
     "test": "per-env",
-    "test:development": "pnpm start:production:stylesheets && npm-run-all --parallel test:development:components test:development:serve-component-coverage",
+    "test:development": "npm-run-all --parallel test:development:components test:development:serve-component-coverage",
     "test:development:components": "web-test-runner --watch",
     "test:development:lint-rules": "vitest --config ./vitest.config.js & chokidar './src/eslint/**' './src/stylelint/**' --ignore './src/eslint/rules/*.test.ts' './src/stylelint/*.test.ts' --initial --silent --command 'tsc --noCheck --outDir ./dist'",
     "test:development:lint-rules:comment": "Excluded from `test:development` because Vitest muddies the console when running alongside Web Test Runner.",

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,4 +1,4 @@
-@import './variables/system.css';
-@import './variables/light.css';
 @import './variables/dark.css';
+@import './variables/light.css';
 @import './variables/miscellaneous.css';
+@import './variables/system.css';

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -60,6 +60,8 @@ export default {
     // https://github.com/modernweb-dev/web/issues/1700#issuecomment-1059441615
     fromRollup(rollupPluginCommonjs)({
       include: ['**/node_modules/**'],
+      // The default, `true`, doesn't play well with Axe Core, which our
+      // `expect(host).to.be.accessible()` assertions use.
       strictRequires: 'auto',
     }),
     esbuildPlugin({
@@ -76,7 +78,7 @@ export default {
           'lcov',
           {
             start() {
-              // eslint-disable-next-line no-console -- ok since this is a script run in the terminal
+              // eslint-disable-next-line no-console
               console.log(
                 `Code coverage report: ${chalk.bgBlue(
                   'http://localhost:8080',
@@ -84,7 +86,7 @@ export default {
               );
             },
             onTestRunStarted() {
-              // eslint-disable-next-line no-console -- ok since this is a script run in the terminal
+              // eslint-disable-next-line no-console
               console.log(
                 `Code coverage report: ${chalk.bgBlue(
                   'http://localhost:8080',
@@ -96,8 +98,11 @@ export default {
   testRunnerHtml(testFramework) {
     return `<html>
       <body>
-        <link href="./dist/styles/fonts.css" rel="stylesheet">
-        <link href="./dist/styles/variables.css" rel="stylesheet">
+        <link href="./src/styles/fonts.css" rel="stylesheet">
+        <link href="./src/styles/variables/light.css" rel="stylesheet">
+        <link href="./src/styles/variables/dark.css" rel="stylesheet">
+        <link href="./src/styles/variables/miscellaneous.css" rel="stylesheet">
+        <link href="./src/styles/variables/system.css" rel="stylesheet">
         <script type="module" src="${testFramework}"></script>
       </body>
     </html>`;


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

`start:production` [now](https://github.com/CrowdStrike/glide-core/blob/main/.husky/pre-push#L4) runs locally on push and removes `./dist`. And `./dist` contains stylesheets that Web Test Runner [relies](https://github.com/CrowdStrike/glide-core/blob/main/web-test-runner.config.js#L99-L100) on. 

`start:production` immediately recreates those stylesheets. But, in the meantime, Web Test Runner logs a bunch of 404s   before resuming. Web Test Runner never crashes. But the 404s are distracting. 

One possible fix, implemented here, is to configure Web Test Runner so that it fetches the stylesheets from `./src`. The downside is that we'll have to remember to adjust its configuration if we add or remove stylesheets.






<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Check out the branch.
2. Run `pnpm test`.
3. Run `pnpm start:production`.
4. Verify there are no 404s in your terminal.

## 📸 Images/Videos of Functionality

<img width="579" alt="image" src="https://github.com/user-attachments/assets/97b05ce2-3f5f-4c95-a7ea-7e01abe306b2" />
