### PR TITLE
Checkbox Group Checkbox addition fix

### DIFF
--- a/.changeset/thick-zoos-hug.md
+++ b/.changeset/thick-zoos-hug.md
@@ -2,4 +2,4 @@
 '@crowdstrike/glide-core': patch
 ---
 
-Resolved an issue with adding Checkboxes to Checkbox Group after the initial render.
+Checkboxes added to a Checkbox Group after the initial render now follow the design guidelines.

--- a/.changeset/thick-zoos-hug.md
+++ b/.changeset/thick-zoos-hug.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Resolved an issue with adding Checkboxes to Checkbox Group after the initial render.

--- a/src/checkbox-group.test.basics.ts
+++ b/src/checkbox-group.test.basics.ts
@@ -66,7 +66,7 @@ it('does not include in its `value` disabled checkboxes that are checked', async
   expect(checkboxes[1]?.checked).to.be.true;
 });
 
-it('sets `privateVariant` on added Checkboxes', async () => {
+it('sets `privateVariant` on Checkboxes added after initial render', async () => {
   const host = await fixture<GlideCoreCheckboxGroup>(
     html`<glide-core-checkbox-group label="Label">
       <glide-core-checkbox label="One" value="one"></glide-core-checkbox>

--- a/src/checkbox-group.test.basics.ts
+++ b/src/checkbox-group.test.basics.ts
@@ -66,6 +66,28 @@ it('does not include in its `value` disabled checkboxes that are checked', async
   expect(checkboxes[1]?.checked).to.be.true;
 });
 
+it('sets `privateVariant` on added Checkboxes', async () => {
+  const host = await fixture<GlideCoreCheckboxGroup>(
+    html`<glide-core-checkbox-group label="Label">
+      <glide-core-checkbox label="One" value="one"></glide-core-checkbox>
+      <glide-core-checkbox label="Two" value="two"></glide-core-checkbox>
+    </glide-core-checkbox-group>`,
+  );
+
+  const checkbox = document.createElement('glide-core-checkbox');
+  checkbox.label = 'Three';
+  checkbox.value = 'three';
+
+  host.append(checkbox);
+
+  await host.updateComplete;
+
+  const checkboxes = host.querySelectorAll('glide-core-checkbox');
+
+  expect(checkboxes.length).to.equal(3);
+  expect(checkboxes[2]?.privateVariant).to.equal('minimal');
+});
+
 it('throws when `label` is empty', async () => {
   const spy = sinon.spy();
 

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -222,7 +222,6 @@ export default class GlideCoreCheckboxGroup
     );
 
     for (const checkbox of this.#checkboxElements) {
-      checkbox.privateVariant = 'minimal';
       checkbox.addEventListener('blur', this.#onCheckboxBlur.bind(this));
 
       // When `value` is set on initial render, its setter is called before
@@ -595,6 +594,10 @@ export default class GlideCoreCheckboxGroup
   }
 
   #onDefaultSlotChange() {
+    for (const checkbox of this.#checkboxElements) {
+      checkbox.privateVariant = 'minimal';
+    }
+
     this.#value = this.#checkboxElements
       .filter(
         ({ checked, disabled, value }) => checked && !disabled && value !== '',


### PR DESCRIPTION
## 🚀 Description

Setting `privateMinimal` was only done in `firstUpdated()`, so checkboxes added later in the lifecycle didn't have the private property set. This PR fixes those cases.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

- Go to Checkbox Group's Storybook
- Copy a `glide-core-checkbox` element
- Paste it, adding a fourth option
- Verify it visually appears like the other checkbox elements
