### PR TITLE
Add Storybook title add-on

### DIFF
--- a/.storybook/manager.jsx
+++ b/.storybook/manager.jsx
@@ -3,6 +3,7 @@ import '../src/styles/variables.css';
 import { addons, types, useStorybookApi } from '@storybook/manager-api';
 import { create } from '@storybook/theming/create';
 import { html } from 'lit';
+import { STORY_RENDERED } from '@storybook/core-events';
 import { IconButton, Icons } from '@storybook/components';
 import logo from './assets/logo.png';
 import React from 'react';
@@ -33,6 +34,17 @@ addons.register('github', () => {
         </IconButton>
       );
     },
+  });
+});
+
+addons.register('title', (api) => {
+  api?.on(STORY_RENDERED, () => {
+    const storyData = api.getCurrentStoryData();
+
+    document.title =
+      storyData && storyData.title
+        ? `${storyData.title} ⋅ Glide Core`
+        : 'Glide Core';
   });
 });
 

--- a/src/accordion.test.interactions.ts
+++ b/src/accordion.test.interactions.ts
@@ -106,7 +106,7 @@ it('closes on click when animated', async () => {
     </glide-core-accordion>`,
   );
 
-  await click(host);
+  click(host);
 
   let animation: Animation | undefined;
   let isAnimationFinished = false;


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Adds an add-on that changes Storybook's `document.title` to either "Glide Core" or "[component] ⋅ Glide Core".

It's certainly a hack. You'll notice Storybook's default title flash briefly (depending on network latency) before being replaced. So let me know what you think.

I'm surprised there's not a supported way to do this. Or maybe there is and I just couldn't find it?

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to a few stories. 
2. Verify that each story's title is correct.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
