### PR TITLE
Add a lint rule for public properties whose value is an expression

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2622,6 +2622,9 @@
             {
               "kind": "field",
               "name": "version",
+              "type": {
+                "text": "string"
+              },
               "readonly": true,
               "attribute": "version",
               "reflects": true
@@ -2938,6 +2941,9 @@
             },
             {
               "name": "version",
+              "type": {
+                "text": "string"
+              },
               "readonly": true,
               "fieldName": "version"
             }
@@ -5367,6 +5373,9 @@
             {
               "kind": "field",
               "name": "version",
+              "type": {
+                "text": "string"
+              },
               "readonly": true,
               "attribute": "version",
               "reflects": true
@@ -5414,6 +5423,9 @@
             },
             {
               "name": "version",
+              "type": {
+                "text": "string"
+              },
               "readonly": true,
               "fieldName": "version"
             }
@@ -5530,6 +5542,9 @@
             {
               "kind": "field",
               "name": "version",
+              "type": {
+                "text": "string"
+              },
               "readonly": true,
               "attribute": "version",
               "reflects": true
@@ -5611,6 +5626,9 @@
             },
             {
               "name": "version",
+              "type": {
+                "text": "string"
+              },
               "readonly": true,
               "fieldName": "version"
             }
@@ -7066,6 +7084,9 @@
             {
               "kind": "field",
               "name": "version",
+              "type": {
+                "text": "string"
+              },
               "readonly": true,
               "attribute": "version",
               "reflects": true
@@ -7106,6 +7127,9 @@
             },
             {
               "name": "version",
+              "type": {
+                "text": "string"
+              },
               "readonly": true,
               "fieldName": "version"
             }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,6 +50,7 @@ export default [
       '@crowdstrike/glide-core/event-dispatch-from-this': 'error',
       '@crowdstrike/glide-core/string-event-name': 'error',
       '@crowdstrike/glide-core/slot-type-comment': 'error',
+      '@crowdstrike/glide-core/public-property-expression-type': 'error',
 
       // Enabling this rule would force us to `await` any function that returns a promise.
       // One example is a function that itself `await`s `updateComplete`. The rule is a bit
@@ -316,6 +317,7 @@ export default [
       '@crowdstrike/glide-core/event-dispatch-from-this': 'off',
       '@crowdstrike/glide-core/string-event-name': 'off',
       '@crowdstrike/glide-core/slot-type-comment': 'off',
+      '@crowdstrike/glide-core/public-property-expression-type': 'off',
     },
   },
   {

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -53,7 +53,7 @@ declare global {
  * @attr {'quiet'} [variant]
  *
  * @readonly
- * @attr [version]
+ * @attr {string} [version]
  *
  * @slot {GlideCoreDropdownOption}
  * @slot {Element | string} [description] - Additional information or context
@@ -348,7 +348,7 @@ export default class GlideCoreDropdown
   variant?: 'quiet';
 
   @property({ reflect: true })
-  readonly version = packageJson.version;
+  readonly version: string = packageJson.version;
 
   private get activeOption() {
     return this.#optionElementsIncludingSelectAll?.find(

--- a/src/eslint/plugin.ts
+++ b/src/eslint/plugin.ts
@@ -16,6 +16,7 @@ import { publicGetterDefaultComment } from './rules/public-getter-default-commen
 import { eventDispatchFromThis } from './rules/event-dispatch-from-this.js';
 import { stringEventName } from './rules/string-event-name.js';
 import { slotTypeComment } from './rules/slot-type-comment.js';
+import { publicPropertyExpressionType } from './rules/public-property-expression-type.js';
 
 export default {
   rules: {
@@ -39,5 +40,6 @@ export default {
     'event-dispatch-from-this': eventDispatchFromThis,
     'string-event-name': stringEventName,
     'slot-type-comment': slotTypeComment,
+    'public-property-expression-type': publicPropertyExpressionType,
   },
 };

--- a/src/eslint/rules/public-property-expression-type.test.ts
+++ b/src/eslint/rules/public-property-expression-type.test.ts
@@ -1,0 +1,51 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { publicPropertyExpressionType } from './public-property-expression-type.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('public-property-type', publicPropertyExpressionType, {
+  valid: [
+    {
+      code: `
+        export default class {
+          version: string = packageJson.version;
+        }
+      `,
+    },
+    {
+      code: `
+        export default class {
+          #version = packageJson.version;
+        }
+      `,
+    },
+    {
+      code: `
+        export default class {
+          privateVersion = packageJson.version;
+        }
+      `,
+    },
+    {
+      code: `
+        export default class {
+          version = '0.0.1';
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        export default class {
+          version = packageJson.version;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'addExplicitType',
+        },
+      ],
+    },
+  ],
+});

--- a/src/eslint/rules/public-property-expression-type.ts
+++ b/src/eslint/rules/public-property-expression-type.ts
@@ -7,41 +7,38 @@ const createRule = ESLintUtils.RuleCreator<{
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;
 });
 
-export const publicMemberReturnType = createRule({
-  name: 'public-member-return-type',
+export const publicPropertyExpressionType = createRule({
+  name: 'public-property-expression-type',
   meta: {
     docs: {
       description:
-        'Ensures a return type annotation on public methods and getters with setters.',
+        'Ensures a type annotation on public properties whose value is an expression.',
       recommended: true,
     },
     type: 'suggestion',
     messages: {
-      addReturnType:
-        'Add a return type annotation to help us populate our elements manifest with the correct type.',
+      addExplicitType:
+        'Add a type annotation to help us populate our elements manifest with the correct type.',
     },
     schema: [],
   },
   defaultOptions: [],
   create(context) {
     return {
-      MethodDefinition(node) {
+      PropertyDefinition(node) {
         const isPseudoPrivate =
           node.key.type === AST_NODE_TYPES.Identifier &&
           node.key.name.startsWith('private');
 
         if (
-          node.kind !== 'constructor' &&
-          node.kind !== 'set' &&
+          node.value?.type === AST_NODE_TYPES.MemberExpression &&
           node.key.type !== AST_NODE_TYPES.PrivateIdentifier &&
-          node.accessibility !== 'private' &&
           !isPseudoPrivate &&
-          !node.override &&
-          !node.value.returnType
+          !node.typeAnnotation
         ) {
           context.report({
             node,
-            messageId: 'addReturnType',
+            messageId: 'addExplicitType',
           });
         }
       },

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -32,7 +32,7 @@ declare global {
  * @attr {'bottom'|'left'|'right'|'top'} [placement]
  *
  * @readonly
- * @attr [version]
+ * @attr {string} [version]
  *
  * @slot {Element | string} - The content of the popover
  * @slot {Element} [target] - The element to which the popover will anchor. Can be any focusable element.
@@ -118,13 +118,13 @@ export default class GlideCorePopover extends LitElement {
 
   /*
     The placement of the popover relative to its target. Automatic placement will
-    take over if the popover is cut off by the viewport. 
+    take over if the popover is cut off by the viewport.
   */
   @property()
   placement?: 'bottom' | 'left' | 'right' | 'top';
 
   @property({ reflect: true })
-  readonly version = packageJson.version;
+  readonly version: string = packageJson.version;
 
   override connectedCallback() {
     super.connectedCallback();

--- a/src/radio-group.radio.ts
+++ b/src/radio-group.radio.ts
@@ -20,7 +20,7 @@ declare global {
  * @attr {string} [value]
  *
  * @readonly
- * @attr [version]
+ * @attr {string} [version]
  *
  * @fires {Event} change
  * @fires {Event} input
@@ -159,7 +159,7 @@ export default class GlideCoreRadioGroupRadio extends LitElement {
   }
 
   @property({ reflect: true })
-  readonly version = packageJson.version;
+  readonly version: string = packageJson.version;
 
   override firstUpdated() {
     this.ariaChecked = this.checked.toString();

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -20,7 +20,7 @@ declare global {
  * @attr {boolean} [selected=false]
  *
  * @readonly
- * @attr [version]
+ * @attr {string} [version]
  *
  * @slot {Element | string} - A label
  * @slot {Element} [icon]
@@ -66,7 +66,7 @@ export default class GlideCoreTab extends LitElement {
   }
 
   @property({ reflect: true })
-  readonly version = packageJson.version;
+  readonly version: string = packageJson.version;
 
   protected override firstUpdated() {
     this.setAttribute('role', 'tab');


### PR DESCRIPTION
<!-- Please provide a descriptive title for your Pull Request above.  -->

## 🚀 Description

Covers the for-now unique case of components' `version` attribute—whose value is set to `packageJson.version`. The type of `version` isn't picked up by the element analyzer without an explicit type.

<!-- Please provide a description of the changes in your Pull Request, in particular the motivation for the changes. -->

## 📋 Checklist

<!-- Please ensure you've gone through this checklist before adding reviewers. -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.

## 🔬 How to Test

1. Check out the branch.
2. Remove the type annotation from a component's `version` property.
3. Verify ESLint complains.

## 📸 Images/Videos of Functionality

N/A
