### PR TITLE
Ditch mutation observer in stories

### DIFF
--- a/src/form-controls-layout.stories.ts
+++ b/src/form-controls-layout.stories.ts
@@ -139,12 +139,12 @@ const meta: Meta = {
 
     const dropdown = context.canvasElement.querySelector('glide-core-dropdown');
 
-    const option = context.canvasElement.querySelector(
-      'glide-core-dropdown-option',
-    );
-
     if (dropdown instanceof GlideCoreDropdown) {
       dropdown.addEventListener('change', () => {
+        const option = context.canvasElement.querySelector(
+          'glide-core-dropdown-option',
+        );
+
         if (option) {
           addons.getChannel().emit(UPDATE_STORY_ARGS, {
             storyId: context.id,
@@ -155,7 +155,7 @@ const meta: Meta = {
         }
       });
 
-      const observer = new MutationObserver(() => {
+      dropdown.addEventListener('toggle', () => {
         if (dropdown instanceof GlideCoreDropdown) {
           addons.getChannel().emit(UPDATE_STORY_ARGS, {
             storyId: context.id,
@@ -164,11 +164,6 @@ const meta: Meta = {
             },
           });
         }
-      });
-
-      observer.observe(dropdown, {
-        attributes: true,
-        attributeFilter: ['open'],
       });
     }
 

--- a/src/menu.stories.ts
+++ b/src/menu.stories.ts
@@ -224,41 +224,36 @@ const meta: Meta = {
     },
   },
   play(context) {
-    const menu = context.canvasElement.querySelector('glide-core-menu');
-
-    const observer = new MutationObserver(() => {
-      if (menu instanceof GlideCoreMenu) {
-        addons.getChannel().emit(UPDATE_STORY_ARGS, {
-          storyId: context.id,
-          updatedArgs: {
-            open: menu.open,
-          },
-        });
-      }
-    });
-
-    if (menu) {
-      observer.observe(menu, {
-        attributes: true,
-        attributeFilter: ['open'],
+    context.canvasElement
+      .querySelector('glide-core-menu')
+      ?.addEventListener('toggle', (event: Event) => {
+        if (event.target instanceof GlideCoreMenu) {
+          addons.getChannel().emit(UPDATE_STORY_ARGS, {
+            storyId: context.id,
+            updatedArgs: {
+              open: event.target.open,
+            },
+          });
+        }
       });
-    }
 
-    menu?.addEventListener('click', (event: Event) => {
-      const isLink =
-        event.target instanceof Element &&
-        event.target.closest('glide-core-menu-link');
+    context.canvasElement
+      .querySelector('glide-core-menu')
+      ?.addEventListener('click', (event: Event) => {
+        const isLink =
+          event.target instanceof Element &&
+          event.target.closest('glide-core-menu-link');
 
-      if (isLink && window.top) {
-        event.preventDefault();
+        if (isLink && window.top) {
+          event.preventDefault();
 
-        // The Storybook user expects to navigate when the link is clicked but
-        // doesn't expect to be redirected to the first story. So we refresh the
-        // page to give the impression of a navigation while keeping the user
-        // on the same page.
-        window.top.location.reload();
-      }
-    });
+          // The Storybook user expects to navigate when the link is clicked but
+          // doesn't expect to be redirected to the first story. So we refresh the
+          // page to give the impression of a navigation while keeping the user
+          // on the same page.
+          window.top.location.reload();
+        }
+      });
   },
   render(arguments_) {
     /* eslint-disable unicorn/explicit-length-check, @typescript-eslint/prefer-nullish-coalescing */

--- a/src/modal.stories.ts
+++ b/src/modal.stories.ts
@@ -56,25 +56,18 @@ const meta: Meta = {
         }
       });
 
-    const modal = context.canvasElement.querySelector('glide-core-modal');
-
-    const observer = new MutationObserver(() => {
-      if (modal instanceof GlideCoreModal) {
-        addons.getChannel().emit(UPDATE_STORY_ARGS, {
-          storyId: context.id,
-          updatedArgs: {
-            open: modal.open,
-          },
-        });
-      }
-    });
-
-    if (modal) {
-      observer.observe(modal, {
-        attributes: true,
-        attributeFilter: ['open'],
+    context.canvasElement
+      .querySelector('glide-core-modal')
+      ?.addEventListener('toggle', (event: Event) => {
+        if (event.target instanceof GlideCoreModal) {
+          addons.getChannel().emit(UPDATE_STORY_ARGS, {
+            storyId: context.id,
+            updatedArgs: {
+              open: event.target.open,
+            },
+          });
+        }
       });
-    }
   },
   render(arguments_) {
     /* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/prefer-nullish-coalescing */

--- a/src/popover.stories.ts
+++ b/src/popover.stories.ts
@@ -144,25 +144,18 @@ const meta: Meta = {
     },
   },
   play(context) {
-    const popover = context.canvasElement.querySelector('glide-core-popover');
-
-    const observer = new MutationObserver(() => {
-      if (popover instanceof GlideCorePopover) {
-        addons.getChannel().emit(UPDATE_STORY_ARGS, {
-          storyId: context.id,
-          updatedArgs: {
-            open: popover.open,
-          },
-        });
-      }
-    });
-
-    if (popover) {
-      observer.observe(popover, {
-        attributes: true,
-        attributeFilter: ['open'],
+    context.canvasElement
+      .querySelector('glide-core-popover')
+      ?.addEventListener('toggle', (event: Event) => {
+        if (event.target instanceof GlideCorePopover) {
+          addons.getChannel().emit(UPDATE_STORY_ARGS, {
+            storyId: context.id,
+            updatedArgs: {
+              open: event.target.open,
+            },
+          });
+        }
       });
-    }
   },
   render(arguments_) {
     /* eslint-disable @typescript-eslint/no-unsafe-argument */

--- a/src/split-button.stories.ts
+++ b/src/split-button.stories.ts
@@ -4,13 +4,12 @@ import './menu.link.js';
 import './split-button.js';
 import './split-button.primary-button.js';
 import './split-button.primary-link.js';
-import './split-button.secondary-button.js';
 import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/web-components';
-import type GlideCoreSplitButtonSecondaryButton from './split-button.secondary-button.js';
+import GlideCoreSplitButtonSecondaryButton from './split-button.secondary-button.js';
 
 const meta: Meta = {
   title: 'Split Button',
@@ -65,28 +64,19 @@ const meta: Meta = {
         }
       });
 
-    const secondaryButton = context.canvasElement.querySelector(
-      'glide-core-split-button-secondary-button',
-    );
-
-    const observer = new MutationObserver(() => {
-      addons.getChannel().emit(UPDATE_STORY_ARGS, {
-        storyId: context.id,
-        updatedArgs: {
-          ['<glide-core-split-button-secondary-button>.menu-open']:
-            context.canvasElement.querySelector<GlideCoreSplitButtonSecondaryButton>(
-              'glide-core-split-button-secondary-button',
-            )?.menuOpen,
-        },
+    context.canvasElement
+      .querySelector('glide-core-split-button-secondary-button')
+      ?.addEventListener('toggle', (event: Event) => {
+        if (event.target instanceof GlideCoreSplitButtonSecondaryButton) {
+          addons.getChannel().emit(UPDATE_STORY_ARGS, {
+            storyId: context.id,
+            updatedArgs: {
+              ['<glide-core-split-button-secondary-button>.menu-open']:
+                !event.target.menuOpen,
+            },
+          });
+        }
       });
-    });
-
-    if (secondaryButton) {
-      observer.observe(secondaryButton, {
-        attributes: true,
-        attributeFilter: ['menu-open'],
-      });
-    }
   },
   render(arguments_) {
     /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */

--- a/src/tooltip.stories.ts
+++ b/src/tooltip.stories.ts
@@ -157,33 +157,27 @@ const meta: Meta = {
     },
   },
   play(context) {
-    const tooltip = context.canvasElement.querySelector('glide-core-tooltip');
+    context.canvasElement
+      .querySelector('glide-core-tooltip')
+      ?.addEventListener('toggle', (event: Event) => {
+        if (event.target instanceof GlideCoreTooltip) {
+          addons.getChannel().emit(UPDATE_STORY_ARGS, {
+            storyId: context.id,
+            updatedArgs: {
+              open: event.target.open,
 
-    const observer = new MutationObserver(() => {
-      if (tooltip instanceof GlideCoreTooltip) {
-        addons.getChannel().emit(UPDATE_STORY_ARGS, {
-          storyId: context.id,
-          updatedArgs: {
-            open: tooltip.open,
-            // Storybook reverts arguments back to their initial values when the
-            // above event is emitted unless the argument's value was changed via
-            // a control. And, for whatever reason, only changes to Lit property
-            // expressions cause a re-render and thus a reversion.
-            //
-            // So the current value of `shortcut` is preserved for visual tests and
-            // for when users change its value via DevTools instead of a control.
-            shortcut: tooltip.shortcut,
-          },
-        });
-      }
-    });
-
-    if (tooltip) {
-      observer.observe(tooltip, {
-        attributes: true,
-        attributeFilter: ['open'],
+              // Storybook reverts arguments back to their initial values when the
+              // above event is emitted unless the argument's value was changed via
+              // a control. And, for whatever reason, only changes to Lit property
+              // expressions cause a re-render and thus a reversion.
+              //
+              // So the current value of `shortcut` is preserved for visual tests and
+              // for when users change its value via DevTools instead of a control.
+              shortcut: event.target.shortcut,
+            },
+          });
+        }
       });
-    }
   },
   render(arguments_) {
     /* eslint-disable @typescript-eslint/no-unsafe-argument */

--- a/src/tooltip.test.visuals.ts
+++ b/src/tooltip.test.visuals.ts
@@ -87,8 +87,12 @@ for (const story of stories.Tooltip) {
           await page
             .locator('glide-core-tooltip')
             .evaluate<void, GlideCoreTooltip>((element) => {
-              element.open = true;
               element.shortcut = ['CMD', 'K'];
+
+              // `open` will synchronously trigger a "toggle" event. So `shortcut` needs
+              // to be set first. Otherwise, the story (via its `play()` method) will set
+              // `shortcut` back to its initial value: an empty array.
+              element.open = true;
             });
 
           await expect(page).toHaveScreenshot(


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

When we wrote these stories, we didn't have a universal "toggle" event. So we had to use a mutation observer to tell us when these components opened and closed. We can ditch the mutation observer now that we have "toggle".

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to each story.
2. Open and close the component.
3. Verify the `open` attribute in the controls table toggles to `true` and `false`.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
