### PR TITLE
Add `tooltip` attribute to Button

### DIFF
--- a/.changeset/flat-buses-compare.md
+++ b/.changeset/flat-buses-compare.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Button now supports a `tooltip` attribute for showing a tooltip when Button is disabled.
+- Button is now focusable when disabled to support showing a tooltip.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -315,7 +315,7 @@ export default class Component extends LitElement {
 @customElement('glide-core-example')
 export default class Component extends LitElement {
   override render() {
-    return html` <button part="component">Button</button>`;
+    return html`<button part="component">Button</button>`;
   }
 }
 ```

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -671,6 +671,15 @@
             },
             {
               "kind": "field",
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "tooltip",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "type",
               "type": {
                 "text": "'button' | 'submit' | 'reset'"
@@ -754,6 +763,13 @@
               },
               "default": "'large'",
               "fieldName": "size"
+            },
+            {
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "tooltip"
             },
             {
               "name": "type",

--- a/src/aria-snapshots/button-test-aria-ts-tooltip.yml
+++ b/src/aria-snapshots/button-test-aria-ts-tooltip.yml
@@ -1,0 +1,2 @@
+- button "Label" [disabled]
+- tooltip "Tooltip"

--- a/src/button.stories.ts
+++ b/src/button.stories.ts
@@ -31,6 +31,7 @@ const meta: Meta = {
         label=${arguments_.label || nothing}
         name=${arguments_.name || nothing}
         size=${arguments_.size || nothing}
+        tooltip=${arguments_.tooltip || nothing}
         type=${arguments_.type || nothing}
         value=${arguments_.value || nothing}
         variant=${arguments_.variant || nothing}
@@ -49,6 +50,7 @@ const meta: Meta = {
     'slot="prefix-icon"': '',
     'slot="suffix-icon"': '',
     type: 'button',
+    tooltip: '',
     value: '',
     variant: 'primary',
     version: '',
@@ -106,6 +108,14 @@ const meta: Meta = {
         type: { summary: 'Element' },
       },
     },
+    tooltip: {
+      table: {
+        type: {
+          summary: 'string',
+          detail: 'Shown when Button is disabled',
+        },
+      },
+    },
     type: {
       control: { type: 'select' },
       options: ['button', 'reset', 'submit'],
@@ -160,6 +170,7 @@ export const WithIcons: StoryObj = {
         label=${arguments_.label || nothing}
         name=${arguments_.name || nothing}
         size=${arguments_.size || nothing}
+        tooltip=${arguments_.tooltip || nothing}
         type=${arguments_.type || nothing}
         value=${arguments_.value || nothing}
         variant=${arguments_.variant || nothing}

--- a/src/button.styles.ts
+++ b/src/button.styles.ts
@@ -34,7 +34,7 @@ export default [
         outline: none;
       }
 
-      &:disabled {
+      &.disabled {
         cursor: not-allowed;
         opacity: 1;
       }
@@ -54,7 +54,7 @@ export default [
         border-color: transparent;
         color: var(--glide-core-private-color-button-text-primary);
 
-        &:disabled {
+        &.disabled {
           background-color: var(
             --glide-core-color-interactive-surface-container--disabled
           );
@@ -62,7 +62,7 @@ export default [
           color: var(--glide-core-color-interactive-text-link--disabled);
         }
 
-        &:not(:disabled):active {
+        &:not(.disabled):active {
           background-color: var(
             --glide-core-private-color-button-surface-active
           );
@@ -70,7 +70,7 @@ export default [
           color: var(--glide-core-private-color-button-text-primary);
         }
 
-        &:not(:active):hover:not(:disabled) {
+        &:not(:active):hover:not(.disabled) {
           background-color: var(
             --glide-core-color-interactive-surface-container--hover
           );
@@ -85,7 +85,7 @@ export default [
         border-color: var(--glide-core-private-color-button-stroke-default);
         color: var(--glide-core-color-interactive-text-link);
 
-        &:disabled {
+        &.disabled {
           background-color: var(
             --glide-core-color-interactive-surface-container--disabled
           );
@@ -93,7 +93,7 @@ export default [
           color: var(--glide-core-color-interactive-text-link--disabled);
         }
 
-        &:not(:disabled):active {
+        &:not(.disabled):active {
           background-color: var(
             --glide-core-private-color-button-surface-active
           );
@@ -101,7 +101,7 @@ export default [
           color: var(--glide-core-private-color-button-text-primary);
         }
 
-        &:not(:active):hover:not(:disabled) {
+        &:not(:active):hover:not(.disabled) {
           background-color: var(
             --glide-core-color-interactive-surface-container--hover
           );
@@ -116,18 +116,18 @@ export default [
         border-color: transparent;
         color: var(--glide-core-color-interactive-text-link);
 
-        &:disabled {
+        &.disabled {
           color: var(--glide-core-color-interactive-text-link--disabled);
         }
 
-        &:not(:disabled):active {
+        &:not(.disabled):active {
           background-color: var(
             --glide-core-private-color-button-surface-active
           );
           color: var(--glide-core-private-color-button-text-primary);
         }
 
-        &:not(:active):hover:not(:disabled) {
+        &:not(:active):hover:not(.disabled) {
           background-color: var(
             --glide-core-color-interactive-surface-container--hover
           );

--- a/src/button.test.aria.ts
+++ b/src/button.test.aria.ts
@@ -22,3 +22,20 @@ test('disabled=${false}', async ({ page }, test) => {
     name: `${test.titlePath.join('.')}.yml`,
   });
 });
+
+test('tooltip', async ({ page }, test) => {
+  await page.goto('?id=button--button');
+
+  await page
+    .locator('glide-core-button')
+    .evaluate<void, GlideCoreButton>((element) => {
+      element.disabled = true;
+      element.tooltip = 'Tooltip';
+    });
+
+  await page.locator('glide-core-tooltip').getByRole('button').focus();
+
+  await expect(page.locator('glide-core-button')).toMatchAriaSnapshot({
+    name: `${test.titlePath.join('.')}.yml`,
+  });
+});

--- a/src/button.test.events.ts
+++ b/src/button.test.events.ts
@@ -1,5 +1,6 @@
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import GlideCoreButton from './button.js';
 import { click } from './library/mouse.js';
 
@@ -45,6 +46,20 @@ it('dispatches a "click" event on Enter', async () => {
   expect(event.bubbles).to.be.true;
 });
 
+it('does not dispatch a "click" event on Enter when disabled', async () => {
+  const host = await fixture<GlideCoreButton>(html`
+    <glide-core-button label="Label" disabled></glide-core-button>
+  `);
+
+  const spy = sinon.spy();
+  host.addEventListener('click', spy);
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Enter' });
+
+  expect(spy.callCount).to.equal(0);
+});
+
 it('dispatches a "click" event on Space', async () => {
   const host = await fixture<GlideCoreButton>(html`
     <glide-core-button label="Label"></glide-core-button>
@@ -59,11 +74,25 @@ it('dispatches a "click" event on Space', async () => {
   expect(event.bubbles).to.be.true;
 });
 
+it('does not dispatch a "click" event on Space when disabled', async () => {
+  const host = await fixture<GlideCoreButton>(html`
+    <glide-core-button label="Label" disabled></glide-core-button>
+  `);
+
+  const spy = sinon.spy();
+  host.addEventListener('click', spy);
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: ' ' });
+
+  expect(spy.callCount).to.equal(0);
+});
+
 it('dispatches a "reset" event on click', async () => {
   const form = document.createElement('form');
 
   const host = await fixture<GlideCoreButton>(
-    html` <glide-core-button label="Label" type="reset"></glide-core-button>`,
+    html`<glide-core-button label="Label" type="reset"></glide-core-button>`,
     {
       parentNode: form,
     },
@@ -75,11 +104,33 @@ it('dispatches a "reset" event on click', async () => {
   expect(event instanceof Event).to.be.true;
 });
 
+it('does not dispatch a "reset" event on click when disabled', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<GlideCoreButton>(
+    html`<glide-core-button
+      label="Label"
+      type="reset"
+      disabled
+    ></glide-core-button>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const spy = sinon.spy();
+  form.addEventListener('reset', spy);
+
+  await click(host);
+
+  expect(spy.callCount).to.equal(0);
+});
+
 it('dispatches a "reset" event on Enter', async () => {
   const form = document.createElement('form');
 
   await fixture<GlideCoreButton>(
-    html` <glide-core-button label="Label" type="reset"></glide-core-button>`,
+    html`<glide-core-button label="Label" type="reset"></glide-core-button>`,
     {
       parentNode: form,
     },
@@ -92,11 +143,34 @@ it('dispatches a "reset" event on Enter', async () => {
   expect(event instanceof Event).to.be.true;
 });
 
+it('does not dispatch a "reset" event on Enter when disabled', async () => {
+  const form = document.createElement('form');
+
+  await fixture<GlideCoreButton>(
+    html`<glide-core-button
+      label="Label"
+      type="reset"
+      disabled
+    ></glide-core-button>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const spy = sinon.spy();
+  form.addEventListener('reset', spy);
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Enter' });
+
+  expect(spy.callCount).to.equal(0);
+});
+
 it('dispatches a "reset" event on Space', async () => {
   const form = document.createElement('form');
 
   const host = await fixture<GlideCoreButton>(
-    html` <glide-core-button label="Label" type="reset"></glide-core-button>`,
+    html`<glide-core-button label="Label" type="reset"></glide-core-button>`,
     {
       parentNode: form,
     },
@@ -109,11 +183,34 @@ it('dispatches a "reset" event on Space', async () => {
   expect(event instanceof Event).to.be.true;
 });
 
+it('does not dispatch a "reset" event on Space when disabled', async () => {
+  const form = document.createElement('form');
+
+  await fixture<GlideCoreButton>(
+    html`<glide-core-button
+      label="Label"
+      type="reset"
+      disabled
+    ></glide-core-button>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const spy = sinon.spy();
+  form.addEventListener('reset', spy);
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: ' ' });
+
+  expect(spy.callCount).to.equal(0);
+});
+
 it('dispatches a "submit" event on click', async () => {
   const form = document.createElement('form');
 
   const host = await fixture<GlideCoreButton>(
-    html` <glide-core-button label="Label" type="submit"></glide-core-button>`,
+    html`<glide-core-button label="Label" type="submit"></glide-core-button>`,
     {
       parentNode: form,
     },
@@ -127,11 +224,33 @@ it('dispatches a "submit" event on click', async () => {
   expect(event instanceof Event).to.be.true;
 });
 
+it('does not dispatch a "submit" event on click when disabled', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<GlideCoreButton>(
+    html`<glide-core-button
+      label="Label"
+      type="submit"
+      disabled
+    ></glide-core-button>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const spy = sinon.spy();
+  form.addEventListener('submit', spy);
+
+  await click(host);
+
+  expect(spy.callCount).to.equal(0);
+});
+
 it('dispatches a "submit" event on Enter', async () => {
   const form = document.createElement('form');
 
   await fixture<GlideCoreButton>(
-    html` <glide-core-button label="Label" type="submit"></glide-core-button>`,
+    html`<glide-core-button label="Label" type="submit"></glide-core-button>`,
     {
       parentNode: form,
     },
@@ -146,11 +265,34 @@ it('dispatches a "submit" event on Enter', async () => {
   expect(event instanceof Event).to.be.true;
 });
 
+it('does not dispatch a "submit" event on Enter when disabled', async () => {
+  const form = document.createElement('form');
+
+  await fixture<GlideCoreButton>(
+    html`<glide-core-button
+      label="Label"
+      type="submit"
+      disabled
+    ></glide-core-button>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const spy = sinon.spy();
+  form.addEventListener('submit', spy);
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Enter' });
+
+  expect(spy.callCount).to.equal(0);
+});
+
 it('dispatches a "submit" event on Space', async () => {
   const form = document.createElement('form');
 
   await fixture<GlideCoreButton>(
-    html` <glide-core-button label="Label" type="submit"></glide-core-button>`,
+    html`<glide-core-button label="Label" type="submit"></glide-core-button>`,
     {
       parentNode: form,
     },
@@ -163,4 +305,27 @@ it('dispatches a "submit" event on Space', async () => {
 
   const event = await oneEvent(form, 'submit');
   expect(event instanceof Event).to.be.true;
+});
+
+it('does not dispatch a "submit" event on Space when disabled', async () => {
+  const form = document.createElement('form');
+
+  await fixture<GlideCoreButton>(
+    html`<glide-core-button
+      label="Label"
+      type="submit"
+      disabled
+    ></glide-core-button>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const spy = sinon.spy();
+  form.addEventListener('submit', spy);
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: ' ' });
+
+  expect(spy.callCount).to.equal(0);
 });

--- a/src/button.test.visuals.ts
+++ b/src/button.test.visuals.ts
@@ -84,13 +84,32 @@ for (const story of stories.Button) {
           });
         });
 
-        test(':focus', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-          await page.locator('glide-core-button').focus();
+        test.describe(':focus', () => {
+          test('disabled=${true}', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
+            await page
+              .locator('glide-core-button')
+              .evaluate<void, GlideCoreButton>((element) => {
+                element.disabled = true;
+                element.tooltip = 'Tooltip';
+              });
+
+            await page.locator('glide-core-button').focus();
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('disabled=${false}', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+            await page.locator('glide-core-button').focus();
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
         });
 
         test.describe(':hover', () => {
@@ -101,6 +120,7 @@ for (const story of stories.Button) {
               .locator('glide-core-button')
               .evaluate<void, GlideCoreButton>((element) => {
                 element.disabled = true;
+                element.tooltip = 'Tooltip';
               });
 
             await page.locator('glide-core-button').hover();

--- a/src/modal.test.aria.ts
+++ b/src/modal.test.aria.ts
@@ -111,7 +111,7 @@ test('slot="tertiary"', async ({ page }, test) => {
       element.open = true;
     });
 
-  await page.locator('glide-core-tooltip').getByRole('button').focus();
+  await page.locator('glide-core-tooltip').first().getByRole('button').focus();
 
   await expect(page.locator('glide-core-modal')).toMatchAriaSnapshot({
     name: `${test.titlePath.join('.')}.yml`,


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

- Button now supports a `tooltip` attribute for showing a tooltip when Button is disabled.
- Button is now focusable when disabled to support showing a tooltip.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to Button in Storybook.
1. Set `tooltip` to something.
1. Hover Button.
1. Verify a tooltip isn't shown.
1. Set `disabled` to `true`.
1. Hover Button.
1. Verify a tooltip is shown.
1. Tab to Button.
1. Verify a tooltip is shown.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
