### PR TITLE
Components are no longer stuck in light mode.

### DIFF
--- a/.changeset/yellow-ears-bathe.md
+++ b/.changeset/yellow-ears-bathe.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Components are no longer stuck in light mode.

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,4 +1,10 @@
-@import './variables/dark.css';
+/*
+  Order matters here.
+  "light" is our default. "dark" uses the
+  same variable names, but different values,
+  so it must come after "light".
+*/
 @import './variables/light.css';
+@import './variables/dark.css';
 @import './variables/miscellaneous.css';
 @import './variables/system.css';

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,8 +1,6 @@
 /*
-  Order matters here.
-  "light" is our default. "dark" uses the
-  same variable names, but different values,
-  so it must come after "light".
+  Order matters here. "light" is our default. "dark" uses the same
+  variable names but different values. So it must come after "light".
 */
 @import './variables/light.css';
 @import './variables/dark.css';


### PR DESCRIPTION
## 🚀 Description

Components are no longer stuck in light mode.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

- Go to [main](https://glide-core.crowdstrike-ux.workers.dev/main)
- Switch to dark mode
- Verify dark mode doesn't take
- Now go to [this branch](https://glide-core.crowdstrike-ux.workers.dev/fix-dark-mode?path=/)
- Switch to dark mode
- Verify the component is now in dark mode

## 📸 Images/Videos of Functionality

(See above)
