### PR TITLE
Support `preventDefault()` in Accordion

### DIFF
--- a/.changeset/sweet-shoes-search.md
+++ b/.changeset/sweet-shoes-search.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+`preventDefault()` can now be called on Accordion's "click" event to prevent Accordion from opening or closing.

--- a/src/accordion.test.interactions.ts
+++ b/src/accordion.test.interactions.ts
@@ -1,4 +1,4 @@
-import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, waitUntil } from '@open-wc/testing';
 import { emulateMedia, sendKeys } from '@web/test-runner-commands';
 import GlideCoreAccordion from './accordion.js';
 import { click } from './library/mouse.js';
@@ -11,6 +11,9 @@ it('opens when `click()` is called', async () => {
   );
 
   host.click();
+
+  // Wait for the timeout in `#onSummaryClick()`.
+  await aTimeout(0);
 
   expect(host.open).to.be.true;
 });
@@ -57,6 +60,23 @@ it('opens on click when animated', async () => {
   expect(host.open).to.be.true;
 });
 
+it('does not open on click when the event is canceled', async () => {
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  const host = await fixture<GlideCoreAccordion>(
+    html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
+  );
+
+  host.addEventListener('click', (event: Event) => event.preventDefault());
+
+  await click(host);
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Enter' });
+  await sendKeys({ press: ' ' });
+
+  expect(host.open).to.be.false;
+});
+
 it('opens on Space', async () => {
   await emulateMedia({ reducedMotion: 'reduce' });
 
@@ -74,7 +94,7 @@ it('opens on Enter', async () => {
   await emulateMedia({ reducedMotion: 'reduce' });
 
   const host = await fixture<GlideCoreAccordion>(
-    html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
+    html`<glide-core-accordion label="Label">Content </glide-core-accordion>`,
   );
 
   await sendKeys({ press: 'Tab' });
@@ -127,4 +147,23 @@ it('closes on click when animated', async () => {
   await waitUntil(() => isAnimationFinished);
 
   expect(host.open).to.be.false;
+});
+
+it('remains open on click when the event is canceled', async () => {
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  const host = await fixture<GlideCoreAccordion>(
+    html`<glide-core-accordion label="Label" open>
+      Content
+    </glide-core-accordion>`,
+  );
+
+  host.addEventListener('click', (event: Event) => event.preventDefault());
+
+  await click(host);
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Enter' });
+  await sendKeys({ press: ' ' });
+
+  expect(host.open).to.be.true;
 });

--- a/src/accordion.ts
+++ b/src/accordion.ts
@@ -254,10 +254,16 @@ export default class GlideCoreAccordion extends LitElement {
   }
 
   #onSummaryClick(event: MouseEvent) {
-    // Canceling it prevents `details` from immediately showing and hiding
-    // the default slot on open and close, letting us animate it when we're ready.
-    event.preventDefault();
+    // We have to give the consumer a chance to cancel the event before we check if
+    // it's been canceled.
+    setTimeout(() => {
+      if (!event.defaultPrevented) {
+        // Canceling it prevents `details` from immediately showing and hiding the
+        // default slot on open and close, letting us animate it when we're ready.
+        event.preventDefault();
 
-    this.open = !this.open;
+        this.open = !this.open;
+      }
+    });
   }
 }


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

N/A

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to Accordion in Storybook.
2. Cancel Accordion's "click" event: `$0.addEventListener('click', (event) => event.preventDefault())`
3. Click Accordion.
4. Verify Accordion remains closed.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
