### PR TITLE
Add Tab Group overflow button hover state

### DIFF
--- a/.changeset/sixty-spies-own.md
+++ b/.changeset/sixty-spies-own.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Tab Group's overflow buttons now change color on hover.

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -38,6 +38,7 @@ export default defineConfig({
   testDir: './src/',
   use: {
     baseURL: 'http://localhost:6006/iframe.html',
+    testIdAttribute: 'data-test',
   },
   webServer: {
     command: 'pnpm start:development:storybook',

--- a/src/tab.group.styles.ts
+++ b/src/tab.group.styles.ts
@@ -91,6 +91,10 @@ export default [
       &.end {
         transform: rotate(-90deg);
       }
+
+      &:hover:not(.disabled) {
+        color: var(--glide-core-color-interactive-icon-active--hover);
+      }
     }
 
     ::slotted([slot='nav']:first-of-type) {

--- a/src/tab.group.test.visuals.ts
+++ b/src/tab.group.test.visuals.ts
@@ -33,6 +33,17 @@ for (const story of stories['Tab Group']) {
           );
         });
 
+        if (story.id.includes('with-overflow')) {
+          test(':hover', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+            await page.getByTestId('overflow-end-button').hover();
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+        }
+
         test('<glide-core-tab>.disabled', async ({ page }, test) => {
           await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 

--- a/src/tab.group.ts
+++ b/src/tab.group.ts
@@ -58,18 +58,17 @@ export default class GlideCoreTabGroup extends LitElement {
           this.isShowOverflowButtons,
           () => html`
             <button
-              style="height: ${this.#tabListElementRef.value?.clientHeight}px"
+              aria-label=${this.#localize.term('previousTab')}
               class=${classMap({
                 'overflow-button': true,
                 start: true,
                 disabled: this.isDisableOverflowStartButton,
               })}
-              @click=${this.#onOverflowStartButtonClick}
-              tabindex="-1"
-              aria-label=${this.#localize.term('previousTab')}
               data-test="overflow-start-button"
-              ${ref(this.#overflowStartButtonElementRef)}
+              tabindex="-1"
               ?disabled=${this.isDisableOverflowStartButton}
+              @click=${this.#onOverflowStartButtonClick}
+              ${ref(this.#overflowStartButtonElementRef)}
             >
               ${chevronIcon}
             </button>
@@ -83,8 +82,8 @@ export default class GlideCoreTabGroup extends LitElement {
           data-test="tablist"
           role="tablist"
           tabindex="-1"
-          @scroll=${this.#setOverflowButtonsState}
           @focusout=${this.#onTabListFocusout}
+          @scroll=${this.#setOverflowButtonsState}
           ${onResize(this.#onTabListResize.bind(this))}
           ${ref(this.#tabListElementRef)}
         >
@@ -101,16 +100,15 @@ export default class GlideCoreTabGroup extends LitElement {
           this.isShowOverflowButtons,
           () => html`
             <button
-              style="height: ${this.#tabListElementRef.value?.clientHeight}px"
+              aria-label=${this.#localize.term('nextTab')}
               class=${classMap({
                 'overflow-button': true,
                 end: true,
                 disabled: this.isDisableOverflowEndButton,
               })}
-              @click=${this.#onOverflowEndButtonClick}
-              tabindex="-1"
-              aria-label=${this.#localize.term('nextTab')}
               data-test="overflow-end-button"
+              tabindex="-1"
+              @click=${this.#onOverflowEndButtonClick}
               ?disabled=${this.isDisableOverflowEndButton}
               ${ref(this.#overflowEndButtonElementRef)}
             >


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Tab Group's overflow buttons now change color on hover.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

Check out the visual test report.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
