### PR TITLE
Use Icon Button in Tab Group

### DIFF
--- a/.changeset/fuzzy-mayflies-flash.md
+++ b/.changeset/fuzzy-mayflies-flash.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+The padding and icon size of Tab Group's overflow buttons have been tweaked slightly.

--- a/src/accordion.test.interactions.ts
+++ b/src/accordion.test.interactions.ts
@@ -1,4 +1,4 @@
-import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { assert, expect, fixture, html, waitUntil } from '@open-wc/testing';
 import { emulateMedia, sendKeys } from '@web/test-runner-commands';
 import GlideCoreAccordion from './accordion.js';
 import { click } from './library/mouse.js';
@@ -37,7 +37,6 @@ it('opens on click when animated', async () => {
   click(host.shadowRoot?.querySelector('[data-test="summary"]'));
 
   let animation: Animation | undefined;
-  let isAnimationFinished = false;
 
   await waitUntil(() => {
     animation = host.shadowRoot
@@ -48,11 +47,8 @@ it('opens on click when animated', async () => {
     return animation;
   });
 
-  animation?.addEventListener('finish', () => {
-    isAnimationFinished = true;
-  });
-
-  await waitUntil(() => isAnimationFinished);
+  assert(animation);
+  await animation.finished;
 
   expect(host.open).to.be.true;
 });
@@ -109,7 +105,6 @@ it('closes on click when animated', async () => {
   click(host);
 
   let animation: Animation | undefined;
-  let isAnimationFinished = false;
 
   await waitUntil(() => {
     animation = host.shadowRoot
@@ -120,11 +115,8 @@ it('closes on click when animated', async () => {
     return animation;
   });
 
-  animation?.addEventListener('finish', () => {
-    isAnimationFinished = true;
-  });
-
-  await waitUntil(() => isAnimationFinished);
+  assert(animation);
+  await animation.finished;
 
   expect(host.open).to.be.false;
 });

--- a/src/tab.group.styles.ts
+++ b/src/tab.group.styles.ts
@@ -68,37 +68,31 @@ export default [
       --private-size: 1.125rem;
 
       align-items: center;
-      background-color: transparent;
-      border: none;
-      color: var(--glide-core-color-interactive-icon-default);
-      cursor: pointer;
       display: flex;
-      flex-shrink: 0;
-      inline-size: 1.875rem;
-      justify-content: center;
-      margin: 0;
-      outline: none;
-      padding: 0;
-
-      &.disabled {
-        color: var(--glide-core-color-interactive-icon-default--disabled);
-      }
 
       &.start {
-        transform: rotate(90deg);
+        padding-inline-start: var(--glide-core-spacing-base-xs);
+
+        & svg {
+          transform: rotate(90deg);
+        }
       }
 
       &.end {
-        transform: rotate(-90deg);
+        padding-inline-end: var(--glide-core-spacing-base-xs);
+
+        svg {
+          transform: rotate(-90deg);
+        }
       }
     }
 
     ::slotted([slot='nav']:first-of-type) {
-      padding-inline-start: 0.1875rem;
+      padding-inline-start: var(--glide-core-spacing-base-sm);
     }
 
     ::slotted([slot='nav']:last-of-type) {
-      padding-inline-end: 0.1875rem;
+      padding-inline-end: var(--glide-core-spacing-base-sm);
     }
   `,
 ];

--- a/src/tab.group.ts
+++ b/src/tab.group.ts
@@ -57,22 +57,21 @@ export default class GlideCoreTabGroup extends LitElement {
         ${when(
           this.isShowOverflowButtons,
           () => html`
-            <button
-              style="height: ${this.#tabListElementRef.value?.clientHeight}px"
+            <glide-core-icon-button
               class=${classMap({
                 'overflow-button': true,
                 start: true,
                 disabled: this.isDisableOverflowStartButton,
               })}
-              @click=${this.#onOverflowStartButtonClick}
-              tabindex="-1"
-              aria-label=${this.#localize.term('previousTab')}
               data-test="overflow-start-button"
-              ${ref(this.#overflowStartButtonElementRef)}
+              label=${this.#localize.term('previousTab')}
+              variant="tertiary"
               ?disabled=${this.isDisableOverflowStartButton}
+              @click=${this.#onOverflowStartButtonClick}
+              ${ref(this.#overflowStartButtonElementRef)}
             >
               ${chevronIcon}
-            </button>
+            </glide-core-icon-button>
           `,
         )}
         <div
@@ -100,22 +99,21 @@ export default class GlideCoreTabGroup extends LitElement {
         ${when(
           this.isShowOverflowButtons,
           () => html`
-            <button
-              style="height: ${this.#tabListElementRef.value?.clientHeight}px"
+            <glide-core-icon-button
               class=${classMap({
                 'overflow-button': true,
                 end: true,
                 disabled: this.isDisableOverflowEndButton,
               })}
-              @click=${this.#onOverflowEndButtonClick}
-              tabindex="-1"
-              aria-label=${this.#localize.term('nextTab')}
               data-test="overflow-end-button"
+              label=${this.#localize.term('nextTab')}
+              variant="tertiary"
               ?disabled=${this.isDisableOverflowEndButton}
+              @click=${this.#onOverflowEndButtonClick}
               ${ref(this.#overflowEndButtonElementRef)}
             >
               ${chevronIcon}
-            </button>
+            </glide-core-icon-button>
           `,
         )}
       </div>


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Swaps out Tab Group's one-off overflow buttons for Icon Buttons.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

Our tests and the visual test report should have us covered. But it wouldn't hurt to have a poke around Storybook as well.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
