### PR TITLE
Checkbox Group fixes

### DIFF
--- a/.changeset/perfect-jobs-remember.md
+++ b/.changeset/perfect-jobs-remember.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+- Checkbox Group's `value` is no longer reflected to match native.
+- Checkbox Group now removes from its `value` the `value` of a checked Checkbox that is disabled. This also works in reverse. If a disabled but checked Checkbox is enabled, it's `value` is added to Checkbox Group's `value`.

--- a/.changeset/strange-lions-peel.md
+++ b/.changeset/strange-lions-peel.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Checkbox Group now updates its `value` when a Checkbox is checked or unchecked programmatically.
+- Checkbox Group now updates its `value` when its form is reset.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1027,8 +1027,7 @@
                 "text": "string[]"
               },
               "default": "[]",
-              "attribute": "value",
-              "reflects": true
+              "attribute": "value"
             },
             {
               "kind": "field",
@@ -1654,6 +1653,18 @@
             },
             {
               "name": "invalid",
+              "type": {
+                "text": "Event"
+              }
+            },
+            {
+              "name": "private-checked-change",
+              "type": {
+                "text": "Event"
+              }
+            },
+            {
+              "name": "private-disabled-change",
               "type": {
                 "text": "Event"
               }

--- a/src/checkbox-group.stories.ts
+++ b/src/checkbox-group.stories.ts
@@ -232,19 +232,19 @@ const meta: Meta = {
           },
         });
 
-        // const checkboxes = context.canvasElement.querySelectorAll(
-        //   'glide-core-checkbox',
-        // );
+        const checkboxes = context.canvasElement.querySelectorAll(
+          'glide-core-checkbox',
+        );
 
-        // for (const checkbox of checkboxes) {
-        //   addons.getChannel().emit(UPDATE_STORY_ARGS, {
-        //     storyId: context.id,
-        //     updatedArgs: {
-        //       [`<glide-core-checkbox>.${checkbox.value}.checked`]:
-        //         checkboxGroup.value.includes(checkbox.value),
-        //     },
-        //   });
-        // }
+        for (const checkbox of checkboxes) {
+          addons.getChannel().emit(UPDATE_STORY_ARGS, {
+            storyId: context.id,
+            updatedArgs: {
+              [`<glide-core-checkbox>.${checkbox.value}.checked`]:
+                checkboxGroup.value.includes(checkbox.value),
+            },
+          });
+        }
       });
     }
   },

--- a/src/checkbox-group.stories.ts
+++ b/src/checkbox-group.stories.ts
@@ -232,19 +232,19 @@ const meta: Meta = {
           },
         });
 
-        const checkboxes = context.canvasElement.querySelectorAll(
-          'glide-core-checkbox',
-        );
+        // const checkboxes = context.canvasElement.querySelectorAll(
+        //   'glide-core-checkbox',
+        // );
 
-        for (const checkbox of checkboxes) {
-          addons.getChannel().emit(UPDATE_STORY_ARGS, {
-            storyId: context.id,
-            updatedArgs: {
-              [`<glide-core-checkbox>.${checkbox.value}.checked`]:
-                checkboxGroup.value.includes(checkbox.value),
-            },
-          });
-        }
+        // for (const checkbox of checkboxes) {
+        //   addons.getChannel().emit(UPDATE_STORY_ARGS, {
+        //     storyId: context.id,
+        //     updatedArgs: {
+        //       [`<glide-core-checkbox>.${checkbox.value}.checked`]:
+        //         checkboxGroup.value.includes(checkbox.value),
+        //     },
+        //   });
+        // }
       });
     }
   },

--- a/src/checkbox-group.test.basics.ts
+++ b/src/checkbox-group.test.basics.ts
@@ -41,6 +41,31 @@ it('enables checkboxes when `value` is set initially', async () => {
   expect(checkbox?.disabled).to.be.false;
 });
 
+it('does not include in its `value` disabled checkboxes that are checked', async () => {
+  const host = await fixture<GlideCoreCheckboxGroup>(
+    html`<glide-core-checkbox-group label="Label">
+      <glide-core-checkbox
+        label="One"
+        value="one"
+        checked
+        disabled
+      ></glide-core-checkbox>
+
+      <glide-core-checkbox
+        label="Two"
+        value="two"
+        checked
+      ></glide-core-checkbox>
+    </glide-core-checkbox-group>`,
+  );
+
+  const checkboxes = host.querySelectorAll('glide-core-checkbox');
+
+  expect(host.value).to.deep.equal(['two']);
+  expect(checkboxes[0]?.checked).to.be.true;
+  expect(checkboxes[1]?.checked).to.be.true;
+});
+
 it('throws when `label` is empty', async () => {
   const spy = sinon.spy();
 

--- a/src/checkbox-group.test.interactions.ts
+++ b/src/checkbox-group.test.interactions.ts
@@ -3,7 +3,7 @@ import { assert, expect, fixture, html } from '@open-wc/testing';
 import { click } from './library/mouse.js';
 import GlideCoreCheckboxGroup from './checkbox-group.js';
 
-it('checks and unchecks checkboxes when `value` is set programmatically', async () => {
+it('checks and unchecks checkboxes when its `value` is set programmatically', async () => {
   const host = await fixture<GlideCoreCheckboxGroup>(
     html`<glide-core-checkbox-group label="Label">
       <glide-core-checkbox label="One" value="one"></glide-core-checkbox>
@@ -26,7 +26,7 @@ it('checks and unchecks checkboxes when `value` is set programmatically', async 
   expect(checkboxes[2]?.checked).to.be.false;
 });
 
-it('updates `value` when the `value` of its checkbox is set programmatically', async () => {
+it('updates its `value` when the `value` of a checkbox is set programmatically', async () => {
   const host = await fixture<GlideCoreCheckboxGroup>(
     html`<glide-core-checkbox-group label="Label">
       <glide-core-checkbox
@@ -45,15 +45,14 @@ it('updates `value` when the `value` of its checkbox is set programmatically', a
 
   const checkbox = host.querySelector('glide-core-checkbox');
   assert(checkbox);
-  checkbox.value = 'three';
 
+  checkbox.value = 'three';
   await host.updateComplete;
 
   expect(host.value).to.deep.equal(['three', 'two']);
-  expect(host.getAttribute('value')).to.equal('["three","two"]');
 });
 
-it('updates `value` when the `value` of its checkbox is emptied programmatically', async () => {
+it('updates its `value` when the `value` of a checkbox is emptied programmatically', async () => {
   const host = await fixture<GlideCoreCheckboxGroup>(
     html`<glide-core-checkbox-group label="Label">
       <glide-core-checkbox
@@ -72,15 +71,14 @@ it('updates `value` when the `value` of its checkbox is emptied programmatically
 
   const checkbox = host.querySelector('glide-core-checkbox');
   assert(checkbox);
-  checkbox.value = '';
 
+  checkbox.value = '';
   await host.updateComplete;
 
   expect(host.value).to.deep.equal(['two']);
-  expect(host.getAttribute('value')).to.equal('["two"]');
 });
 
-it('enables checkboxes when `value` is set programmatically', async () => {
+it('enables checkboxes when its `value` is set programmatically', async () => {
   const host = await fixture<GlideCoreCheckboxGroup>(
     html`<glide-core-checkbox-group label="Label">
       <glide-core-checkbox
@@ -101,6 +99,52 @@ it('enables checkboxes when `value` is set programmatically', async () => {
 
   const checkbox = host.querySelector('glide-core-checkbox');
   expect(checkbox?.disabled).to.be.false;
+});
+
+it('updates its `value` when a checkbox is checked programmatically', async () => {
+  const host = await fixture<GlideCoreCheckboxGroup>(
+    html`<glide-core-checkbox-group label="Label">
+      <glide-core-checkbox label="One" value="one"></glide-core-checkbox>
+
+      <glide-core-checkbox
+        label="Two"
+        value="two"
+        checked
+      ></glide-core-checkbox>
+    </glide-core-checkbox-group>`,
+  );
+
+  const checkbox = host.querySelector('glide-core-checkbox');
+  assert(checkbox);
+
+  checkbox.checked = true;
+
+  expect(host.value).to.deep.equal(['two', 'one']);
+});
+
+it('updates its `value` when a checkbox is unchecked programmatically', async () => {
+  const host = await fixture<GlideCoreCheckboxGroup>(
+    html`<glide-core-checkbox-group label="Label">
+      <glide-core-checkbox
+        label="One"
+        value="one"
+        checked
+      ></glide-core-checkbox>
+
+      <glide-core-checkbox
+        label="Two"
+        value="two"
+        checked
+      ></glide-core-checkbox>
+    </glide-core-checkbox-group>`,
+  );
+
+  const checkbox = host.querySelector('glide-core-checkbox');
+  assert(checkbox);
+
+  checkbox.checked = false;
+
+  expect(host.value).to.deep.equal(['two']);
 });
 
 it('can be disabled programmatically', async () => {
@@ -144,4 +188,59 @@ it('adds values to `value` in the order they were selected or deselected', async
 
   await click(checkboxes[2]);
   expect(host.value).to.deep.equal(['two', 'one', 'three']);
+});
+
+it('adds the `value` of a programmatically enabled checkbox to its `value`', async () => {
+  const host = await fixture<GlideCoreCheckboxGroup>(
+    html`<glide-core-checkbox-group label="Label">
+      <glide-core-checkbox
+        label="One"
+        value="one"
+        checked
+        disabled
+      ></glide-core-checkbox>
+
+      <glide-core-checkbox
+        label="Two"
+        value="two"
+        checked
+      ></glide-core-checkbox>
+    </glide-core-checkbox-group>`,
+  );
+
+  const checkboxes = host.querySelectorAll('glide-core-checkbox');
+
+  assert(checkboxes[0]);
+  checkboxes[0].disabled = false;
+
+  expect(host.value).to.deep.equal(['two', 'one']);
+  expect(checkboxes[0].checked).to.be.true;
+  expect(checkboxes[1]?.checked).to.be.true;
+});
+
+it('removes the `value` of a programmatically disabled checkbox from its `value`', async () => {
+  const host = await fixture<GlideCoreCheckboxGroup>(
+    html`<glide-core-checkbox-group label="Label">
+      <glide-core-checkbox
+        label="One"
+        value="one"
+        checked
+      ></glide-core-checkbox>
+
+      <glide-core-checkbox
+        label="Two"
+        value="two"
+        checked
+      ></glide-core-checkbox>
+    </glide-core-checkbox-group>`,
+  );
+
+  const checkboxes = host.querySelectorAll('glide-core-checkbox');
+
+  assert(checkboxes[0]);
+  checkboxes[0].disabled = true;
+
+  expect(host.value).to.deep.equal(['two']);
+  expect(checkboxes[0].checked).to.be.true;
+  expect(checkboxes[1]?.checked).to.be.true;
 });

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -83,14 +83,40 @@ export default class GlideCoreCheckbox
 
   static override styles = styles;
 
+  /**
+    @default false
+  */
   @property({ type: Boolean })
-  checked = false;
+  get checked(): boolean {
+    return this.#isChecked;
+  }
+
+  set checked(isChecked: boolean) {
+    const hasChanged = isChecked !== this.#isChecked;
+    this.#isChecked = isChecked;
+
+    if (hasChanged) {
+      this.dispatchEvent(
+        new Event('private-checked-change', { bubbles: true }),
+      );
+    }
+  }
 
   @property({ attribute: 'private-internally-inert', type: Boolean })
   privateInternallyInert = false;
 
+  /**
+   * @default false
+   */
   @property({ reflect: true, type: Boolean })
-  disabled = false;
+  get disabled(): boolean {
+    return this.#isDisabled;
+  }
+
+  set disabled(isDisabled: boolean) {
+    this.#isDisabled = isDisabled;
+    this.dispatchEvent(new Event('private-disabled-change', { bubbles: true }));
+  }
 
   @property({ attribute: 'hide-label', type: Boolean })
   hideLabel = false;
@@ -567,6 +593,10 @@ export default class GlideCoreCheckbox
   #internals: ElementInternals;
 
   #intersectionObserver?: IntersectionObserver;
+
+  #isChecked = false;
+
+  #isDisabled = false;
 
   #label?: string;
 


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

### Minor

- Checkbox Group's `value` is no longer reflected to match native.
- Checkbox Group now removes from its `value` the `value` of a checked Checkbox that is disabled. This also works in reverse. If a disabled but checked Checkbox is enabled, it's `value` is added to Checkbox Group's `value`.

### Patch


- Checkbox Group now updates its `value` when a Checkbox is checked or unchecked programmatically.
- Checkbox Group now updates its `value` when its form is reset.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

### Checkbox Group's `value` is no longer reflected to match native

1. Navigate to Checkbox Group in Storybook.
2. Check a Checkbox.
3. Call `getAttribute('value')` on Checkbox Group.
4. Verify the result is `null`.

### Checkbox Group now removes from its `value` the `value` of a checked Checkbox that is disabled

1. Navigate to Checkbox Group in Storybook.
2. Check a Checkbox.
3. Disable the Checkbox.
4. Verify that Checkbox Group's `value` is an empty array.

### Checkbox Group now updates its `value` when a Checkbox is checked or unchecked programmatically.

1. Navigate to Checkbox Group in Storybook.
2. Programmatically check a Checkbox.
3. Verify Checkbox Group's `value` includes the Checkbox's `value`.
4. Programmatically uncheck the Checkbox.
5. Verify Checkbox Group's `value` does not include the Checkbox's `value`.

### Checkbox Group now updates its `value` when its form is reset

1. Navigate to Checkbox Group in Storybook.
2. Check a Checkbox.
3. Call `reset()` on the form.
4. Verify Checkbox Group's `value` is an empty array.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
