### PR TITLE
Support `preventDefault()` in Popover

### DIFF
--- a/.changeset/nice-mirrors-guess.md
+++ b/.changeset/nice-mirrors-guess.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+`preventDefault()` can now be called on Popover's target to prevent Popover from opening or closing when the target is clicked.

--- a/src/popover.test.interactions.ts
+++ b/src/popover.test.interactions.ts
@@ -44,6 +44,33 @@ it('opens when open and enabled programmatically', async () => {
   expect(popover?.checkVisibility()).to.be.true;
 });
 
+it('remains closed when its target is clicked and the event is canceled', async () => {
+  const host = await fixture<GlideCorePopover>(
+    html`<glide-core-popover>
+      Popover
+      <button slot="target">Target</button>
+    </glide-core-popover>`,
+  );
+
+  const target = host.querySelector('button');
+
+  target?.addEventListener('click', (event: Event) => event.preventDefault());
+
+  await click(target);
+  target?.focus();
+  await sendKeys({ press: 'Enter' });
+  await sendKeys({ press: ' ' });
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  const popover = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="popover"]',
+  );
+
+  expect(popover?.checkVisibility()).to.not.be.ok;
+});
+
 it('closes when open and disabled programmatically', async () => {
   const host = await fixture<GlideCorePopover>(
     html`<glide-core-popover open>

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -320,8 +320,10 @@ export default class GlideCorePopover extends LitElement {
     this.#cleanUpFloatingUi?.();
   }
 
-  #onTargetSlotClick() {
-    this.open = !this.open;
+  #onTargetSlotClick(event: Event) {
+    if (!event.defaultPrevented) {
+      this.open = !this.open;
+    }
   }
 
   #onTargetSlotKeydown(event: KeyboardEvent) {


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

`preventDefault()` can now be called on the "click" event of Popover's target to prevent Popover from opening or closing.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing


1. Navigate to Popover in Storybook.
2. Cancel the target's "click" event: `$0.addEventListener('click', (event) => event.preventDefault())`
3. Click the target.
4. Verify Popover remains closed.


<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
