### PR TITLE
Disable Tab text selection when double clicked

### DIFF
--- a/.changeset/dry-hats-destroy.md
+++ b/.changeset/dry-hats-destroy.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Tab's text is no longer selected when double clicked.

--- a/src/tab.styles.ts
+++ b/src/tab.styles.ts
@@ -22,6 +22,7 @@ export default [
       gap: 0.4375rem;
       justify-content: center;
       padding-block: 0.4375rem;
+      user-select: none;
 
       &:hover {
         color: var(--glide-core-text-primary);


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Sets `user-select: none` on Tab to match the behavior of our other interactive elements.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to Tab Group in Storybook.
2. Double-click a Tab.
3. Verify the Tab's text isn't selected.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
