### PR TITLE
Show `not-allowed` cursor on each Checkbox Group Checkbox

### DIFF
--- a/.changeset/perfect-turkeys-kick.md
+++ b/.changeset/perfect-turkeys-kick.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Checkboxes when disabled and used with Checkbox Group now show a `not-allowed` cursor on hover.
+- Multiselectable Dropdown Options when disabled now show a `not-allowed` cursor on hover.

--- a/src/checkbox.styles.ts
+++ b/src/checkbox.styles.ts
@@ -43,6 +43,10 @@ export default [
       flex-shrink: 0;
       inline-size: 0.875rem;
       position: relative;
+
+      &.disabled {
+        cursor: not-allowed;
+      }
     }
 
     .checkbox {

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -308,7 +308,12 @@ export default class GlideCoreCheckbox
             })}
             part="private-label-and-input-and-checkbox"
           >
-            <div class="input-and-checkbox">
+            <div
+              class=${classMap({
+                'input-and-checkbox': true,
+                disabled: this.disabled,
+              })}
+            >
               <input
                 aria-invalid=${this.#isShowValidationFeedback}
                 class="input"


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

- Checkboxes when disabled and used with Checkbox Group now show a `not-allowed` cursor on hover.
- Multiselect Dropdown Options when disabled now show a `not-allowed` cursor on hover.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to Checkbox Group in Storybook.
2. Set `disabled` to `true`.
3. Hover over each Checkbox.
4. Verify each has a `not-allowed` cursor.
5. Rinse and repeat for multiselect Dropdown.

I would have added visual tests. But there doesn't appear to be a way to include the cursor in screenshots.


<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
