### PR TITLE
Radio Group tabbability fixes

### DIFF
--- a/.changeset/clean-kids-collect.md
+++ b/.changeset/clean-kids-collect.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Radio Group no longer makes every Radio tabbable when Radio Group is enabled programmatically.

--- a/src/radio-group.test.interactions.ts
+++ b/src/radio-group.test.interactions.ts
@@ -315,31 +315,57 @@ it('updates the tabbable state of each radio when a radio is checked programmati
   expect(radios[1]?.tabIndex).to.equal(-1);
 });
 
-it('disables radios when disabled programmatically', async () => {
+it('disables radios when the group is disabled programmatically', async () => {
   const host = await fixture<GlideCoreRadioGroup>(html`
     <glide-core-radio-group label="Label">
-      <glide-core-radio-group-radio
-        label="One"
-        value="one"
-      ></glide-core-radio-group-radio>
+      <glide-core-radio-group-radio label="One"></glide-core-radio-group-radio>
+      <glide-core-radio-group-radio label="Two"></glide-core-radio-group-radio>
     </glide-core-radio-group>
   `);
 
   host.disabled = true;
   await host.updateComplete;
 
-  const radio = document.querySelector('glide-core-radio-group-radio');
+  const radios = document.querySelectorAll('glide-core-radio-group-radio');
 
-  expect(radio?.hasAttribute('disabled')).to.be.true;
-  expect(radio?.ariaDisabled).to.equal('true');
+  expect(radios[0]?.hasAttribute('disabled')).to.be.true;
+  expect(radios[0]?.ariaDisabled).to.equal('true');
+  expect(radios[1]?.hasAttribute('disabled')).to.be.true;
+  expect(radios[1]?.ariaDisabled).to.equal('true');
 });
 
-it('enables radios when enabled programmatically', async () => {
+it('enables radios when the group is enabled programmatically', async () => {
+  const host = await fixture<GlideCoreRadioGroup>(html`
+    <glide-core-radio-group label="Label" disabled>
+      <glide-core-radio-group-radio label="One"></glide-core-radio-group-radio>
+      <glide-core-radio-group-radio label="One"></glide-core-radio-group-radio>
+    </glide-core-radio-group>
+  `);
+
+  host.disabled = false;
+  await host.updateComplete;
+
+  const radios = document.querySelectorAll('glide-core-radio-group-radio');
+
+  expect(radios[0]?.hasAttribute('disabled')).to.be.false;
+  expect(radios[0]?.ariaDisabled).to.equal('false');
+  expect(radios[1]?.hasAttribute('disabled')).to.be.false;
+  expect(radios[1]?.ariaDisabled).to.equal('false');
+});
+
+it('makes the first enabled radio tabbable when the group is enabled programmatically', async () => {
   const host = await fixture<GlideCoreRadioGroup>(html`
     <glide-core-radio-group label="Label" disabled>
       <glide-core-radio-group-radio
-        label="One"
-        value="one"
+        label="Label"
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Label"
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Label"
       ></glide-core-radio-group-radio>
     </glide-core-radio-group>
   `);
@@ -347,10 +373,39 @@ it('enables radios when enabled programmatically', async () => {
   host.disabled = false;
   await host.updateComplete;
 
-  const radio = document.querySelector('glide-core-radio-group-radio');
+  const radios = host.querySelectorAll('glide-core-radio-group-radio');
 
-  expect(radio?.disabled).to.be.false;
-  expect(radio?.ariaDisabled).to.equal('false');
+  expect(radios[0]?.tabIndex).to.equal(0);
+  expect(radios[1]?.tabIndex).to.equal(-1);
+  expect(radios[2]?.tabIndex).to.equal(-1);
+});
+
+it('makes the first checked radio tabbable when the group is enabled programmatically', async () => {
+  const host = await fixture<GlideCoreRadioGroup>(html`
+    <glide-core-radio-group label="Label" disabled>
+      <glide-core-radio-group-radio
+        label="Label"
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Label"
+        checked
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Label"
+      ></glide-core-radio-group-radio>
+    </glide-core-radio-group>
+  `);
+
+  host.disabled = false;
+  await host.updateComplete;
+
+  const radios = host.querySelectorAll('glide-core-radio-group-radio');
+
+  expect(radios[0]?.tabIndex).to.equal(-1);
+  expect(radios[1]?.tabIndex).to.equal(0);
+  expect(radios[2]?.tabIndex).to.equal(-1);
 });
 
 it('does not check a radio on click when it is disabled', async () => {
@@ -368,7 +423,6 @@ it('does not check a radio on click when it is disabled', async () => {
   const radios = host.querySelectorAll('glide-core-radio-group-radio');
   await click(radios[1]);
 
-  expect(radios[0]).to.not.have.focus;
   expect(radios[0]?.hasAttribute('checked')).to.be.true;
   expect(radios[1]?.hasAttribute('checked')).to.be.false;
 });
@@ -441,7 +495,9 @@ it('makes the next enabled radio tabbable when the current one is disabled progr
   assert(radios[0]);
   radios[0].disabled = true;
 
+  expect(radios[0]?.tabIndex).to.equal(-1);
   expect(radios[1]?.tabIndex).to.equal(0);
+  expect(radios[2]?.tabIndex).to.equal(-1);
 });
 
 it('makes the first enabled radio tabbable when the current one is disabled programmatically', async () => {
@@ -473,7 +529,9 @@ it('makes the first enabled radio tabbable when the current one is disabled prog
   assert(radios[3]);
   radios[3].disabled = true;
 
+  expect(radios[0]?.tabIndex).to.equal(-1);
   expect(radios[1]?.tabIndex).to.equal(0);
+  expect(radios[2]?.tabIndex).to.equal(-1);
 });
 
 it('makes a radio tabbable when it is enabled programmatically and no other radio is tabbable', async () => {
@@ -501,5 +559,7 @@ it('makes a radio tabbable when it is enabled programmatically and no other radi
   assert(radios[1]);
   radios[1].disabled = false;
 
+  expect(radios[0]?.tabIndex).to.equal(-1);
   expect(radios[1].tabIndex).to.equal(0);
+  expect(radios[2]?.tabIndex).to.equal(-1);
 });

--- a/src/radio-group.ts
+++ b/src/radio-group.ts
@@ -91,8 +91,25 @@ export default class GlideCoreRadioGroup
     this.#isDisabled = isDisabled;
 
     for (const radio of this.#radioElements) {
+      this.#isEnablingOrDisablingTheGroup = true;
       radio.disabled = isDisabled;
-      radio.tabIndex = isDisabled ? -1 : 0;
+      this.#isEnablingOrDisablingTheGroup = false;
+
+      const firstCheckedRadio = this.#radioElements.find(
+        (radio) => radio.checked,
+      );
+
+      const firstEnabledRadio = this.#radioElements.find(
+        (radio) => !radio.disabled,
+      );
+
+      if (isDisabled) {
+        radio.tabIndex = -1;
+      } else if (radio === firstCheckedRadio) {
+        radio.tabIndex = 0;
+      } else if (!firstCheckedRadio && radio === firstEnabledRadio) {
+        radio.tabIndex = 0;
+      }
     }
   }
 
@@ -501,6 +518,8 @@ export default class GlideCoreRadioGroup
 
   #isDisabled = false;
 
+  #isEnablingOrDisablingTheGroup = false;
+
   #isRequired = false;
 
   #value = '';
@@ -713,6 +732,10 @@ export default class GlideCoreRadioGroup
   }
 
   #onRadiosDisabledChange(event: Event) {
+    if (this.#isEnablingOrDisablingTheGroup) {
+      return;
+    }
+
     if (
       event.target instanceof GlideCoreRadioGroupRadio &&
       event.target.disabled


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

- Radio Group no longer makes every Radio tabbable when Radio Group is enabled programmatically.
- Filled in some test gaps.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to Checkbox Group in Storybook.
2. Set `disabled` to `true`.
3. Set `disabled` to `false`.
4. Do some tabbing.
5. Verify only the first Radio is tabbable.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->

## 📸 Images and videos

N/A

<!--

  - Include images or videos of your visual changes.
  - Use the table below to show them side by side if possible.
  - Write "N/A" for non-visual changes.

  | Before | After |
  | ------ | ----- |
  | Image  | Image |

-->
