### PR TITLE
WIP: Fix nested tab groups

### DIFF
--- a/src/tab.group.test.interactions.ts
+++ b/src/tab.group.test.interactions.ts
@@ -4,6 +4,8 @@ import { assert, expect, fixture, html, waitUntil } from '@open-wc/testing';
 import { click } from './library/mouse.js';
 import GlideCoreTabGroup from './tab.group.js';
 import './tab.panel.js';
+import type GlideCoreTab from './tab.js';
+import type GlideCoreTabPanel from './tab.panel.js';
 
 it('changes tabs on click', async () => {
   const host = await fixture<GlideCoreTabGroup>(html`
@@ -127,6 +129,36 @@ it('changes tabs on keyboard interaction', async () => {
   expect(tabs[2]?.selected).to.be.true;
   expect(tabs[2]?.tabIndex).to.equal(0);
 });
+
+it('only changes nested tabs when clicking a nested tab group', async () => {
+  const host = await fixture<GlideCoreTabGroup>(html`
+   <glide-core-tab-group>
+      <glide-core-tab panel="1" slot="nav">One</glide-core-tab>
+      <glide-core-tab panel="2" slot="nav">Two</glide-core-tab>
+      <glide-core-tab-panel name="1">
+        One
+        <glide-core-tab-group>
+          <glide-core-tab panel="nested_1" slot="nav">Nested 1</glide-core-tab>
+          <glide-core-tab panel="nested_2" slot="nav">Nested 2</glide-core-tab>
+          <glide-core-tab-panel name="nested_1">Nested 1</glide-core-tab-panel>
+          <glide-core-tab-panel name="nested_2">Nested 2</glide-core-tab-panel>
+        </glide-core-tab-group>
+      </glide-core-tab-panel>
+      <glide-core-tab-panel name="2">
+        Two
+      </glide-core-tab-panel>
+    </glide-core-tab-group>
+  `);
+
+  const parentTabs = host.querySelectorAll<GlideCoreTab>(':scope > glide-core-tab');
+  const panels = host.querySelectorAll<GlideCoreTabPanel>(':scope > glide-core-tab-panel');
+  const nestedTabs = panels[0]?.querySelectorAll<GlideCoreTab>('glide-core-tab') || [];
+
+  await click(nestedTabs[1]);
+
+  expect(parentTabs[1]?.selected).to.be.false;
+  expect(nestedTabs[1]?.selected).to.be.true;
+})
 
 it('has overflow buttons when overflowing', async () => {
   const parentNode = document.createElement('div');

--- a/src/tab.group.ts
+++ b/src/tab.group.ts
@@ -176,7 +176,7 @@ export default class GlideCoreTabGroup extends LitElement {
   }
 
   get #tabElements() {
-    return [...this.querySelectorAll('glide-core-tab')];
+    return [...this.querySelectorAll<GlideCoreTab>(':scope > glide-core-tab')];
   }
 
   #onClick(event: Event) {
@@ -186,7 +186,8 @@ export default class GlideCoreTabGroup extends LitElement {
     if (
       clickedTab &&
       clickedTab instanceof GlideCoreTab &&
-      !clickedTab.disabled
+      !clickedTab.disabled &&
+      this.#tabElements.includes(clickedTab)
     ) {
       this.#showTab(clickedTab);
     }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Previously, if you nested a `glide-core-tab-group` inside of a `glide-core-tab-panel`. Switching tabs within the nested `tab-group` would result in a blank panel.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- [ ] I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- [ ] I have added tests to cover new or updated functionality.
- [ ] I have added or updated Storybook stories.
- [ ] I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- [ ] I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- [ ] I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- [ ] I have scheduled a design review.

## 🔬 How to Test

<!-- Please provide steps to test the functionality added/updated/removed. Preview URLs are generated with each build. -->

## 📸 Images/Videos of Functionality

<!-- For visual changes, it's extremely helpful to include screenshots, gifs, or videos of what has changed. Before and after images are ideal when adjusting styling.

Use a markdown table to display changes side-by-side for easier comparison.

| Before  | After |
| ------- | ----- |
|  Image  | Image |

-->
