### PR TITLE
Radio Group fixes

### DIFF
--- a/.changeset/breezy-otters-type.md
+++ b/.changeset/breezy-otters-type.md
@@ -1,0 +1,7 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Disabled Radio Group Radios that are checked no longer appear checked visually or to screenreaders so it's clear to the user what will be submitted with the form.
+- If multiple Radio Group Radios are checked, only the last now appears checked visually and to screenreaders so it's clear to the user what will be submitted with the form.
+- If multiple Radio Group Radios are checked, only the last is now tabbable.

--- a/.changeset/early-masks-attend.md
+++ b/.changeset/early-masks-attend.md
@@ -1,0 +1,8 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+- Radio Group no longer unchecks all but the last checked Radio Group Radio when multiple are checked initially.
+- Radio Group now sets its `value` to an empty string when disabled.
+- Radio Group now sets its `value` to an empty string when its checked Radio Group Radio is disabled.
+- When multiple Radio Group Radios are checked and the `value` of one that isn't the last is changed programmatically, Radio Group's `value` remains set to that of the last checked and enabled Radio Group Radio.

--- a/src/aria-snapshots/radio-group-test-aria-ts-disabled.yml
+++ b/src/aria-snapshots/radio-group-test-aria-ts-disabled.yml
@@ -1,5 +1,5 @@
 - text: Label
 - radiogroup "Label":
-  - radio "One" [checked] [disabled]
+  - radio "One" [disabled]
   - radio "Two" [disabled]
   - radio "Three" [disabled]

--- a/src/aria-snapshots/radio-group-test-aria-ts-glide-core-radio-group-radio-disabled.yml
+++ b/src/aria-snapshots/radio-group-test-aria-ts-glide-core-radio-group-radio-disabled.yml
@@ -1,5 +1,5 @@
 - text: Label
 - radiogroup "Label":
-  - radio "One" [checked] [disabled]
+  - radio "One" [disabled]
   - radio "Two"
   - radio "Three"

--- a/src/dropdown.option.test.basics.single.ts
+++ b/src/dropdown.option.test.basics.single.ts
@@ -34,7 +34,7 @@ it('is editable', async () => {
   expect(button?.checkVisibility()).to.be.true;
 });
 
-it('is checked when selected', async () => {
+it('appears checked when selected', async () => {
   const host = await fixture<GlideCoreDropdownOption>(
     html`<glide-core-dropdown-option
       label="Label"
@@ -49,7 +49,7 @@ it('is checked when selected', async () => {
   expect(checkmark?.checkVisibility()).to.be.true;
 });
 
-it('is unchecked when selected and disabled', async () => {
+it('appears unchecked when selected and disabled', async () => {
   const host = await fixture<GlideCoreDropdownOption>(
     html`<glide-core-dropdown-option
       label="Label"

--- a/src/dropdown.option.test.interactions.single.ts
+++ b/src/dropdown.option.test.interactions.single.ts
@@ -160,7 +160,7 @@ it('sets `privateIsEditActive`', async () => {
   expect(host.privateIsEditActive).to.be.false;
 });
 
-it('is checked when programmatically enabled', async () => {
+it('appears checked when programmatically enabled', async () => {
   const host = await fixture<GlideCoreDropdownOption>(
     html`<glide-core-dropdown-option
       label="Label"
@@ -179,7 +179,7 @@ it('is checked when programmatically enabled', async () => {
   expect(checkmark?.checkVisibility()).to.be.true;
 });
 
-it('is unchecked when programmatically disabled', async () => {
+it('appears unchecked when programmatically disabled', async () => {
   const host = await fixture<GlideCoreDropdownOption>(
     html`<glide-core-dropdown-option
       label="Label"

--- a/src/radio-group.radio.test.interactions.ts
+++ b/src/radio-group.radio.test.interactions.ts
@@ -10,6 +10,31 @@ it('sets `aria-checked` on the host when checked programmatically', async () => 
   expect(host.ariaChecked).to.equal('false');
 });
 
+it('sets `aria-checked` on the host when checked and enabled programmatically', async () => {
+  const host = await fixture<GlideCoreRadioGroupRadio>(html`
+    <glide-core-radio-group-radio
+      label="Label"
+      checked
+      disabled
+    ></glide-core-radio-group-radio>
+  `);
+
+  host.disabled = false;
+  expect(host.ariaChecked).to.equal('true');
+});
+
+it('sets `aria-checked` on the host when checked and disabled programmatically', async () => {
+  const host = await fixture<GlideCoreRadioGroupRadio>(html`
+    <glide-core-radio-group-radio
+      label="Label"
+      checked
+    ></glide-core-radio-group-radio>
+  `);
+
+  host.disabled = true;
+  expect(host.ariaChecked).to.equal('false');
+});
+
 it('sets `aria-disabled` on the host when disabled programmatically', async () => {
   const host = await fixture<GlideCoreRadioGroupRadio>(html`
     <glide-core-radio-group-radio label="Label"></glide-core-radio-group-radio>

--- a/src/radio-group.radio.ts
+++ b/src/radio-group.radio.ts
@@ -1,6 +1,6 @@
 import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import packageJson from '../package.json' with { type: 'json' };
 import styles from './radio-group.radio.styles.js';
 import shadowRootMode from './library/shadow-root-mode.js';
@@ -47,7 +47,7 @@ export default class GlideCoreRadioGroupRadio extends LitElement {
     const wasChecked = this.#checked;
 
     this.#checked = isChecked;
-    this.ariaChecked = isChecked.toString();
+    this.ariaChecked = isChecked && !this.disabled ? 'true' : 'false';
 
     if (isChecked && wasChecked !== isChecked) {
       this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
@@ -162,7 +162,11 @@ export default class GlideCoreRadioGroupRadio extends LitElement {
   readonly version: string = packageJson.version;
 
   override firstUpdated() {
-    this.ariaChecked = this.checked.toString();
+    this.ariaChecked =
+      this.checked && !this.disabled && this === this.lastCheckedRadio
+        ? 'true'
+        : 'false';
+
     this.ariaDisabled = this.disabled.toString();
     this.ariaInvalid = this.privateInvalid.toString();
     this.ariaRequired = this.privateRequired.toString();
@@ -173,13 +177,25 @@ export default class GlideCoreRadioGroupRadio extends LitElement {
     }
   }
 
+  @state()
+  private get lastCheckedRadio(): GlideCoreRadioGroupRadio | undefined {
+    const radios = this.parentElement?.querySelectorAll(
+      'glide-core-radio-group-radio',
+    );
+
+    if (radios && radios.length > 0) {
+      return [...radios].findLast((radio) => radio.checked);
+    }
+  }
+
   override render() {
     return html`
       <div class="component" data-test="component">
         <div
           class=${classMap({
             circle: true,
-            checked: this.checked,
+            checked:
+              this.checked && this === this.lastCheckedRadio && !this.disabled,
             disabled: this.disabled,
             animate: this.hasUpdated,
           })}

--- a/src/radio-group.radio.ts
+++ b/src/radio-group.radio.ts
@@ -80,9 +80,10 @@ export default class GlideCoreRadioGroupRadio extends LitElement {
     return this.#disabled;
   }
 
-  set disabled(disabled: boolean) {
-    this.#disabled = disabled;
-    this.ariaDisabled = disabled.toString();
+  set disabled(isDisabled: boolean) {
+    this.#disabled = isDisabled;
+    this.ariaDisabled = isDisabled.toString();
+    this.ariaChecked = this.checked && !isDisabled ? 'true' : 'false';
 
     // `this.disabled` can be changed programmatically. Radio Group needs to know when
     // that happens so it can make radios tabbable or untabbable.

--- a/src/radio-group.test.basics.ts
+++ b/src/radio-group.test.basics.ts
@@ -70,26 +70,7 @@ it('can be disabled', async () => {
   expect(radios[1]?.ariaDisabled).to.equal('true');
 });
 
-it('sets `value` when a radio is checked', async () => {
-  const host = await fixture<GlideCoreRadioGroup>(html`
-    <glide-core-radio-group label="Label">
-      <glide-core-radio-group-radio
-        label="One"
-        value="one"
-      ></glide-core-radio-group-radio>
-
-      <glide-core-radio-group-radio
-        label="Two"
-        value="two"
-        checked
-      ></glide-core-radio-group-radio>
-    </glide-core-radio-group>
-  `);
-
-  expect(host.value).to.equal('two');
-});
-
-it('sets `value` to the last checked radio', async () => {
+it('sets its `value` to that of the last checked radio', async () => {
   const host = await fixture<GlideCoreRadioGroup>(html`
     <glide-core-radio-group label="Label">
       <glide-core-radio-group-radio
@@ -109,7 +90,7 @@ it('sets `value` to the last checked radio', async () => {
   expect(host.value).to.equal('two');
 });
 
-it('makes the first enabled radio tabbable', async () => {
+it('makes the first enabled radio tabbable when none are checked', async () => {
   const host = await fixture(
     html`<glide-core-radio-group label="Label">
       <glide-core-radio-group-radio
@@ -125,6 +106,34 @@ it('makes the first enabled radio tabbable', async () => {
 
   expect(radios[0]?.tabIndex).to.equal(-1);
   expect(radios[1]?.tabIndex).to.equal(0);
+});
+
+it('makes the last checked and enabled radio tabbable', async () => {
+  const host = await fixture(
+    html`<glide-core-radio-group label="Label">
+      <glide-core-radio-group-radio
+        label="One"
+        checked
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Two"
+        checked
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Three"
+        checked
+        disabled
+      ></glide-core-radio-group-radio>
+    </glide-core-radio-group>`,
+  );
+
+  const radios = host.querySelectorAll('glide-core-radio-group-radio');
+
+  expect(radios[0]?.tabIndex).to.equal(-1);
+  expect(radios[1]?.tabIndex).to.equal(0);
+  expect(radios[2]?.tabIndex).to.equal(-1);
 });
 
 it('makes radios untabbable when disabled', async () => {
@@ -211,6 +220,44 @@ it('gives precedence to a checked radio over an initial `value`', async () => {
   `);
 
   expect(host.value).to.equal('two');
+});
+
+it('has no `value` when a disabled radio is checked', async () => {
+  const host = await fixture<GlideCoreRadioGroup>(html`
+    <glide-core-radio-group label="Label">
+      <glide-core-radio-group-radio
+        label="One"
+        value="one"
+        checked
+        disabled
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Two"
+        value="two"
+      ></glide-core-radio-group-radio>
+    </glide-core-radio-group>
+  `);
+
+  expect(host.value).to.equal('');
+});
+
+it('has no `value` when disabled', async () => {
+  const host = await fixture<GlideCoreRadioGroup>(html`
+    <glide-core-radio-group label="Label" disabled>
+      <glide-core-radio-group-radio
+        label="One"
+        value="one"
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Two"
+        value="two"
+      ></glide-core-radio-group-radio>
+    </glide-core-radio-group>
+  `);
+
+  expect(host.value).to.equal('');
 });
 
 it('throws when subclassed', async () => {

--- a/src/radio-group.test.interactions.ts
+++ b/src/radio-group.test.interactions.ts
@@ -380,7 +380,7 @@ it('makes the first enabled radio tabbable when the group is enabled programmati
   expect(radios[2]?.tabIndex).to.equal(-1);
 });
 
-it('makes last checked radio tabbable when the group is enabled programmatically', async () => {
+it('makes the last checked radio tabbable when the group is enabled programmatically', async () => {
   const host = await fixture<GlideCoreRadioGroup>(html`
     <glide-core-radio-group label="Label" disabled>
       <glide-core-radio-group-radio
@@ -693,7 +693,7 @@ it('retains its `value` when the `value` of a checked radio that is not the last
   expect(host.value).to.equal('two');
 });
 
-it('updates its `value` when the `value` of the last checked and enabled radio is unchecked', async () => {
+it('updates its `value` when the last checked and enabled radio is unchecked', async () => {
   const host = await fixture<GlideCoreRadioGroup>(html`
     <glide-core-radio-group label="Label">
       <glide-core-radio-group-radio

--- a/src/radio-group.test.interactions.ts
+++ b/src/radio-group.test.interactions.ts
@@ -380,7 +380,7 @@ it('makes the first enabled radio tabbable when the group is enabled programmati
   expect(radios[2]?.tabIndex).to.equal(-1);
 });
 
-it('makes the first checked radio tabbable when the group is enabled programmatically', async () => {
+it('makes last checked radio tabbable when the group is enabled programmatically', async () => {
   const host = await fixture<GlideCoreRadioGroup>(html`
     <glide-core-radio-group label="Label" disabled>
       <glide-core-radio-group-radio
@@ -394,6 +394,7 @@ it('makes the first checked radio tabbable when the group is enabled programmati
 
       <glide-core-radio-group-radio
         label="Label"
+        checked
       ></glide-core-radio-group-radio>
     </glide-core-radio-group>
   `);
@@ -404,8 +405,8 @@ it('makes the first checked radio tabbable when the group is enabled programmati
   const radios = host.querySelectorAll('glide-core-radio-group-radio');
 
   expect(radios[0]?.tabIndex).to.equal(-1);
-  expect(radios[1]?.tabIndex).to.equal(0);
-  expect(radios[2]?.tabIndex).to.equal(-1);
+  expect(radios[1]?.tabIndex).to.equal(-1);
+  expect(radios[2]?.tabIndex).to.equal(0);
 });
 
 it('does not check a radio on click when it is disabled', async () => {
@@ -562,4 +563,164 @@ it('makes a radio tabbable when it is enabled programmatically and no other radi
   expect(radios[0]?.tabIndex).to.equal(-1);
   expect(radios[1].tabIndex).to.equal(0);
   expect(radios[2]?.tabIndex).to.equal(-1);
+});
+
+it('updates its `value` when a checked radio is programmatically enabled', async () => {
+  const host = await fixture<GlideCoreRadioGroup>(html`
+    <glide-core-radio-group label="Label">
+      <glide-core-radio-group-radio
+        label="One"
+        value="one"
+        checked
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Two"
+        value="two"
+        checked
+        disabled
+      ></glide-core-radio-group-radio>
+    </glide-core-radio-group>
+  `);
+
+  const radios = host.querySelectorAll('glide-core-radio-group-radio');
+
+  assert(radios[1]);
+  radios[1].disabled = false;
+
+  expect(host.value).to.equal('two');
+});
+
+it('updates its `value` when a checked radio is programmatically disabled', async () => {
+  const host = await fixture<GlideCoreRadioGroup>(html`
+    <glide-core-radio-group label="Label">
+      <glide-core-radio-group-radio
+        label="One"
+        value="one"
+        checked
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Two"
+        value="two"
+        checked
+      ></glide-core-radio-group-radio>
+    </glide-core-radio-group>
+  `);
+
+  const radios = host.querySelectorAll('glide-core-radio-group-radio');
+
+  assert(radios[1]);
+  radios[1].disabled = true;
+
+  expect(host.value).to.equal('one');
+});
+
+it('updates its `value` when the group is programmatically enabled', async () => {
+  const host = await fixture<GlideCoreRadioGroup>(html`
+    <glide-core-radio-group label="Label" disabled>
+      <glide-core-radio-group-radio
+        label="One"
+        value="one"
+        checked
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Two"
+        value="two"
+        checked
+      ></glide-core-radio-group-radio>
+    </glide-core-radio-group>
+  `);
+
+  host.disabled = false;
+  await host.updateComplete;
+
+  expect(host.value).to.equal('two');
+});
+
+it('updates its `value` when the group is programmatically disabled', async () => {
+  const host = await fixture<GlideCoreRadioGroup>(html`
+    <glide-core-radio-group label="Label">
+      <glide-core-radio-group-radio
+        label="One"
+        value="one"
+        checked
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Two"
+        value="two"
+      ></glide-core-radio-group-radio>
+    </glide-core-radio-group>
+  `);
+
+  host.disabled = true;
+  await host.updateComplete;
+
+  expect(host.value).to.equal('');
+});
+
+it('retains its `value` when the `value` of a checked radio that is not the last enabled one is changed', async () => {
+  const host = await fixture<GlideCoreRadioGroup>(html`
+    <glide-core-radio-group label="Label">
+      <glide-core-radio-group-radio
+        label="One"
+        value="one"
+        checked
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Two"
+        value="two"
+        checked
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Three"
+        value="three"
+        checked
+        disabled
+      ></glide-core-radio-group-radio>
+    </glide-core-radio-group>
+  `);
+
+  const radios = host.querySelectorAll('glide-core-radio-group-radio');
+
+  assert(radios[0]);
+  radios[0].value = 'test';
+
+  expect(host.value).to.equal('two');
+});
+
+it('updates its `value` when the `value` of the last checked and enabled radio is unchecked', async () => {
+  const host = await fixture<GlideCoreRadioGroup>(html`
+    <glide-core-radio-group label="Label">
+      <glide-core-radio-group-radio
+        label="One"
+        value="one"
+        checked
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Two"
+        value="two"
+        checked
+      ></glide-core-radio-group-radio>
+
+      <glide-core-radio-group-radio
+        label="Three"
+        value="three"
+        checked
+        disabled
+      ></glide-core-radio-group-radio>
+    </glide-core-radio-group>
+  `);
+
+  const radios = host.querySelectorAll('glide-core-radio-group-radio');
+
+  assert(radios[1]);
+  radios[1].checked = false;
+
+  expect(host.value).to.equal('two');
 });

--- a/src/radio-group.test.visuals.ts
+++ b/src/radio-group.test.visuals.ts
@@ -89,21 +89,41 @@ for (const story of stories['Radio Group']) {
           );
         });
 
-        test('<glide-core-radio-group-radio>.disabled', async ({
-          page,
-        }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+        test.describe('<glide-core-radio-group-radio>.disabled', () => {
+          test('<glide-core-radio-group-radio>[checked=${true}]', async ({
+            page,
+          }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
-          await page
-            .locator('glide-core-radio-group-radio')
-            .nth(1)
-            .evaluate<void, GlideCoreRadioGroupRadio>((element) => {
-              element.disabled = true;
-            });
+            await page
+              .locator('glide-core-radio-group-radio')
+              .nth(1)
+              .evaluate<void, GlideCoreRadioGroupRadio>((element) => {
+                element.disabled = true;
+                element.checked = true;
+              });
 
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('<glide-core-radio-group-radio>[checked=${false}]', async ({
+            page,
+          }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-radio-group-radio')
+              .nth(1)
+              .evaluate<void, GlideCoreRadioGroupRadio>((element) => {
+                element.disabled = true;
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
         });
       });
     }


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

### Minor

- Radio Group no longer unchecks all but the last checked Radio Group Radio when multiple are checked initially.
- Radio Group now sets its `value` to an empty string when disabled.
- Radio Group now sets its `value` to an empty string when its checked Radio Group Radio is disabled.
- When multiple Radio Group Radios are checked and the `value` of one that isn't the last is changed programmatically, Radio Group's `value` remains set to that of the last checked and enabled Radio Group Radio.

### Patch

- Disabled Radio Group Radios that are checked no longer appear checked visually or to screenreaders so it's clear to the user what will be submitted with the form
- If multiple Radio Group Radios are checked, only the last now appears checked visually and to screenreaders so it's clear to the user what will be submitted with the form.
- If multiple Radio Group Radios are checked, only the last is now tabbable.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

### Radio Group no longer unchecks all but the last checked Radio Group Radio when multiple are checked initially

1. Check out the branch.
2. Change Radio Group's story so that multiple Radio Group Radios are checked initially.
3. Verify each Radio Group Radio remains checked.


### Radio Group now sets its `value` to an empty string when disabled

1. Navigate to Radio Group in Storybook.
2. Disable Radio Group.
3. Verify Radio Group's `value` is an empty string.

### Radio Group now sets its `value` to an empty string when its checked Radio Group Radio is disabled

1. Navigate to Radio Group in Storybook.
2. Disable the first Radio Group Radio.
3. Verify Radio Group's `value` is an empty string.

### When multiple Radio Group Radios are checked and the `value` of one that isn't the last is changed programmatically, Radio Group's `value` remains set to that of the last checked and enabled Radio Group Radio

1. Check out the branch.
2. Change Radio Group's story so that multiple Radio Group Radios are checked initially.
3. Programmatically change the `value` any but the last checked Radio Group Radio.
4. Verify Radio Group's `value` is unchanged.


### Disabled Radio Group Radios that are checked no longer appear checked visually or to screenreaders

1. Navigate to Radio Group in Storybook.
2. Programmatically disable the first Radio Group Radio.
3. Verify the Radio Group Radio appears unchecked.
4. Verify `aria-checked` on the Radio Group Radio is set to `"false"`.

### If multiple Radio Group Radios are checked, only the last now appears checked visually and to screenreaders

1. Check out the branch.
2. Change Radio Group's story so that multiple Radio Group Radios are checked initially.
3. Verify only the last checked Radio Group Radio appears checked.
4. Verify only the last checked Radio Group Radio has `aria-checked` set to `"true"`.


### If multiple Radio Group Radios are checked, only the last is now tabbable

1. Check out the branch.
2. Change Radio Group's story so that multiple Radio Group Radios are checked initially.
3. Verify only the last checked Radio Group Radio is tabbable.


<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->