### PR TITLE
Remove `rows` from Textarea

### DIFF
--- a/.changeset/happy-chicken-buy.md
+++ b/.changeset/happy-chicken-buy.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Textarea no longer exposes a `rows` attribute. Following the design guidelines, Textarea is three rows by default, with the ability to grow to five based on the value entered.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -7463,16 +7463,6 @@
             },
             {
               "kind": "field",
-              "name": "rows",
-              "type": {
-                "text": "number"
-              },
-              "default": "2",
-              "attribute": "rows",
-              "reflects": true
-            },
-            {
-              "kind": "field",
               "name": "required",
               "type": {
                 "text": "boolean"
@@ -7735,14 +7725,6 @@
               },
               "default": "''",
               "fieldName": "placeholder"
-            },
-            {
-              "name": "rows",
-              "type": {
-                "text": "number"
-              },
-              "default": "2",
-              "fieldName": "rows"
             },
             {
               "name": "required",

--- a/src/textarea.stories.ts
+++ b/src/textarea.stories.ts
@@ -75,7 +75,6 @@ const meta: Meta = {
     'reportValidity()': '',
     required: false,
     'resetValidityFeedback()': '',
-    rows: 2,
     'setCustomValidity(message)': '',
     'setValidity(flags, message)': '',
     'slot="description"': '',
@@ -207,13 +206,6 @@ const meta: Meta = {
         },
       },
     },
-    rows: {
-      control: 'number',
-      table: {
-        defaultValue: { summary: '2' },
-        type: { summary: 'number' },
-      },
-    },
     'setCustomValidity(message)': {
       control: false,
       table: {
@@ -278,7 +270,6 @@ const meta: Meta = {
         name=${arguments_.name || nothing}
         orientation=${arguments_.orientation}
         placeholder=${arguments_.placeholder || nothing}
-        rows=${arguments_.rows}
         spellcheck=${arguments_.spellcheck}
         tooltip=${arguments_.tooltip || nothing}
         value=${arguments_.value || nothing}

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -32,7 +32,6 @@ declare global {
  * @attr {string} [placeholder='']
  * @attr {boolean} [readonly=false]
  * @attr {boolean} [required=false]
- * @attr {number} [rows=2]
  * @attr {boolean} [spellcheck=false]
  * @attr {string} [tooltip]
  * @attr {string} [value='']
@@ -101,9 +100,6 @@ export default class GlideCoreTextarea
 
   @property({ reflect: true })
   placeholder?: string = '';
-
-  @property({ reflect: true, type: Number })
-  rows = 2;
 
   @property({ reflect: true, type: Boolean })
   required = false;
@@ -236,7 +232,6 @@ export default class GlideCoreTextarea
           id="textarea"
           name=${ifDefined(this.name)}
           placeholder=${ifDefined(this.placeholder)}
-          rows=${this.rows}
           autocapitalize=${this.autocapitalize}
           autocomplete=${this.autocomplete}
           spellcheck=${this.spellcheck}


### PR DESCRIPTION
## 🚀 Description

Textarea no longer exposes a `rows` attribute. If it was provided, it was a no-op anyway. Following the design guidelines, Textarea is three rows by default, with the ability to grow to five based on the value entered.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

N/A

## 📸 Images and videos

N/A
