### PR TITLE
Add Tag truncation

### DIFF
--- a/.changeset/sixty-pots-smell.md
+++ b/.changeset/sixty-pots-smell.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Tag now truncates with an ellipsis when it would otherwise overflow its container.

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -245,8 +245,22 @@ export default [
     }
 
     .tags {
-      display: flex;
+      display: grid;
       gap: var(--glide-core-spacing-xs);
+
+      /*
+        Tags will shrink down to zero and never overflow if they don't have a minimum
+        width. If they don't overflow, they'll remain visible and additionally won't be
+        included in the overflow count text. Thus a minimum width.
+
+        "3.5rem" is the size of a tag with only a single character. Ideally, its
+        minimum would be wider so a few characters are always visible. But a single-
+        character tag is possible and even likely. Setting a higher minimum width
+        would mean single or double-character tags would have whitespace between them.
+        It's equally unfortunate that Dropdown has to know anything about Tag's width.
+      */
+      grid-auto-columns: minmax(3.5rem, auto);
+      grid-auto-flow: column;
       list-style-type: none;
       margin-block: 0;
       padding-inline-start: 0;

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -881,6 +881,7 @@ export default class GlideCoreDropdown
                     <span data-test="tag-overflow-count">
                       ${this.selectedOptions.length - this.tagOverflowLimit}
                     </span>
+
                     more
                   </div>`;
                 },

--- a/src/tag.styles.ts
+++ b/src/tag.styles.ts
@@ -7,6 +7,26 @@ export default [
     ${focusOutline('.removal-button:focus-visible')}
   `,
   css`
+    @keyframes fade-in {
+      0% {
+        opacity: 0;
+      }
+
+      100% {
+        opacity: 1;
+      }
+    }
+
+    @keyframes fade-out {
+      0% {
+        opacity: 1;
+      }
+
+      100% {
+        opacity: 0;
+      }
+    }
+
     .component {
       align-items: center;
       background: var(--glide-core-surface-base-gray-lighter);
@@ -19,13 +39,10 @@ export default [
       font-weight: var(--glide-core-body-xs-font-weight);
       justify-content: center;
       line-height: 1;
-      margin: 0;
       max-inline-size: max-content;
       min-block-size: var(--glide-core-spacing-md);
       opacity: 1;
-      overflow: hidden;
       padding: var(--glide-core-spacing-xxxs) var(--glide-core-spacing-xs);
-      white-space: nowrap;
 
       &.large {
         min-block-size: 0.875rem;
@@ -58,24 +75,10 @@ export default [
       }
     }
 
-    @keyframes fade-in {
-      0% {
-        opacity: 0;
-      }
-
-      100% {
-        opacity: 1;
-      }
-    }
-
-    @keyframes fade-out {
-      0% {
-        opacity: 1;
-      }
-
-      100% {
-        opacity: 0;
-      }
+    .label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .removal-button {

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -105,7 +105,8 @@ export default class GlideCoreTag extends LitElement {
           <!-- @type {Element} -->
         </slot>
 
-        ${this.label}
+        <div class="label">${this.label}</div>
+
         ${when(this.privateEditable, () => {
           return html`<button
             aria-label=${this.#localize.term('editTag', this.label!)}


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Tag now truncates with an ellipsis when it would otherwise overflow its container.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to Dropdown in Storybook.
2. Set `multiple` to `true`.
3. Add a [bunch](https://www.lipsum.com/) of text to the first option's `label`.
4. Select all three options.
5. Resize the window back and forth.
6. Verify that Dropdown's tags truncate and untruncate.
7. Verify its tags are hidden as they overflow.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->

## 📸 Images and videos

N/A

<!--

  - Include images or videos of your visual changes.
  - Use the table below to show them side by side if possible.
  - Write "N/A" for non-visual changes.

  | Before | After |
  | ------ | ----- |
  | Image  | Image |

-->
