### PR TITLE
Add French and Japanese translations

### DIFF
--- a/.changeset/curvy-walls-attack.md
+++ b/.changeset/curvy-walls-attack.md
@@ -2,4 +2,4 @@
 '@crowdstrike/glide-core': patch
 ---
 
-Accessibility strings are now fully translated for French and Japanese.
+Most text is provided by consumers via attributes. But many components have built-in text to help screenreaders. That text has been fully localized for French and Japanese.

--- a/.changeset/curvy-walls-attack.md
+++ b/.changeset/curvy-walls-attack.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Accessibility strings are now fully translated for French and Japanese.

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1,13 +1,19 @@
 {
-  "close": "Fermer",
-  "dismiss": "Congédier",
+  "close": "FERMER",
+  "dismiss": "Ignorer",
   "selectAll": "Tout sélectionner",
   "notifications": "Notifications",
   "nextTab": "Onglet suivant",
   "previousTab": "Onglet précédent",
-  "announcedCharacterCount": "Nombre de caractères {current} de {maximum}",
+  "noResults": "Aucun résultat trouvé",
+  "tooltip": "Info-bulle :",
+  "announcedCharacterCount": "Nombre de caractères {current} sur {maximum}",
   "displayedCharacterCount": "{current}/{maximum}",
   "clearEntry": "Effacer l'entrée {label}",
-  "removeTag": "Supprimer la balise : {label}",
-  "actionsFor": "Actions pour {label}"
+  "editOption": "Modifier l'option : {label}",
+  "editTag": "Modifier la balise : {label}",
+  "removeTag": "Enlever la balise : {label}",
+  "actionsFor": "Action pour {label}",
+  "itemCount": "{count} éléments",
+  "closeInlineAlert": "Fermer l'alerte {variant}"
 }

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1,13 +1,6 @@
 import type { Translation } from '../library/localize.js';
 
-export const PENDING_STRINGS = [
-  'editOption',
-  'editTag',
-  'itemCount',
-  'noResults',
-  'closeInlineAlert',
-  'tooltip',
-] as const;
+export const PENDING_STRINGS = [] as const;
 
 type PendingTranslation = (typeof PENDING_STRINGS)[number];
 
@@ -17,20 +10,26 @@ const translation: Omit<Translation, PendingTranslation> = {
   $dir: 'ltr',
 
   // These come from ./fr.json
-  close: 'Fermer',
-  dismiss: 'Congédier',
+  close: 'FERMER',
+  dismiss: 'Ignorer',
   selectAll: 'Tout sélectionner',
   notifications: 'Notifications',
   nextTab: 'Onglet suivant',
   previousTab: 'Onglet précédent',
+  noResults: 'Aucun résultat trouvé',
+  tooltip: 'Info-bulle :',
 
   announcedCharacterCount: (current: number, maximum: number) =>
-    `Nombre de caractères ${current} de ${maximum}`,
+    `Nombre de caractères ${current} sur ${maximum}`,
   displayedCharacterCount: (current: number, maximum: number) =>
     `${current}/${maximum}`,
   clearEntry: (label: string) => `Effacer l'entrée ${label}`,
-  removeTag: (label: string) => `Supprimer la balise : ${label}`,
-  actionsFor: (label: string) => `Actions pour ${label}`,
+  editOption: (label: string) => `Modifier l'option : ${label}`,
+  editTag: (label: string) => `Modifier la balise : ${label}`,
+  removeTag: (label: string) => `Enlever la balise : ${label}`,
+  actionsFor: (label: string) => `Action pour ${label}`,
+  itemCount: (count: string) => `${count} éléments`,
+  closeInlineAlert: (variant: string) => `Fermer l'alerte ${variant}`,
 };
 
 export default translation;

--- a/src/translations/ja.json
+++ b/src/translations/ja.json
@@ -1,13 +1,19 @@
 {
   "close": "閉じる",
-  "dismiss": "無視",
+  "dismiss": "閉じる",
   "selectAll": "すべて選択",
   "notifications": "通知",
   "nextTab": "次のタブ",
   "previousTab": "前のタブ",
-  "announcedCharacterCount": "{maximum} 文字数の{current}",
+  "noResults": "結果が見つかりません",
+  "tooltip": "ツールチップ：",
+  "announcedCharacterCount": "文字数 {current}/{maximum}",
   "displayedCharacterCount": "{current}/{maximum}",
-  "clearEntry": "{label}エントリのクリア",
-  "removeTag": "タグを削除: {label}",
-  "actionsFor": "{label}のアクション"
+  "clearEntry": "{label}入力をクリア",
+  "editOption": "編集オプション：{label}",
+  "editTag": "タグの編集：{label}",
+  "removeTag": "タグの削除：{label}",
+  "actionsFor": "{label}のアクション",
+  "itemCount": "{count}件",
+  "closeInlineAlert": "{variant}アラートを閉じる"
 }

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -1,13 +1,6 @@
 import type { Translation } from '../library/localize.js';
 
-export const PENDING_STRINGS = [
-  'editOption',
-  'editTag',
-  'itemCount',
-  'noResults',
-  'closeInlineAlert',
-  'tooltip',
-] as const;
+export const PENDING_STRINGS = [] as const;
 
 type PendingTranslation = (typeof PENDING_STRINGS)[number];
 
@@ -18,19 +11,25 @@ const translation: Omit<Translation, PendingTranslation> = {
 
   // These come from ./ja.json
   close: '閉じる',
-  dismiss: '無視',
+  dismiss: '閉じる',
   selectAll: 'すべて選択',
   notifications: '通知',
   nextTab: 'Onglet suivant',
   previousTab: 'Onglet précédent',
+  noResults: '結果が見つかりません',
+  tooltip: 'ツールチップ：',
 
   announcedCharacterCount: (current: number, maximum: number) =>
-    `${maximum} 文字数の${current}`,
+    `文字数 ${current}/${maximum}`,
   displayedCharacterCount: (current: number, maximum: number) =>
     `${current}/${maximum}`,
-  clearEntry: (label: string) => `${label}エントリのクリア`,
-  removeTag: (label: string) => `タグを削除: ${label}`,
+  clearEntry: (label: string) => `${label}入力をクリア`,
+  editOption: (label: string) => `編集オプション：${label}`,
+  editTag: (label: string) => `タグの編集：${label}`,
+  removeTag: (label: string) => `タグの削除：${label}`,
   actionsFor: (label: string) => `${label}のアクション`,
+  itemCount: (count: string) => `${count}件`,
+  closeInlineAlert: (variant: string) => `${variant}アラートを閉じる`,
 };
 
 export default translation;


### PR DESCRIPTION
## 🚀 Description

All of our static strings in this repository are visually hidden, but are there to help screen readers / accessibility. We were lacking some French and Japanese translations. This PR addresses those gaps.

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

N/A

## 📸 Images/Videos of Functionality

N/A