### PR TITLE
Split Button Primary Button and Split Button Primary Link padding

### DIFF
--- a/.changeset/thin-yaks-talk.md
+++ b/.changeset/thin-yaks-talk.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Split Button Primary Button and Split Button Primary Link now have more inner-right padding.

--- a/src/inline-alert.test.interactions.ts
+++ b/src/inline-alert.test.interactions.ts
@@ -1,28 +1,30 @@
-import { aTimeout, expect, fixture, html } from '@open-wc/testing';
-import { sendKeys } from '@web/test-runner-commands';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { emulateMedia, sendKeys } from '@web/test-runner-commands';
 import { click } from './library/mouse.js';
 import GlideCoreInlineAlert from './inline-alert.js';
 
 it('removes itself on removable button click', async () => {
+  await emulateMedia({ reducedMotion: 'reduce' });
+
   const host = await fixture<GlideCoreInlineAlert>(
     html`<glide-core-inline-alert variant="informational" removable>
       Label
     </glide-core-inline-alert>`,
   );
 
-  await click(host.shadowRoot?.querySelector('[data-test="removal-button"]'));
+  click(host.shadowRoot?.querySelector('[data-test="removal-button"]'));
 
-  const animationDuration = host.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="component"]',
-  )?.dataset.animationDuration;
-
-  await aTimeout(Number(animationDuration));
+  await waitUntil(() => {
+    return !document.querySelector('glide-core-inline-alert');
+  });
 
   expect(document.querySelector('glide-core-inline-alert')).to.be.null;
 });
 
 it('removes itself on removable button Space', async () => {
-  const host = await fixture<GlideCoreInlineAlert>(
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  await fixture<GlideCoreInlineAlert>(
     html`<glide-core-inline-alert variant="informational" removable>
       Label
     </glide-core-inline-alert>`,
@@ -31,17 +33,17 @@ it('removes itself on removable button Space', async () => {
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
 
-  const animationDuration = host.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="component"]',
-  )?.dataset.animationDuration;
-
-  await aTimeout(Number(animationDuration));
+  await waitUntil(() => {
+    return !document.querySelector('glide-core-inline-alert');
+  });
 
   expect(document.querySelector('glide-core-inline-alert')).to.be.null;
 });
 
 it('removes itself on removable button Enter', async () => {
-  const host = await fixture<GlideCoreInlineAlert>(
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  await fixture<GlideCoreInlineAlert>(
     html`<glide-core-inline-alert variant="informational" removable>
       Label
     </glide-core-inline-alert>`,
@@ -50,11 +52,9 @@ it('removes itself on removable button Enter', async () => {
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Enter' });
 
-  const animationDuration = host.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="component"]',
-  )?.dataset.animationDuration;
-
-  await aTimeout(Number(animationDuration));
+  await waitUntil(() => {
+    return !document.querySelector('glide-core-inline-alert');
+  });
 
   expect(document.querySelector('glide-core-inline-alert')).to.be.null;
 });

--- a/src/inline-alert.ts
+++ b/src/inline-alert.ts
@@ -77,7 +77,6 @@ export default class GlideCoreInlineAlert extends LitElement {
         role="alert"
         aria-labelledby="label"
         data-test="component"
-        data-animation-duration=${this.#animationDuration}
         style="--private-animation-duration: ${this.#animationDuration}ms"
         ${ref(this.#componentElementRef)}
       >

--- a/src/split-button.primary-button.styles.ts
+++ b/src/split-button.primary-button.styles.ts
@@ -21,7 +21,6 @@ export default [
       justify-content: center;
       padding-block: var(--glide-core-spacing-base-xs);
       padding-inline: var(--glide-core-spacing-base-md);
-      padding-inline-end: var(--glide-core-spacing-base-xs);
       position: relative;
       text-decoration: none;
       transition-duration: 150ms;

--- a/src/tag.test.interactions.ts
+++ b/src/tag.test.interactions.ts
@@ -1,70 +1,66 @@
-import { aTimeout, expect, fixture, html } from '@open-wc/testing';
-import { sendKeys } from '@web/test-runner-commands';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { emulateMedia, sendKeys } from '@web/test-runner-commands';
 import GlideCoreTag from './tag.js';
 
 it('removes itself on click', async () => {
+  await emulateMedia({ reducedMotion: 'reduce' });
+
   const host = await fixture<GlideCoreTag>(
     html`<glide-core-tag label="Label" removable></glide-core-tag>`,
   );
 
   host.click();
 
-  const animationDuration = host.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="component"]',
-  )?.dataset.animationDuration;
-
-  await aTimeout(Number(animationDuration));
+  await waitUntil(() => {
+    return !document.querySelector('glide-core-tag');
+  });
 
   expect(document.querySelector('glide-core-tag')).to.be.null;
 });
 
 it('does not remove itself on click when disabled', async () => {
+  await emulateMedia({ reducedMotion: 'reduce' });
+
   const host = await fixture<GlideCoreTag>(
     html`<glide-core-tag label="Label" disabled removable></glide-core-tag>`,
   );
 
   host.click();
 
-  const animationDuration = host.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="component"]',
-  )?.dataset.animationDuration;
-
-  await aTimeout(Number(animationDuration));
-
   expect(document.querySelector('glide-core-tag') instanceof GlideCoreTag).to.be
     .true;
 });
 
 it('removes itself on Space', async () => {
-  const host = await fixture<GlideCoreTag>(
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  await fixture<GlideCoreTag>(
     html`<glide-core-tag label="Label" removable></glide-core-tag>`,
   );
 
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
 
-  const animationDuration = host.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="component"]',
-  )?.dataset.animationDuration;
-
-  await aTimeout(Number(animationDuration));
+  await waitUntil(() => {
+    return !document.querySelector('glide-core-tag');
+  });
 
   expect(document.querySelector('glide-core-tag')).to.be.null;
 });
 
 it('removes itself on Enter', async () => {
-  const host = await fixture<GlideCoreTag>(
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  await fixture<GlideCoreTag>(
     html`<glide-core-tag label="Label" removable></glide-core-tag>`,
   );
 
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Enter' });
 
-  const animationDuration = host.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="component"]',
-  )?.dataset.animationDuration;
-
-  await aTimeout(Number(animationDuration));
+  await waitUntil(() => {
+    return !document.querySelector('glide-core-tag');
+  });
 
   expect(document.querySelector('glide-core-tag')).to.be.null;
 });


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

- Split Button Primary Button and Split Button Primary Link now have more inner-right padding.
- Resolves some test flakiness.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

Check out the visual test report.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
