### PR TITLE
Disabled Dropdown Option fixes

### DIFF
--- a/.changeset/itchy-carrots-love.md
+++ b/.changeset/itchy-carrots-love.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Dropdown now removes from its `value` the `value` of a selected Dropdown Option that is disabled. This also works in reverse. If a disabled but selected Dropdown Option is enabled, it's `value` is added to Dropdown's `value`.

--- a/.changeset/mighty-apricots-burn.md
+++ b/.changeset/mighty-apricots-burn.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Multiselect Dropdown no longer shows the checkboxes of selected but disabled options as checked. This change brings what the user sees as selected in line with what's submitted with the form. Same change and thinking for single-select Dropdown.
+- Dropdown Option now correctly sets `aria-selected` when selected then disabled or enabled programmatically.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2205,6 +2205,12 @@
               }
             },
             {
+              "name": "private-disabled-change",
+              "type": {
+                "text": "Event"
+              }
+            },
+            {
               "name": "private-editable-change",
               "type": {
                 "text": "Event"
@@ -2380,7 +2386,7 @@
           "slots": [
             {
               "name": "icon:value",
-              "description": "Icons for the selected option or options. Slot one icon per option. \\`<value>\\` should be equal to the \\`value\\` of each option.",
+              "description": "Icons for the selected option or options. Slot one icon per Dropdown Option. \\`<value>\\` should be equal to the \\`value\\` of each Dropdown Option.",
               "type": {
                 "text": "Element"
               }

--- a/src/dropdown.option.test.basics.multiple.ts
+++ b/src/dropdown.option.test.basics.multiple.ts
@@ -44,3 +44,30 @@ it('is editable', async () => {
   const button = host.shadowRoot?.querySelector('[data-test="edit-button"]');
   expect(button?.checkVisibility()).to.be.true;
 });
+
+it('is unchecked when selected and enabled', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      private-multiple
+      selected
+    ></glide-core-dropdown-option>`,
+  );
+
+  const checkbox = host.shadowRoot?.querySelector('glide-core-checkbox');
+  expect(checkbox?.checked).to.be.true;
+});
+
+it('is unchecked when selected and disabled', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      disabled
+      private-multiple
+      selected
+    ></glide-core-dropdown-option>`,
+  );
+
+  const checkbox = host.shadowRoot?.querySelector('glide-core-checkbox');
+  expect(checkbox?.checked).to.be.false;
+});

--- a/src/dropdown.option.test.basics.single.ts
+++ b/src/dropdown.option.test.basics.single.ts
@@ -1,7 +1,7 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import GlideCoreDropdownOption from './dropdown.option.js';
 
-it('seta `aria-selected` when selected', async () => {
+it('sets `aria-selected` when selected', async () => {
   const host = await fixture<GlideCoreDropdownOption>(
     html`<glide-core-dropdown-option
       label="Label"
@@ -12,7 +12,7 @@ it('seta `aria-selected` when selected', async () => {
   expect(host.ariaSelected).to.equal('true');
 });
 
-it('does not set `aria-selected` when unselected', async () => {
+it('sets `aria-selected` when unselected', async () => {
   const host = await fixture<GlideCoreDropdownOption>(
     html`<glide-core-dropdown-option
       label="Label"
@@ -32,4 +32,35 @@ it('is editable', async () => {
 
   const button = host.shadowRoot?.querySelector('[data-test="edit-button"]');
   expect(button?.checkVisibility()).to.be.true;
+});
+
+it('is checked when selected', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      selected
+    ></glide-core-dropdown-option>`,
+  );
+
+  const checkmark = host.shadowRoot?.querySelector(
+    '[data-test="checked-icon-container"] svg',
+  );
+
+  expect(checkmark?.checkVisibility()).to.be.true;
+});
+
+it('is unchecked when selected and disabled', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      selected
+      disabled
+    ></glide-core-dropdown-option>`,
+  );
+
+  const checkmark = host.shadowRoot?.querySelector(
+    '[data-test="checked-icon-container"] svg',
+  );
+
+  expect(checkmark?.checkVisibility()).to.not.be.ok;
 });

--- a/src/dropdown.option.test.basics.ts
+++ b/src/dropdown.option.test.basics.ts
@@ -12,6 +12,39 @@ it('registers itself', async () => {
   );
 });
 
+it('sets `aria-selected` when selected', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      selected
+    ></glide-core-dropdown-option>`,
+  );
+
+  expect(host.ariaSelected).to.equal('true');
+});
+
+it('sets `aria-selected` when unselected', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+    ></glide-core-dropdown-option>`,
+  );
+
+  expect(host.ariaSelected).to.equal('false');
+});
+
+it('sets `aria-selected` when disabled', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      selected
+      disabled
+    ></glide-core-dropdown-option>`,
+  );
+
+  expect(host.ariaSelected).to.equal('false');
+});
+
 it('throws when `label` is empty', async () => {
   const spy = sinon.spy();
 

--- a/src/dropdown.option.test.interactions.multiple.ts
+++ b/src/dropdown.option.test.interactions.multiple.ts
@@ -58,3 +58,36 @@ it('sets `privateIsEditActive`', async () => {
   await hover(button, 'outside');
   expect(host.privateIsEditActive).to.be.false;
 });
+
+it('is checked when selected and programmatically enabled', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      private-multiple
+      disabled
+      selected
+    ></glide-core-dropdown-option>`,
+  );
+
+  host.disabled = false;
+  await host.updateComplete;
+
+  const checkbox = host.shadowRoot?.querySelector('glide-core-checkbox');
+  expect(checkbox?.checked).to.be.true;
+});
+
+it('is unchecked when selected and programmatically disabled', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      private-multiple
+      selected
+    ></glide-core-dropdown-option>`,
+  );
+
+  host.disabled = true;
+  await host.updateComplete;
+
+  const checkbox = host.shadowRoot?.querySelector('glide-core-checkbox');
+  expect(checkbox?.checked).to.be.false;
+});

--- a/src/dropdown.option.test.interactions.single.ts
+++ b/src/dropdown.option.test.interactions.single.ts
@@ -95,6 +95,54 @@ it('has no tooltip when active and with a short label set programmatically', asy
   expect(tooltip?.open).to.be.false;
 });
 
+it('sets `aria-selected` when selected programmatically', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+    ></glide-core-dropdown-option>`,
+  );
+
+  host.selected = true;
+  expect(host.ariaSelected).to.equal('true');
+});
+
+it('sets `aria-selected` when deselected programmatically', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      selected
+    ></glide-core-dropdown-option>`,
+  );
+
+  host.selected = false;
+  expect(host.ariaSelected).to.equal('false');
+});
+
+it('sets `aria-selected` when disabled programmatically', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      selected
+    ></glide-core-dropdown-option>`,
+  );
+
+  host.disabled = true;
+  expect(host.ariaSelected).to.equal('false');
+});
+
+it('sets `aria-selected` when enabled programmatically', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      disabled
+      selected
+    ></glide-core-dropdown-option>`,
+  );
+
+  host.disabled = false;
+  expect(host.ariaSelected).to.equal('true');
+});
+
 it('sets `privateIsEditActive`', async () => {
   const host = await fixture<GlideCoreDropdownOption>(
     html`<glide-core-dropdown-option
@@ -110,4 +158,41 @@ it('sets `privateIsEditActive`', async () => {
 
   await hover(button, 'outside');
   expect(host.privateIsEditActive).to.be.false;
+});
+
+it('is checked when programmatically enabled', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      disabled
+      selected
+    ></glide-core-dropdown-option>`,
+  );
+
+  host.disabled = false;
+  await host.updateComplete;
+
+  const checkmark = host.shadowRoot?.querySelector(
+    '[data-test="checked-icon-container"] svg',
+  );
+
+  expect(checkmark?.checkVisibility()).to.be.true;
+});
+
+it('is unchecked when programmatically disabled', async () => {
+  const host = await fixture<GlideCoreDropdownOption>(
+    html`<glide-core-dropdown-option
+      label="Label"
+      selected
+    ></glide-core-dropdown-option>`,
+  );
+
+  host.disabled = true;
+  await host.updateComplete;
+
+  const checkmark = host.shadowRoot?.querySelector(
+    '[data-test="checked-icon-container"] svg',
+  );
+
+  expect(checkmark?.checkVisibility()).to.not.be.ok;
 });

--- a/src/dropdown.test.basics.multiple.ts
+++ b/src/dropdown.test.basics.multiple.ts
@@ -342,3 +342,25 @@ it('has no "single-select" icon', async () => {
 
   expect(iconSlot).to.be.null;
 });
+
+it('does not include in its `value` disabled options that are selected', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" multiple>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        disabled
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        disabled
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  expect(host.value).to.deep.equal([]);
+});

--- a/src/dropdown.test.basics.single.ts
+++ b/src/dropdown.test.basics.single.ts
@@ -202,3 +202,18 @@ it('only shows the last selected option as selected when multiple are selected i
       ?.checkVisibility(),
   ).to.be.true;
 });
+
+it('does not include in its `value` disabled options that are selected', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="Label"
+        value="value"
+        disabled
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  expect(host.value).to.deep.equal([]);
+});

--- a/src/dropdown.test.forms.multiple.ts
+++ b/src/dropdown.test.forms.multiple.ts
@@ -37,10 +37,9 @@ it('can be reset', async () => {
 
   await host.updateComplete;
 
-  expect(host.value).to.deep.equal([]);
-
   const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
 
+  expect(host.value).to.deep.equal([]);
   expect(label?.textContent?.trim()).to.equal('Placeholder');
 });
 

--- a/src/dropdown.test.interactions.multiple.ts
+++ b/src/dropdown.test.interactions.multiple.ts
@@ -1410,9 +1410,120 @@ it('clicks its primary button when `click()` is called', async () => {
   });
 
   const button = host.shadowRoot?.querySelector('[data-test="primary-button"]');
-
   assert(button);
 
   const event = await oneEvent(button, 'click');
   expect(event instanceof PointerEvent).to.be.true;
+});
+
+it('adds the `value` of a programmatically enabled option to its `value`', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" multiple>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        disabled
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = host.querySelector('glide-core-dropdown-option');
+
+  assert(option);
+  option.disabled = false;
+
+  expect(host.value).to.deep.equal(['two', 'one']);
+});
+
+it('removes the `value` of a programmatically disabled option from its `value`', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = host.querySelector('glide-core-dropdown-option');
+
+  assert(option);
+  option.disabled = true;
+
+  expect(host.value).to.deep.equal(['two']);
+});
+
+it('updates its tags when a selected option is enabled programmatically', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" multiple>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        disabled
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = host.querySelector('glide-core-dropdown-option');
+  assert(option);
+
+  option.disabled = false;
+  await host.updateComplete;
+
+  const tagContainers = host.shadowRoot?.querySelectorAll<HTMLElement>(
+    '[data-test="tag-container"]',
+  );
+
+  expect(tagContainers?.length).to.equal(2);
+});
+
+it('updates its tags when a selected option is disabled programmatically', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" multiple>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = host.querySelector('glide-core-dropdown-option');
+  assert(option);
+
+  option.disabled = true;
+  await host.updateComplete;
+
+  const tagContainers = host.shadowRoot?.querySelectorAll<HTMLElement>(
+    '[data-test="tag-container"]',
+  );
+
+  expect(tagContainers?.length).to.equal(1);
 });

--- a/src/dropdown.test.interactions.single.ts
+++ b/src/dropdown.test.interactions.single.ts
@@ -700,3 +700,106 @@ it('unhides its options when made unfilterable', async () => {
 
   expect(options.length).to.equal(2);
 });
+
+it('adds the `value` of a programmatically enabled option to its `value`', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        disabled
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = host.querySelector('glide-core-dropdown-option');
+
+  assert(option);
+  option.disabled = false;
+
+  expect(host.value).to.deep.equal(['one']);
+});
+
+it('removes the `value` of a programmatically disabled option from its `value`', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = host.querySelector('glide-core-dropdown-option');
+
+  assert(option);
+  option.disabled = true;
+
+  expect(host.value).to.deep.equal([]);
+  expect(option.selected).to.be.true;
+});
+
+it('updates its internal label when a selected option is enabled programmatically', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        disabled
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = host.querySelector('glide-core-dropdown-option');
+  assert(option);
+
+  option.disabled = false;
+  await host.updateComplete;
+
+  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
+  expect(label?.textContent?.trim()).to.equal('One');
+});
+
+it('updates its internal label when a selected option is disabled programmatically', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = host.querySelector('glide-core-dropdown-option');
+  assert(option);
+
+  option.disabled = true;
+  await host.updateComplete;
+
+  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
+  expect(label?.textContent?.trim()).to.equal('');
+});


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

### Minor

Dropdown now removes from its `value` the `value` of a selected Dropdown Option that is disabled. This also works in reverse. If a disabled but selected Dropdown Option is enabled, it's `value` is added to Dropdown's `value`.

### Patch

- Multiselect Dropdown no longer shows the checkboxes of selected but disabled options as checked. This change brings what the user sees as selected in line with what's submitted with the form. Same change and thinking for single-select Dropdown.
- Dropdown Option now correctly sets `aria-selected` when selected then disabled or enabled programmatically.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

### Dropdown now removes from its `value` the `value` of a selected Dropdown Option that is disabled

1. Navigate to Dropdown in Storybook.
2. Selected the first option.
3. Disable the option.
4. Verify Dropdown's `value` no longer includes the `value` of the option.
5. Verify Dropdown's internal label is no longer equal to the `label` of the option.
6. Do the same for multiselect Dropdown.

### Multiselect Dropdown no longer shows the checkboxes of selected but disabled options as checked

1. Navigate to [multiselect Dropdown](https://glide-core.crowdstrike-ux.workers.dev/dropdown-disabled-fixes?path=/story/dropdown--dropdown&args=multiple:!true) in Storybook.
2. Select a couple options.
3. Disable an option.
4. Verify the option's checkbox is unchecked.
5. Do the same for single-select Dropdown.

### Dropdown Option now correctly sets `aria-selected` when selected then disabled or enabled programmatically

1. Navigate to Dropdown in Storybook.
2. Select an option.
3. Disable the option.
4. Verify `aria-selected` is `"false"`.
6. Enable the option.
7. Verify `aria-selected` is `"true"`.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
