### PR TITLE
Align Input's pattern attribute with native

### DIFF
--- a/.changeset/dirty-pumas-search.md
+++ b/.changeset/dirty-pumas-search.md
@@ -1,0 +1,8 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Input's `pattern` validation now matches native behavior:
+
+- Requires a full string `value` match instead of a partial match.
+- Empty values are considered valid when `pattern` is present.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -3601,6 +3601,7 @@
               "type": {
                 "text": "string | undefined"
               },
+              "default": "''",
               "attribute": "pattern",
               "reflects": true
             },
@@ -3905,6 +3906,7 @@
               "type": {
                 "text": "string | undefined"
               },
+              "default": "''",
               "fieldName": "pattern"
             },
             {

--- a/src/input.test.forms.ts
+++ b/src/input.test.forms.ts
@@ -330,7 +330,7 @@ it('is valid when the `value` attribute matches `pattern`', async () => {
   const host = await fixture<GlideCoreInput>(
     html`<glide-core-input
       label="Label"
-      pattern="[a-z]{4,8}"
+      pattern="[A-Za-z_s][A-Za-z_0-9s]*"
       value="value"
     ></glide-core-input>`,
   );
@@ -367,12 +367,30 @@ it('is valid when `value` matches `pattern` after being set programmatically', a
   ).to.equal('false');
 });
 
-it('is invalid when `value` does not match `pattern`', async () => {
+it('is valid when `pattern` is set and `value` is empty', async () => {
   const host = await fixture<GlideCoreInput>(
     html`<glide-core-input
       label="Label"
       pattern="[a-z]{4,8}"
-      value="1234"
+    ></glide-core-input>`,
+  );
+
+  expect(host.validity?.valid).to.be.true;
+  expect(host.validity?.patternMismatch).to.be.false;
+  expect(host.checkValidity()).to.be.true;
+  expect(host.reportValidity()).to.be.true;
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="input"]')?.ariaInvalid,
+  ).to.equal('false');
+});
+
+it('is invalid when `value` does not match `pattern`', async () => {
+  const host = await fixture<GlideCoreInput>(
+    html`<glide-core-input
+      label="Label"
+      pattern="[A-Za-z_s][A-Za-z_0-9s]*"
+      value="!value"
     ></glide-core-input>`,
   );
 
@@ -415,12 +433,26 @@ it('is invalid when `required` and `value` does not match `pattern`', async () =
     html`<glide-core-input
       label="Label"
       pattern="[a-z]{4,8}"
+      value="val"
       required
     ></glide-core-input>`,
   );
 
   expect(host.validity?.valid).to.be.false;
   expect(host.validity?.patternMismatch).to.be.true;
+});
+
+it('is invalid when `required`, has an empty `value`, and a `pattern`', async () => {
+  const host = await fixture<GlideCoreInput>(
+    html`<glide-core-input
+      label="Label"
+      pattern="[a-z]{4,8}"
+      required
+    ></glide-core-input>`,
+  );
+
+  expect(host.validity?.valid).to.be.false;
+  expect(host.validity?.patternMismatch).to.be.false;
   expect(host.validity?.valueMissing).to.be.true;
 });
 
@@ -429,6 +461,7 @@ it('is valid when `pattern` is programmatically removed', async () => {
     html`<glide-core-input
       label="Label"
       pattern="[a-z]{4,8}"
+      value="val"
     ></glide-core-input>`,
   );
 
@@ -557,10 +590,12 @@ it('is valid when `setValidity()` is called', async () => {
 });
 
 it('retains existing validity state when `setCustomValidity()` is called', async () => {
+  // `value` does not match `pattern` intentionally to force an invalid state
   const host = await fixture<GlideCoreInput>(
     html`<glide-core-input
       label="Label"
       pattern="[a-z]{4,8}"
+      value="val"
       required
     ></glide-core-input>`,
   );
@@ -570,7 +605,7 @@ it('retains existing validity state when `setCustomValidity()` is called', async
   expect(host.validity?.valid).to.be.false;
   expect(host.validity?.customError).to.be.true;
   expect(host.validity?.patternMismatch).to.be.true;
-  expect(host.validity?.valueMissing).to.be.true;
+  expect(host.validity?.valueMissing).to.be.false;
 });
 
 it('removes its validity feedback but retains its validity state when `resetValidityFeedback()` is called', async () => {


### PR DESCRIPTION
## 🚀 Description

Input's `pattern` validation now matches native behavior:

- Requires a full string `value` match instead of a partial match.
- Empty values are considered valid when `pattern` is present.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

- Navigate to `Input`'s [Storybook](https://glide-core.crowdstrike-ux.workers.dev/input-pattern?path=/docs/input--overview)
- Set a pattern like `[A-Za-z_\s][A-Za-z_0-9\s]*`
- Enter `hello` into the Input
- Check `glide-core-input`'s validity with `$0.validity.valid`
- Verify it returns `true`
- Update the value to be `!hello`
- Verify `$0.validity.valid` returns `false`
- Delete the entire value from the input
- Verify `$0.validity.valid` returns `true`

## 📸 Images and videos

N/A
