### PR TITLE
Dropdown fixes

### DIFF
--- a/.changeset/metal-queens-taste.md
+++ b/.changeset/metal-queens-taste.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Multiselect Dropdown no longer deselects initially selected options on first render.
+- Single-select Dropdown now only shows a checkmark for the last selected option if multiple are selected. Dropdown already only includes in its `value` the `value` of the last selected option. This change brings what the user sees as selected in line with what's submitted with the form.

--- a/src/dropdown.option.test.basics.ts
+++ b/src/dropdown.option.test.basics.ts
@@ -12,21 +12,6 @@ it('registers itself', async () => {
   );
 });
 
-it('is selectable', async () => {
-  const host = await fixture<GlideCoreDropdownOption>(
-    html`<glide-core-dropdown-option
-      label="Label"
-      selected
-    ></glide-core-dropdown-option>`,
-  );
-
-  const checkedIconContainer = host.shadowRoot?.querySelector(
-    '[data-test="checked-icon-container"] svg',
-  );
-
-  expect(checkedIconContainer?.checkVisibility()).to.be.true;
-});
-
 it('throws when `label` is empty', async () => {
   const spy = sinon.spy();
 

--- a/src/dropdown.option.ts
+++ b/src/dropdown.option.ts
@@ -127,27 +127,8 @@ export default class GlideCoreDropdownOption extends LitElement {
     this.#selected = isSelected;
     this.ariaSelected = isSelected.toString();
 
-    if (this.isMultiple) {
-      if (this.#checkboxElementRef.value) {
-        this.#checkboxElementRef.value.checked = isSelected;
-      }
-    } else {
-      // When not `this.isMultiple`, only one option may be selected at the time. This handles
-      // deselecting every other option when a new one is selected.
-      //
-      // Siblings modifying siblings is unusual but simplifies things for Dropdown. Dropdown
-      // selects and deselects options in various situations. So it's simpler and more reliable
-      // to iterate through them once here instead of doing so multiple times in Dropdown or
-      // else abstracting the deselection into a Dropdown method that will result in a bug
-      // when not used.
-      //
-      // `this.privateActive` would get the same treatment if not for Select All, which is in
-      // Dropdown's shadow DOM and so is inaccessible from this component.
-      for (const option of this.#optionElements) {
-        if (option !== this && this.selected && option.selected) {
-          option.selected = false;
-        }
-      }
+    if (this.isMultiple && this.#checkboxElementRef.value) {
+      this.#checkboxElementRef.value.checked = isSelected;
     }
 
     // Prefixed with "private" because Dropdown uses it internally, to track the set of
@@ -180,6 +161,11 @@ export default class GlideCoreDropdownOption extends LitElement {
     return (
       this.privateMultiple || this.closest('glide-core-dropdown')?.multiple
     );
+  }
+
+  @state()
+  private get lastSelectedOption() {
+    return this.#optionElements.findLast((option) => option.selected);
   }
 
   override click() {
@@ -381,7 +367,7 @@ export default class GlideCoreDropdownOption extends LitElement {
                 </div>
               </glide-core-tooltip>
 
-              ${when(this.selected, () => {
+              ${when(this.selected && this === this.lastSelectedOption, () => {
                 return html`<div
                   class="checked-icon-container"
                   data-test="checked-icon-container"

--- a/src/dropdown.test.basics.single.ts
+++ b/src/dropdown.test.basics.single.ts
@@ -1,4 +1,4 @@
-import { expect, fixture, html } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html } from '@open-wc/testing';
 import GlideCoreDropdown from './dropdown.js';
 import type GlideCoreDropdownOption from './dropdown.option.js';
 
@@ -166,4 +166,39 @@ it('has no icon when no option is selected', async () => {
   );
 
   expect(iconSlot).to.be.null;
+});
+
+it('only shows the last selected option as selected when multiple are selected initially', async () => {
+  const host = await fixture(
+    html`<glide-core-dropdown label="Label" open>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  expect(
+    options[0]?.shadowRoot
+      ?.querySelector('[data-test="checked-icon-container"] svg')
+      ?.checkVisibility(),
+  ).to.not.be.ok;
+
+  expect(
+    options[1]?.shadowRoot
+      ?.querySelector('[data-test="checked-icon-container"] svg')
+      ?.checkVisibility(),
+  ).to.be.true;
 });

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -2223,6 +2223,20 @@ export default class GlideCoreDropdown
   }
 
   #onOptionsSelectedChange(event: Event) {
+    if (!this.multiple) {
+      for (const option of this.#optionElements) {
+        if (
+          option !== event.target &&
+          event.target instanceof GlideCoreDropdownOption &&
+          event.target.selected &&
+          option.selected &&
+          event.target !== this.#selectAllElementRef.value
+        ) {
+          option.selected = false;
+        }
+      }
+    }
+
     if (
       event.target !== this.#selectAllElementRef.value &&
       !this.#isSelectionChangeFromSelectAll &&


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

- Multiselect Dropdown no longer deselects initially selected options on first render.
- Single-select Dropdown now only shows a checkmark for the last selected option if multiple are selected.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

### Multiselect Dropdown no longer deselects initially selected options on first render

1. Check out this branch.
2. Set `multiple` in `dropdown.stories.ts`.
3. Set a couple options as selected in `dropdown.stories.ts`.
4. Verify in Storybook that those options are selected.

### Single-select Dropdown now only shows a checkmark for the last selected option if multiple are selected

1. Check out this branch.
2. Set the first two options as selected in `dropdown.stories.ts`.
3. Verify in Storybook that only the second option has a checkmark.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
