### PR TITLE
Remove extra background-color from pinned

### DIFF
--- a/src/drawer.styles.ts
+++ b/src/drawer.styles.ts
@@ -26,9 +26,6 @@ export default [
       visibility: hidden;
 
       &.pinned {
-        background-color: var(
-          --glide-core-private-color-template-surface-container-detail
-        );
         box-shadow: none;
       }
 


### PR DESCRIPTION
## 🚀 Description

We already set `background-color` to this value above. No need to override it here.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

- Check out Drawer in Storybook
- Verify it looks the same as it does now on `main`
