### PR TITLE
Add `split="right"` to Form Controls Layout

### DIFF
--- a/.changeset/bright-mayflies-appear.md
+++ b/.changeset/bright-mayflies-appear.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Form Controls Layout's `split` attribute now supports a `"right"` value that gives each control's label 66.5% of the available space and the control itself the remaining 33.5%.

--- a/.changeset/bright-mayflies-appear.md
+++ b/.changeset/bright-mayflies-appear.md
@@ -2,4 +2,5 @@
 '@crowdstrike/glide-core': patch
 ---
 
-Form Controls Layout's `split` attribute now supports a `"right"` value that gives each control's label 66.5% of the available space and the control itself the remaining 33.5%.
+- Form Controls Layout now supports `split="right"`, which gives each control's label 66.5% of the available space and the control itself the remaining 33.5%.
+- Form Controls Layout's `split="left"` has been adjusted from a 33.33% / 66.66% split to a 33.5% / 66.5% split.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1006,7 +1006,7 @@
               "kind": "field",
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "attribute": "privateSplit"
             },
@@ -1226,7 +1226,7 @@
             {
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "fieldName": "privateSplit"
             },
@@ -1472,7 +1472,7 @@
               "kind": "field",
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "attribute": "privateSplit"
             },
@@ -1795,7 +1795,7 @@
             {
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "fieldName": "privateSplit"
             },
@@ -2591,7 +2591,7 @@
               "kind": "field",
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "attribute": "privateSplit"
             },
@@ -2926,7 +2926,7 @@
             {
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "fieldName": "privateSplit"
             },
@@ -3073,7 +3073,7 @@
               "kind": "field",
               "name": "split",
               "type": {
-                "text": "'left' | 'middle'"
+                "text": "'left' | 'middle' | 'right'"
               },
               "default": "'left'",
               "attribute": "split",
@@ -3094,7 +3094,7 @@
             {
               "name": "split",
               "type": {
-                "text": "'left' | 'middle'"
+                "text": "'left' | 'middle' | 'right'"
               },
               "default": "'left'",
               "fieldName": "split"
@@ -3751,7 +3751,7 @@
               "kind": "field",
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "attribute": "privateSplit"
             },
@@ -4039,7 +4039,7 @@
             {
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "fieldName": "privateSplit"
             },
@@ -4209,7 +4209,7 @@
               "kind": "field",
               "name": "split",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "attribute": "split"
             },
@@ -4274,7 +4274,7 @@
             {
               "name": "split",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "fieldName": "split"
             },
@@ -5826,7 +5826,7 @@
               "kind": "field",
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "attribute": "privateSplit"
             },
@@ -6037,7 +6037,7 @@
             {
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "fieldName": "privateSplit"
             },
@@ -7716,7 +7716,7 @@
               "kind": "field",
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "attribute": "privateSplit"
             },
@@ -7964,7 +7964,7 @@
             {
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "fieldName": "privateSplit"
             },
@@ -8352,7 +8352,7 @@
               "kind": "field",
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "attribute": "privateSplit"
             },
@@ -8454,7 +8454,7 @@
             {
               "name": "privateSplit",
               "type": {
-                "text": "'left' | 'middle' | undefined"
+                "text": "'left' | 'middle' | 'right' | undefined"
               },
               "fieldName": "privateSplit"
             },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
       // 0.2, the default, produces too many false negatives. 0, on the other
       // hand, produces too many false positives. The idea is for this number
       // to be as close to 0 as possible without any false positives.
-      threshold: 0.05,
+      threshold: 0.03,
     },
   },
   fullyParallel: true,

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,7 +4,10 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   expect: {
     toHaveScreenshot: {
-      threshold: 0, // 0.2 by default.
+      // 0.2, the default, produces too many false negatives. 0, on the other
+      // hand, produces too many false positives. The idea is for this number
+      // to be as close to 0 as possible without any false positives.
+      threshold: 0.05,
     },
   },
   fullyParallel: true,

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -110,7 +110,7 @@ export default class GlideCoreCheckboxGroup
 
   // Private because it's only meant to be used by Form Controls Layout.
   @property()
-  privateSplit?: 'left' | 'middle';
+  privateSplit?: 'left' | 'middle' | 'right';
 
   /**
    * @default false

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -180,7 +180,7 @@ export default class GlideCoreCheckbox
 
   // Private because it's only meant to be used by Form Controls Layout.
   @property()
-  privateSplit?: 'left' | 'middle';
+  privateSplit?: 'left' | 'middle' | 'right';
 
   // Private because it's only meant to be used by Checkbox Group and Dropdown Option.
   @property({ attribute: 'private-variant' })

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -230,7 +230,7 @@ export default class GlideCoreDropdown
 
   // Private because it's only meant to be used by Form Controls Layout.
   @property()
-  privateSplit?: 'left' | 'middle';
+  privateSplit?: 'left' | 'middle' | 'right';
 
   @property({ reflect: true, type: Boolean })
   readonly = false;
@@ -2591,7 +2591,9 @@ export default class GlideCoreDropdown
                           Number.parseFloat(
                             window
                               .getComputedStyle(document.body)
-                              .getPropertyValue('--glide-core-spacing-base-xxs'),
+                              .getPropertyValue(
+                                '--glide-core-spacing-base-xxs',
+                              ),
                           ) *
                           Number.parseFloat(
                             window.getComputedStyle(document.documentElement)

--- a/src/form-controls-layout.stories.ts
+++ b/src/form-controls-layout.stories.ts
@@ -60,10 +60,10 @@ const meta: Meta = {
     },
     split: {
       control: { type: 'radio' },
-      options: ['left', 'middle'],
+      options: ['left', 'middle', 'right'],
       table: {
         defaultValue: { summary: '"left"' },
-        type: { summary: '"left" | "middle"' },
+        type: { summary: '"left" | "middle" | "right"' },
       },
     },
     version: {

--- a/src/form-controls-layout.test.visuals.ts
+++ b/src/form-controls-layout.test.visuals.ts
@@ -34,6 +34,20 @@ for (const story of stories['Form Controls Layout']) {
             `${test.titlePath.join('.')}.png`,
           );
         });
+
+        test('split="right"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-form-controls-layout')
+            .evaluate<void, GlideCoreFormControlsLayout>((element) => {
+              element.split = 'right';
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
       });
     }
   });

--- a/src/form-controls-layout.ts
+++ b/src/form-controls-layout.ts
@@ -20,7 +20,7 @@ declare global {
 }
 
 /**
- * @attr {'left'|'middle'} [split='left']
+ * @attr {'left'|'middle'|'right'} [split='left']
  *
  * @readonly
  * @attr {string} [version]
@@ -41,11 +41,11 @@ export default class GlideCoreFormControlsLayout extends LitElement {
    * @default 'left'
    */
   @property({ reflect: true })
-  get split(): 'left' | 'middle' {
+  get split(): 'left' | 'middle' | 'right' {
     return this.#split;
   }
 
-  set split(split: 'left' | 'middle') {
+  set split(split: 'left' | 'middle' | 'right') {
     this.#split = split;
 
     if (this.#slotElementRef.value) {
@@ -81,7 +81,7 @@ export default class GlideCoreFormControlsLayout extends LitElement {
 
   #slotElementRef = createRef<HTMLSlotElement>();
 
-  #split: 'left' | 'middle' = 'left';
+  #split: 'left' | 'middle' | 'right' = 'left';
 
   #onSlotChange() {
     if (this.#slotElementRef.value) {

--- a/src/input.ts
+++ b/src/input.ts
@@ -161,7 +161,7 @@ export default class GlideCoreInput extends LitElement implements FormControl {
 
   // Private because it's only meant to be used by Form Controls Layout.
   @property()
-  privateSplit?: 'left' | 'middle';
+  privateSplit?: 'left' | 'middle' | 'right';
 
   @property({
     type: Number,

--- a/src/label.styles.ts
+++ b/src/label.styles.ts
@@ -23,13 +23,17 @@ export default [
       }
 
       &.left {
-        grid-template-columns: calc(100% / 3) 1fr;
+        grid-template-columns: 33.5% 1fr;
       }
 
       &.middle {
         grid-template-columns: calc(50% - var(--private-column-gap) / 2) calc(
             50% - var(--private-column-gap) / 2
           );
+      }
+
+      &.right {
+        grid-template-columns: 66.5% 1fr;
       }
 
       &.hidden-label {
@@ -53,7 +57,8 @@ export default [
       min-inline-size: 3ch;
 
       &.middle,
-      &.left {
+      &.left,
+      &.right {
         justify-content: flex-end;
       }
     }

--- a/src/label.ts
+++ b/src/label.ts
@@ -26,7 +26,7 @@ declare global {
  * @attr {string} [label]
  * @attr {'horizontal'|'vertical'} [orientation='horizontal']
  * @attr {boolean} [required=false]
- * @attr {'left'|'middle'} [split]
+ * @attr {'left'|'middle'|'right'} [split]
  * @attr {string} [tooltip]
  *
  * @slot {HTMLLabelElement}
@@ -60,7 +60,7 @@ export default class GlideCoreLabel extends LitElement {
   required = false;
 
   @property()
-  split?: 'left' | 'middle';
+  split?: 'left' | 'middle' | 'right';
 
   @property()
   tooltip?: string;
@@ -90,6 +90,7 @@ export default class GlideCoreLabel extends LitElement {
         vertical: this.orientation === 'vertical',
         left: this.split === 'left',
         middle: this.split === 'middle',
+        right: this.split === 'right',
         'hidden-label': this.hide,
       })}
     >
@@ -99,6 +100,7 @@ export default class GlideCoreLabel extends LitElement {
           hidden: this.hide,
           left: this.split === 'left',
           middle: this.split === 'middle',
+          right: this.split === 'right',
         })}
         part="private-tooltips"
       >

--- a/src/library/form-control.ts
+++ b/src/library/form-control.ts
@@ -5,7 +5,7 @@ export default interface FormControl {
   label?: string;
   name: string;
   orientation: 'horizontal' | 'vertical';
-  privateSplit?: 'left' | 'middle';
+  privateSplit?: 'left' | 'middle' | 'right';
   required: boolean;
   summary?: string;
   tooltip?: string;

--- a/src/radio-group.ts
+++ b/src/radio-group.ts
@@ -134,7 +134,7 @@ export default class GlideCoreRadioGroup
 
   // Private because it's only meant to be used by Form Controls Layout.
   @property()
-  privateSplit?: 'left' | 'middle';
+  privateSplit?: 'left' | 'middle' | 'right';
 
   @property({ reflect: true })
   tooltip?: string;

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -140,7 +140,7 @@ export default class GlideCoreTextarea
 
   // Private because it's only meant to be used by Form Controls Layout.
   @property()
-  privateSplit?: 'left' | 'middle';
+  privateSplit?: 'left' | 'middle' | 'right';
 
   @property({ reflect: true })
   tooltip?: string;

--- a/src/toggle.ts
+++ b/src/toggle.ts
@@ -60,7 +60,7 @@ export default class GlideCoreToggle extends LitElement {
 
   // Private because it's only meant to be used by Form Controls Layout.
   @property()
-  privateSplit?: 'left' | 'middle';
+  privateSplit?: 'left' | 'middle' | 'right';
 
   @property({ reflect: true })
   summary?: string;


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Form Controls Layout's `split` attribute now supports a `"right"` value that gives each control's label 66.5% of the available space and the control itself 33.5% of the available space.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

Check out the visual test report.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
