### PR TITLE
Remove nested Tab Group from story

### DIFF
--- a/src/tab.group.stories.ts
+++ b/src/tab.group.stories.ts
@@ -127,24 +127,6 @@ const meta: Meta = {
           })}
         >
           ${unsafeHTML(arguments_['<glide-core-tab-panel>[slot="default"]'])}
-
-          <glide-core-tab-group>
-            <glide-core-tab slot="nav" panel="1"> test </glide-core-tab>
-
-            <glide-core-tab slot="nav" panel="2">
-              With Icon test
-
-              <glide-core-example-icon
-                slot="icon"
-                name="checkmark"
-              ></glide-core-example-icon>
-            </glide-core-tab>
-
-            <glide-core-tab-panel name="1"> </glide-core-tab-panel>
-            <glide-core-tab-panel name="2">
-              With Icon test
-            </glide-core-tab-panel>
-          </glide-core-tab-group>
         </glide-core-tab-panel>
         <glide-core-tab-panel name="2"> With Icon </glide-core-tab-panel>
       </glide-core-tab-group>


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

N/A

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

Just have a poke around Tab Group in Storybook.

## 📸 Images/Videos of Functionality

N/A
