### PR TITLE
Add `useDefault: true` to `@property()` decorators

### DIFF
--- a/.changeset/red-grapes-eat.md
+++ b/.changeset/red-grapes-eat.md
@@ -1,0 +1,9 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Modal Icon Button's `label` attribute is now reflected.
+- Icon Button's `label` attribute is now reflected.
+- Input's `clearable`, `hide-label`, `password-toggle`, and `readonly` attributes are now reflected.
+- Textarea's `placeholder` attribute is now `undefined` by default instead of an empty string, matching our other components.
+- All component attributes whose value is a primitive no longer reflect their values when they're at their default, matching native.

--- a/.changeset/tender-buttons-sniff.md
+++ b/.changeset/tender-buttons-sniff.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+All components now use Lit's new [`useDefault`](https://lit.dev/docs/components/properties/#property-options) option with `@property()` decorators. `useDefault` was added to Lit in `3.3.0`. You may encounter a typechecking error resolved by upgrading Lit if your `tsconfig.json` doesn't include `skipLibCheck: true`.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -634,21 +634,21 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "disabled",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
               "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "label",
               "reflects": true
             },
             {
@@ -735,20 +735,20 @@
           ],
           "attributes": [
             {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "disabled"
-            },
-            {
               "name": "label",
               "type": {
                 "text": "string | undefined"
               },
               "fieldName": "label",
               "required": true
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "disabled"
             },
             {
               "name": "name",
@@ -956,6 +956,15 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "disabled",
               "type": {
                 "text": "boolean"
@@ -972,15 +981,6 @@
               },
               "default": "false",
               "attribute": "hide-label"
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "label",
-              "reflects": true
             },
             {
               "kind": "field",
@@ -1184,6 +1184,14 @@
           ],
           "attributes": [
             {
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "label",
+              "required": true
+            },
+            {
               "name": "disabled",
               "type": {
                 "text": "boolean"
@@ -1198,14 +1206,6 @@
               },
               "default": "false",
               "fieldName": "hideLabel"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "label",
-              "required": true
             },
             {
               "name": "name",
@@ -1355,6 +1355,16 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "default": "undefined",
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "checked",
               "type": {
                 "text": "boolean"
@@ -1398,16 +1408,6 @@
               },
               "default": "false",
               "attribute": "indeterminate"
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "default": "undefined",
-              "attribute": "label",
-              "reflects": true
             },
             {
               "kind": "field",
@@ -1696,6 +1696,15 @@
           ],
           "attributes": [
             {
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "default": "undefined",
+              "fieldName": "label",
+              "required": true
+            },
+            {
               "name": "checked",
               "type": {
                 "text": "boolean"
@@ -1734,15 +1743,6 @@
               },
               "default": "false",
               "fieldName": "indeterminate"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "default": "undefined",
-              "fieldName": "label",
-              "required": true
             },
             {
               "name": "orientation",
@@ -2110,6 +2110,16 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "default": "undefined",
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "count",
               "type": {
                 "text": "number | undefined"
@@ -2135,16 +2145,6 @@
               },
               "default": "false",
               "attribute": "editable",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "default": "undefined",
-              "attribute": "label",
               "reflects": true
             },
             {
@@ -2245,6 +2245,12 @@
               }
             },
             {
+              "name": "private-label-change",
+              "type": {
+                "text": "Event"
+              }
+            },
+            {
               "name": "private-disabled-change",
               "type": {
                 "text": "Event"
@@ -2252,12 +2258,6 @@
             },
             {
               "name": "private-editable-change",
-              "type": {
-                "text": "Event"
-              }
-            },
-            {
-              "name": "private-label-change",
               "type": {
                 "text": "Event"
               }
@@ -2276,6 +2276,15 @@
             }
           ],
           "attributes": [
+            {
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "default": "undefined",
+              "fieldName": "label",
+              "required": true
+            },
             {
               "name": "count",
               "type": {
@@ -2298,15 +2307,6 @@
               },
               "default": "false",
               "fieldName": "editable"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "default": "undefined",
-              "fieldName": "label",
-              "required": true
             },
             {
               "name": "private-indeterminate",
@@ -2502,6 +2502,15 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "addButtonLabel",
               "type": {
                 "text": "string | undefined"
@@ -2537,15 +2546,6 @@
               },
               "default": "false",
               "attribute": "hide-label",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "label",
               "reflects": true
             },
             {
@@ -2854,6 +2854,14 @@
           ],
           "attributes": [
             {
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "label",
+              "required": true
+            },
+            {
               "name": "add-button-label",
               "type": {
                 "text": "string | undefined"
@@ -2883,14 +2891,6 @@
               },
               "default": "false",
               "fieldName": "hideLabel"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "label",
-              "required": true
             },
             {
               "name": "name",
@@ -3206,6 +3206,16 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "description": "For screenreaders",
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "ariaControls",
               "type": {
                 "text": "string | null"
@@ -3246,15 +3256,6 @@
             },
             {
               "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "description": "For screenreaders",
-              "attribute": "label"
-            },
-            {
-              "kind": "field",
               "name": "variant",
               "type": {
                 "text": "'primary' | 'secondary' | 'tertiary'"
@@ -3279,6 +3280,15 @@
             }
           ],
           "attributes": [
+            {
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "description": "For screenreaders",
+              "fieldName": "label",
+              "required": true
+            },
             {
               "name": "aria-controls",
               "type": {
@@ -3310,15 +3320,6 @@
               },
               "default": "false",
               "fieldName": "disabled"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "description": "For screenreaders",
-              "fieldName": "label",
-              "required": true
             },
             {
               "name": "variant",
@@ -3595,97 +3596,11 @@
             },
             {
               "kind": "field",
-              "name": "type",
-              "type": {
-                "text": "| 'date'\n    | 'email'\n    | 'number'\n    | 'password'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'time'\n    | 'url'"
-              },
-              "default": "'text'",
-              "attribute": "type",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "attribute": "name",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "attribute": "value"
-            },
-            {
-              "kind": "field",
               "name": "label",
               "type": {
                 "text": "string | undefined"
               },
               "attribute": "label",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "hideLabel",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "hide-label"
-            },
-            {
-              "kind": "field",
-              "name": "orientation",
-              "type": {
-                "text": "'horizontal' | 'vertical'"
-              },
-              "default": "'horizontal'",
-              "attribute": "orientation",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "pattern",
-              "type": {
-                "text": "string | undefined"
-              },
-              "default": "''",
-              "attribute": "pattern",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "placeholder",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "placeholder",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "clearable",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "clearable"
-            },
-            {
-              "kind": "field",
-              "name": "spellcheck",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "spellcheck",
               "reflects": true
             },
             {
@@ -3710,32 +3625,13 @@
             },
             {
               "kind": "field",
-              "name": "passwordToggle",
+              "name": "clearable",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
-              "description": "For 'password' type, whether to show a button to toggle the password's visibility",
-              "attribute": "password-toggle"
-            },
-            {
-              "kind": "field",
-              "name": "required",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "required",
+              "attribute": "clearable",
               "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "readonly",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "readonly"
             },
             {
               "kind": "field",
@@ -3749,11 +3645,13 @@
             },
             {
               "kind": "field",
-              "name": "privateSplit",
+              "name": "hideLabel",
               "type": {
-                "text": "'left' | 'middle' | 'right' | undefined"
+                "text": "boolean"
               },
-              "attribute": "privateSplit"
+              "default": "false",
+              "attribute": "hide-label",
+              "reflects": true
             },
             {
               "kind": "field",
@@ -3766,12 +3664,90 @@
             },
             {
               "kind": "field",
-              "name": "version",
+              "name": "name",
               "type": {
                 "text": "string"
               },
-              "readonly": true,
-              "attribute": "version",
+              "default": "''",
+              "attribute": "name",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "orientation",
+              "type": {
+                "text": "'horizontal' | 'vertical'"
+              },
+              "default": "'horizontal'",
+              "attribute": "orientation",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "passwordToggle",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "For 'password' type, whether to show a button to toggle the password's visibility",
+              "attribute": "password-toggle",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "placeholder",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "placeholder",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "pattern",
+              "type": {
+                "text": "string | undefined"
+              },
+              "default": "''",
+              "attribute": "pattern",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "privateSplit",
+              "type": {
+                "text": "'left' | 'middle' | 'right' | undefined"
+              },
+              "attribute": "privateSplit"
+            },
+            {
+              "kind": "field",
+              "name": "readonly",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "readonly",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "required",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "spellcheck",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "spellcheck",
               "reflects": true
             },
             {
@@ -3781,6 +3757,35 @@
                 "text": "string | undefined"
               },
               "attribute": "tooltip",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "type",
+              "type": {
+                "text": "| 'date'\n    | 'email'\n    | 'number'\n    | 'password'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'time'\n    | 'url'"
+              },
+              "default": "'text'",
+              "attribute": "type",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "attribute": "value"
+            },
+            {
+              "kind": "field",
+              "name": "version",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "version",
               "reflects": true
             },
             {
@@ -3909,83 +3914,12 @@
           ],
           "attributes": [
             {
-              "name": "type",
-              "type": {
-                "text": "| 'date'\n    | 'email'\n    | 'number'\n    | 'password'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'time'\n    | 'url'"
-              },
-              "default": "'text'",
-              "fieldName": "type"
-            },
-            {
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "fieldName": "name"
-            },
-            {
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "fieldName": "value"
-            },
-            {
               "name": "label",
               "type": {
                 "text": "string | undefined"
               },
               "fieldName": "label",
               "required": true
-            },
-            {
-              "name": "hide-label",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "hideLabel"
-            },
-            {
-              "name": "orientation",
-              "type": {
-                "text": "'horizontal' | 'vertical'"
-              },
-              "default": "'horizontal'",
-              "fieldName": "orientation"
-            },
-            {
-              "name": "pattern",
-              "type": {
-                "text": "string | undefined"
-              },
-              "default": "''",
-              "fieldName": "pattern"
-            },
-            {
-              "name": "placeholder",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "placeholder"
-            },
-            {
-              "name": "clearable",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "clearable"
-            },
-            {
-              "name": "spellcheck",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "spellcheck"
             },
             {
               "name": "autocapitalize",
@@ -4004,29 +3938,12 @@
               "fieldName": "autocomplete"
             },
             {
-              "name": "password-toggle",
+              "name": "clearable",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
-              "description": "For 'password' type, whether to show a button to toggle the password's visibility",
-              "fieldName": "passwordToggle"
-            },
-            {
-              "name": "required",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "required"
-            },
-            {
-              "name": "readonly",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "readonly"
+              "fieldName": "clearable"
             },
             {
               "name": "disabled",
@@ -4037,11 +3954,12 @@
               "fieldName": "disabled"
             },
             {
-              "name": "privateSplit",
+              "name": "hide-label",
               "type": {
-                "text": "'left' | 'middle' | 'right' | undefined"
+                "text": "boolean"
               },
-              "fieldName": "privateSplit"
+              "default": "false",
+              "fieldName": "hideLabel"
             },
             {
               "name": "maxlength",
@@ -4051,12 +3969,75 @@
               "fieldName": "maxlength"
             },
             {
-              "name": "version",
+              "name": "name",
               "type": {
                 "text": "string"
               },
-              "readonly": true,
-              "fieldName": "version"
+              "default": "''",
+              "fieldName": "name"
+            },
+            {
+              "name": "orientation",
+              "type": {
+                "text": "'horizontal' | 'vertical'"
+              },
+              "default": "'horizontal'",
+              "fieldName": "orientation"
+            },
+            {
+              "name": "password-toggle",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "For 'password' type, whether to show a button to toggle the password's visibility",
+              "fieldName": "passwordToggle"
+            },
+            {
+              "name": "placeholder",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "placeholder"
+            },
+            {
+              "name": "pattern",
+              "type": {
+                "text": "string | undefined"
+              },
+              "default": "''",
+              "fieldName": "pattern"
+            },
+            {
+              "name": "privateSplit",
+              "type": {
+                "text": "'left' | 'middle' | 'right' | undefined"
+              },
+              "fieldName": "privateSplit"
+            },
+            {
+              "name": "readonly",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "readonly"
+            },
+            {
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "required"
+            },
+            {
+              "name": "spellcheck",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "spellcheck"
             },
             {
               "name": "tooltip",
@@ -4064,6 +4045,30 @@
                 "text": "string | undefined"
               },
               "fieldName": "tooltip"
+            },
+            {
+              "name": "type",
+              "type": {
+                "text": "| 'date'\n    | 'email'\n    | 'number'\n    | 'password'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'time'\n    | 'url'"
+              },
+              "default": "'text'",
+              "fieldName": "type"
+            },
+            {
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "fieldName": "value"
+            },
+            {
+              "name": "version",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "fieldName": "version"
             }
           ],
           "superclass": {
@@ -4363,21 +4368,21 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "disabled",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
               "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "label",
               "reflects": true
             },
             {
@@ -4414,20 +4419,20 @@
           ],
           "attributes": [
             {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "disabled"
-            },
-            {
               "name": "label",
               "type": {
                 "text": "string | undefined"
               },
               "fieldName": "label",
               "required": true
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "disabled"
             },
             {
               "name": "privateActive",
@@ -4516,21 +4521,21 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "disabled",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
               "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "label",
               "reflects": true
             },
             {
@@ -4576,20 +4581,20 @@
           ],
           "attributes": [
             {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "disabled"
-            },
-            {
               "name": "label",
               "type": {
                 "text": "string | undefined"
               },
               "fieldName": "label",
               "required": true
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "disabled"
             },
             {
               "name": "url",
@@ -5071,7 +5076,8 @@
               "type": {
                 "text": "string | undefined"
               },
-              "attribute": "label"
+              "attribute": "label",
+              "reflects": true
             },
             {
               "kind": "field",
@@ -5200,21 +5206,21 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "backButton",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
               "attribute": "back-button",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "label",
               "reflects": true
             },
             {
@@ -5267,20 +5273,20 @@
           ],
           "attributes": [
             {
-              "name": "back-button",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "backButton"
-            },
-            {
               "name": "label",
               "type": {
                 "text": "string | undefined"
               },
               "fieldName": "label",
               "required": true
+            },
+            {
+              "name": "back-button",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "backButton"
             },
             {
               "name": "open",
@@ -5548,6 +5554,16 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "default": "undefined",
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "checked",
               "type": {
                 "text": "boolean"
@@ -5570,16 +5586,6 @@
               "kind": "field",
               "name": "privateInvalid",
               "attribute": "privateInvalid"
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "default": "undefined",
-              "attribute": "label",
-              "reflects": true
             },
             {
               "kind": "field",
@@ -5641,6 +5647,15 @@
           ],
           "attributes": [
             {
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "default": "undefined",
+              "fieldName": "label",
+              "required": true
+            },
+            {
               "name": "checked",
               "type": {
                 "text": "boolean"
@@ -5659,15 +5674,6 @@
             {
               "name": "privateInvalid",
               "fieldName": "privateInvalid"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "default": "undefined",
-              "fieldName": "label",
-              "required": true
             },
             {
               "name": "privateRequired",
@@ -5776,6 +5782,15 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "disabled",
               "type": {
                 "text": "boolean"
@@ -5792,15 +5807,6 @@
               },
               "default": "false",
               "attribute": "hide-label"
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "label",
-              "reflects": true
             },
             {
               "kind": "field",
@@ -5995,6 +6001,14 @@
           ],
           "attributes": [
             {
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "label",
+              "required": true
+            },
+            {
               "name": "disabled",
               "type": {
                 "text": "boolean"
@@ -6009,14 +6023,6 @@
               },
               "default": "false",
               "fieldName": "hideLabel"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "label",
-              "required": true
             },
             {
               "name": "name",
@@ -6260,6 +6266,15 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "ariaControls",
               "type": {
                 "text": "string | null"
@@ -6300,15 +6315,6 @@
             },
             {
               "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "label",
-              "reflects": true
-            },
-            {
-              "kind": "field",
               "name": "privateSize",
               "type": {
                 "text": "'large' | 'small'"
@@ -6337,6 +6343,14 @@
             }
           ],
           "attributes": [
+            {
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "label",
+              "required": true
+            },
             {
               "name": "aria-controls",
               "type": {
@@ -6368,14 +6382,6 @@
               },
               "default": "false",
               "fieldName": "disabled"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "label",
-              "required": true
             },
             {
               "name": "privateSize",
@@ -6458,12 +6464,11 @@
             },
             {
               "kind": "field",
-              "name": "disabled",
+              "name": "url",
               "type": {
-                "text": "boolean"
+                "text": "string | undefined"
               },
-              "default": "false",
-              "attribute": "disabled",
+              "attribute": "url",
               "reflects": true
             },
             {
@@ -6477,11 +6482,12 @@
             },
             {
               "kind": "field",
-              "name": "url",
+              "name": "disabled",
               "type": {
-                "text": "string | undefined"
+                "text": "boolean"
               },
-              "attribute": "url",
+              "default": "false",
+              "attribute": "disabled",
               "reflects": true
             },
             {
@@ -6515,12 +6521,12 @@
           ],
           "attributes": [
             {
-              "name": "disabled",
+              "name": "url",
               "type": {
-                "text": "boolean"
+                "text": "string | undefined"
               },
-              "default": "false",
-              "fieldName": "disabled"
+              "fieldName": "url",
+              "required": true
             },
             {
               "name": "label",
@@ -6531,12 +6537,12 @@
               "required": true
             },
             {
-              "name": "url",
+              "name": "disabled",
               "type": {
-                "text": "string | undefined"
+                "text": "boolean"
               },
-              "fieldName": "url",
-              "required": true
+              "default": "false",
+              "fieldName": "disabled"
             },
             {
               "name": "privateSize",
@@ -6633,21 +6639,21 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "disabled",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
               "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "label",
               "reflects": true
             },
             {
@@ -6714,20 +6720,20 @@
           ],
           "attributes": [
             {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "disabled"
-            },
-            {
               "name": "label",
               "type": {
                 "text": "string | undefined"
               },
               "fieldName": "label",
               "required": true
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "disabled"
             },
             {
               "name": "menu-open",
@@ -7587,109 +7593,11 @@
             },
             {
               "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "attribute": "value"
-            },
-            {
-              "kind": "field",
               "name": "label",
               "type": {
                 "text": "string | undefined"
               },
               "attribute": "label",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "hideLabel",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "hide-label",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "orientation",
-              "type": {
-                "text": "'horizontal' | 'vertical'"
-              },
-              "default": "'horizontal'",
-              "attribute": "orientation",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "placeholder",
-              "type": {
-                "text": "string | undefined"
-              },
-              "default": "''",
-              "attribute": "placeholder",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "required",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "required",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "readonly",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "readonly",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "maxlength",
-              "type": {
-                "text": "number | undefined"
-              },
-              "attribute": "maxlength",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "attribute": "name",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "spellcheck",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "spellcheck",
               "reflects": true
             },
             {
@@ -7714,11 +7622,99 @@
             },
             {
               "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "disabled",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "hideLabel",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "hide-label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "maxlength",
+              "type": {
+                "text": "number | undefined"
+              },
+              "attribute": "maxlength",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "attribute": "name",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "orientation",
+              "type": {
+                "text": "'horizontal' | 'vertical'"
+              },
+              "default": "'horizontal'",
+              "attribute": "orientation",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "placeholder",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "placeholder",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "privateSplit",
               "type": {
                 "text": "'left' | 'middle' | 'right' | undefined"
               },
               "attribute": "privateSplit"
+            },
+            {
+              "kind": "field",
+              "name": "spellcheck",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "spellcheck",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "required",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "readonly",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "readonly",
+              "reflects": true
             },
             {
               "kind": "field",
@@ -7728,6 +7724,15 @@
               },
               "attribute": "tooltip",
               "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "attribute": "value"
             },
             {
               "kind": "field",
@@ -7859,91 +7864,12 @@
           ],
           "attributes": [
             {
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "fieldName": "value"
-            },
-            {
               "name": "label",
               "type": {
                 "text": "string | undefined"
               },
               "fieldName": "label",
               "required": true
-            },
-            {
-              "name": "hide-label",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "hideLabel"
-            },
-            {
-              "name": "orientation",
-              "type": {
-                "text": "'horizontal' | 'vertical'"
-              },
-              "default": "'horizontal'",
-              "fieldName": "orientation"
-            },
-            {
-              "name": "placeholder",
-              "type": {
-                "text": "string | undefined"
-              },
-              "default": "''",
-              "fieldName": "placeholder"
-            },
-            {
-              "name": "required",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "required"
-            },
-            {
-              "name": "readonly",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "readonly"
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "disabled"
-            },
-            {
-              "name": "maxlength",
-              "type": {
-                "text": "number | undefined"
-              },
-              "fieldName": "maxlength"
-            },
-            {
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "fieldName": "name"
-            },
-            {
-              "name": "spellcheck",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "spellcheck"
             },
             {
               "name": "autocapitalize",
@@ -7962,6 +7888,52 @@
               "fieldName": "autocomplete"
             },
             {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "disabled"
+            },
+            {
+              "name": "hide-label",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "hideLabel"
+            },
+            {
+              "name": "maxlength",
+              "type": {
+                "text": "number | undefined"
+              },
+              "fieldName": "maxlength"
+            },
+            {
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "fieldName": "name"
+            },
+            {
+              "name": "orientation",
+              "type": {
+                "text": "'horizontal' | 'vertical'"
+              },
+              "default": "'horizontal'",
+              "fieldName": "orientation"
+            },
+            {
+              "name": "placeholder",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "placeholder"
+            },
+            {
               "name": "privateSplit",
               "type": {
                 "text": "'left' | 'middle' | 'right' | undefined"
@@ -7969,11 +7941,43 @@
               "fieldName": "privateSplit"
             },
             {
+              "name": "spellcheck",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "spellcheck"
+            },
+            {
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "required"
+            },
+            {
+              "name": "readonly",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "readonly"
+            },
+            {
               "name": "tooltip",
               "type": {
                 "text": "string | undefined"
               },
               "fieldName": "tooltip"
+            },
+            {
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "fieldName": "value"
             },
             {
               "name": "version",
@@ -8303,6 +8307,15 @@
             },
             {
               "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "checked",
               "type": {
                 "text": "boolean"
@@ -8328,15 +8341,6 @@
               },
               "default": "false",
               "attribute": "hide-label"
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "label",
-              "reflects": true
             },
             {
               "kind": "field",
@@ -8412,6 +8416,14 @@
           ],
           "attributes": [
             {
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "label",
+              "required": true
+            },
+            {
               "name": "checked",
               "type": {
                 "text": "boolean"
@@ -8434,14 +8446,6 @@
               },
               "default": "false",
               "fieldName": "hideLabel"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "label",
-              "required": true
             },
             {
               "name": "orientation",
@@ -8729,22 +8733,22 @@
             },
             {
               "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
               "name": "label",
               "type": {
                 "text": "string | undefined"
               },
               "default": "undefined",
               "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "disabled",
               "reflects": true
             },
             {
@@ -8818,14 +8822,6 @@
           ],
           "attributes": [
             {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "disabled"
-            },
-            {
               "name": "label",
               "type": {
                 "text": "string | undefined"
@@ -8833,6 +8829,14 @@
               "default": "undefined",
               "fieldName": "label",
               "required": true
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "disabled"
             },
             {
               "name": "offset",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,6 +54,7 @@ export default defineConfig([
       '@crowdstrike/glide-core/string-event-name': 'error',
       '@crowdstrike/glide-core/slot-type-comment': 'error',
       '@crowdstrike/glide-core/public-property-expression-type': 'error',
+      '@crowdstrike/glide-core/use-default-with-property-decorator': 'error',
 
       // Enabling this rule would force us to `await` any function that returns a promise.
       // One example is a function that itself `await`s `updateComplete`. The rule is a bit

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "husky": "^8.0.3",
     "is-ci": "^4.1.0",
     "lint-staged": "^15.2.11",
-    "lit": "^3.2.1",
+    "lit": "^3.3.0",
     "lit-analyzer": "^2.0.3",
     "minify-literals": "^1.0.10",
     "node-html-parser": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,10 +71,10 @@ importers:
         version: 8.6.3(storybook@8.6.3(prettier@3.5.3))
       '@storybook/web-components':
         specifier: ^8.6.3
-        version: 8.6.3(lit@3.2.1)(storybook@8.6.3(prettier@3.5.3))
+        version: 8.6.3(lit@3.3.0)(storybook@8.6.3(prettier@3.5.3))
       '@storybook/web-components-vite':
         specifier: ^8.6.3
-        version: 8.6.3(lit@3.2.1)(storybook@8.6.3(prettier@3.5.3))(vite@6.2.6(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
+        version: 8.6.3(lit@3.3.0)(storybook@8.6.3(prettier@3.5.3))(vite@6.2.5(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@stylistic/eslint-plugin':
         specifier: ^2.13.0
         version: 2.13.0(eslint@9.22.0)(typescript@5.8.2)
@@ -166,8 +166,8 @@ importers:
         specifier: ^15.2.11
         version: 15.4.3
       lit:
-        specifier: ^3.2.1
-        version: 3.2.1
+        specifier: ^3.3.0
+        version: 3.3.0
       lit-analyzer:
         specifier: ^2.0.3
         version: 2.0.3
@@ -248,7 +248,7 @@ importers:
         version: 8.29.0(eslint@9.22.0)(typescript@5.8.2)
       vite:
         specifier: ^6.2.1
-        version: 6.2.6(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+        version: 6.2.5(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       vitest:
         specifier: ^3.0.8
         version: 3.0.8(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -656,8 +656,8 @@ packages:
   '@lit-labs/ssr-dom-shim@1.2.1':
     resolution: {integrity: sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==}
 
-  '@lit/reactive-element@2.0.4':
-    resolution: {integrity: sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==}
+  '@lit/reactive-element@2.1.0':
+    resolution: {integrity: sha512-L2qyoZSQClcBmq0qajBVbhYEcG6iK0XfLn66ifLe/RfC0/ihpc+pl0Wdn8bJ8o+hj38cG0fGXRgSS20MuXn7qA==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -3076,14 +3076,17 @@ packages:
     resolution: {integrity: sha512-XiAjnwVipNrKav7r3CSEZpWt+mwYxrhPRVC7h8knDmn/HWTzzWJvPe+mwBcL2brn4xhItAMzZhFC8tzzqHKmiQ==}
     hasBin: true
 
-  lit-element@4.1.1:
-    resolution: {integrity: sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==}
+  lit-element@4.2.0:
+    resolution: {integrity: sha512-MGrXJVAI5x+Bfth/pU9Kst1iWID6GHDLEzFEnyULB/sFiRLgkd8NPK/PeeXxktA3T6EIIaq8U3KcbTU5XFcP2Q==}
 
   lit-html@3.2.1:
     resolution: {integrity: sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==}
 
-  lit@3.2.1:
-    resolution: {integrity: sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==}
+  lit-html@3.3.0:
+    resolution: {integrity: sha512-RHoswrFAxY2d8Cf2mm4OZ1DgzCoBKUKSPvA1fhtSELxUERq2aQQ2h05pO9j81gS1o7RIRJ+CePLogfyahwmynw==}
+
+  lit@3.3.0:
+    resolution: {integrity: sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==}
 
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
@@ -4418,8 +4421,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@6.2.6:
-    resolution: {integrity: sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==}
+  vite@6.2.5:
+    resolution: {integrity: sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -5109,7 +5112,7 @@ snapshots:
 
   '@lit-labs/ssr-dom-shim@1.2.1': {}
 
-  '@lit/reactive-element@2.0.4':
+  '@lit/reactive-element@2.1.0':
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.2.1
 
@@ -5154,7 +5157,7 @@ snapshots:
   '@open-wc/scoped-elements@3.0.5':
     dependencies:
       '@open-wc/dedupe-mixin': 1.4.0
-      lit: 3.2.1
+      lit: 3.3.0
 
   '@open-wc/semantic-dom-diff@0.20.1':
     dependencies:
@@ -5168,7 +5171,7 @@ snapshots:
   '@open-wc/testing-helpers@3.0.1':
     dependencies:
       '@open-wc/scoped-elements': 3.0.5
-      lit: 3.2.1
+      lit: 3.3.0
       lit-html: 3.2.1
 
   '@open-wc/testing@4.0.0':
@@ -5413,13 +5416,13 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@storybook/builder-vite@8.6.3(storybook@8.6.3(prettier@3.5.3))(vite@6.2.6(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
+  '@storybook/builder-vite@8.6.3(storybook@8.6.3(prettier@3.5.3))(vite@6.2.5(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@storybook/csf-plugin': 8.6.3(storybook@8.6.3(prettier@3.5.3))
       browser-assert: 1.2.1
       storybook: 8.6.3(prettier@3.5.3)
       ts-dedent: 2.2.0
-      vite: 6.2.6(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.5(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
   '@storybook/components@8.6.3(storybook@8.6.3(prettier@3.5.3))':
     dependencies:
@@ -5480,24 +5483,24 @@ snapshots:
     dependencies:
       storybook: 8.6.3(prettier@3.5.3)
 
-  '@storybook/web-components-vite@8.6.3(lit@3.2.1)(storybook@8.6.3(prettier@3.5.3))(vite@6.2.6(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
+  '@storybook/web-components-vite@8.6.3(lit@3.3.0)(storybook@8.6.3(prettier@3.5.3))(vite@6.2.5(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
-      '@storybook/builder-vite': 8.6.3(storybook@8.6.3(prettier@3.5.3))(vite@6.2.6(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
-      '@storybook/web-components': 8.6.3(lit@3.2.1)(storybook@8.6.3(prettier@3.5.3))
+      '@storybook/builder-vite': 8.6.3(storybook@8.6.3(prettier@3.5.3))(vite@6.2.5(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
+      '@storybook/web-components': 8.6.3(lit@3.3.0)(storybook@8.6.3(prettier@3.5.3))
       magic-string: 0.30.17
       storybook: 8.6.3(prettier@3.5.3)
     transitivePeerDependencies:
       - lit
       - vite
 
-  '@storybook/web-components@8.6.3(lit@3.2.1)(storybook@8.6.3(prettier@3.5.3))':
+  '@storybook/web-components@8.6.3(lit@3.3.0)(storybook@8.6.3(prettier@3.5.3))':
     dependencies:
       '@storybook/components': 8.6.3(storybook@8.6.3(prettier@3.5.3))
       '@storybook/global': 5.0.0
       '@storybook/manager-api': 8.6.3(storybook@8.6.3(prettier@3.5.3))
       '@storybook/preview-api': 8.6.3(storybook@8.6.3(prettier@3.5.3))
       '@storybook/theming': 8.6.3(storybook@8.6.3(prettier@3.5.3))
-      lit: 3.2.1
+      lit: 3.3.0
       storybook: 8.6.3(prettier@3.5.3)
       tiny-invariant: 1.3.3
       ts-dedent: 2.2.0
@@ -5797,13 +5800,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.8(vite@6.2.6(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.8(vite@6.2.5(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.0.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.6(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.5(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.0.8':
     dependencies:
@@ -7887,21 +7890,25 @@ snapshots:
       vscode-html-languageservice: 3.1.0
       web-component-analyzer: 2.0.0
 
-  lit-element@4.1.1:
+  lit-element@4.2.0:
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.2.1
-      '@lit/reactive-element': 2.0.4
-      lit-html: 3.2.1
+      '@lit/reactive-element': 2.1.0
+      lit-html: 3.3.0
 
   lit-html@3.2.1:
     dependencies:
       '@types/trusted-types': 2.0.7
 
-  lit@3.2.1:
+  lit-html@3.3.0:
     dependencies:
-      '@lit/reactive-element': 2.0.4
-      lit-element: 4.1.1
-      lit-html: 3.2.1
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.0:
+    dependencies:
+      '@lit/reactive-element': 2.1.0
+      lit-element: 4.2.0
+      lit-html: 3.3.0
 
   locate-path@3.0.0:
     dependencies:
@@ -9290,7 +9297,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.6(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.5(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9305,7 +9312,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.6(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
+  vite@6.2.5(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3
@@ -9320,7 +9327,7 @@ snapshots:
   vitest@3.0.8(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.8
-      '@vitest/mocker': 3.0.8(vite@6.2.6(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.8(vite@6.2.5(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.0.8
       '@vitest/runner': 3.0.8
       '@vitest/snapshot': 3.0.8
@@ -9336,7 +9343,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.6(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.5(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       vite-node: 3.0.8(@types/node@22.10.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/src/button-group.button.ts
+++ b/src/button-group.button.ts
@@ -60,7 +60,7 @@ export default class GlideCoreButtonGroupButton extends LitElement {
 
   // `value` is used by consumers to identify selections based on something other
   // than the label.
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   value = '';
 
   // Private because it's only meant to be used by Button Group.

--- a/src/button-group.ts
+++ b/src/button-group.ts
@@ -62,7 +62,7 @@ export default class GlideCoreButtonGroup extends LitElement {
   /**
    * @default 'horizontal'
    */
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   get orientation(): 'horizontal' | 'vertical' {
     return this.#orientation;
   }

--- a/src/button.ts
+++ b/src/button.ts
@@ -47,26 +47,26 @@ export default class GlideCoreButton extends LitElement {
 
   static override styles = styles;
 
-  @property({ type: Boolean, reflect: true }) disabled = false;
-
   @property({ reflect: true })
   @required
   label?: string;
 
-  @property({ reflect: true }) name = '';
+  @property({ type: Boolean, reflect: true }) disabled = false;
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true }) name = '';
+
+  @property({ reflect: true, useDefault: true })
   size: 'large' | 'small' = 'large';
 
   @property({ reflect: true })
   tooltip?: string;
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   type: 'button' | 'submit' | 'reset' = 'button';
 
-  @property({ reflect: true }) value = '';
+  @property({ reflect: true, useDefault: true }) value = '';
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   variant: 'primary' | 'secondary' | 'tertiary' = 'primary';
 
   @property({ reflect: true })

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -79,6 +79,10 @@ export default class GlideCoreCheckboxGroup
 
   static override styles = styles;
 
+  @property({ reflect: true })
+  @required
+  label?: string;
+
   /**
    * @default false
    */
@@ -98,14 +102,10 @@ export default class GlideCoreCheckboxGroup
   @property({ attribute: 'hide-label', type: Boolean })
   hideLabel = false;
 
-  @property({ reflect: true })
-  @required
-  label?: string;
-
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   name = '';
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   orientation = 'horizontal' as const;
 
   // Private because it's only meant to be used by Form Controls Layout.

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -84,6 +84,26 @@ export default class GlideCoreCheckbox
   static override styles = styles;
 
   /**
+   * @default undefined
+   */
+  @property({ reflect: true })
+  @required
+  get label(): string | undefined {
+    return this.#label;
+  }
+
+  set label(label) {
+    this.#label = label;
+
+    // Wait for the label to render. A rerender won't be scheduled by Lit
+    // until after this setter finishes. So awaiting `this.updateComplete`
+    // won't fly.
+    setTimeout(() => {
+      this.#updateLabelOverflow();
+    });
+  }
+
+  /**
     @default false
   */
   @property({ type: Boolean })
@@ -124,36 +144,17 @@ export default class GlideCoreCheckbox
   @property({ type: Boolean })
   indeterminate = false;
 
-  /**
-   * @default undefined
-   */
-  @property({ reflect: true })
-  @required
-  get label(): string | undefined {
-    return this.#label;
-  }
-
-  set label(label) {
-    this.#label = label;
-
-    // Wait for the label to render. A rerender won't be scheduled by Lit
-    // until after this setter finishes. So awaiting `this.updateComplete`
-    // won't fly.
-    setTimeout(() => {
-      this.#updateLabelOverflow();
-    });
-  }
-
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   orientation: 'horizontal' | 'vertical' = 'horizontal';
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   name = '';
 
   // Private because it's only meant to be used by Dropdown Option to offset the tooltip by the option's padding.
   @property({
     attribute: 'private-label-tooltip-offset',
     reflect: true,
+    useDefault: true,
     type: Number,
   })
   privateLabelTooltipOffset = 4;

--- a/src/dropdown.option.ts
+++ b/src/dropdown.option.ts
@@ -48,6 +48,32 @@ export default class GlideCoreDropdownOption extends LitElement {
 
   static override styles = styles;
 
+  /**
+   * @default undefined
+   */
+  @property({ reflect: true })
+  @required
+  get label(): string | undefined {
+    return this.#label;
+  }
+
+  set label(label) {
+    this.#label = label;
+
+    // Wait for the label to render. A rerender won't be scheduled by Lit
+    // until after this setter finishes. So awaiting `this.updateComplete`
+    // won't fly.
+    setTimeout(() => {
+      this.#updateLabelOverflow();
+    });
+
+    this.dispatchEvent(
+      new Event('private-label-change', {
+        bubbles: true,
+      }),
+    );
+  }
+
   @property({ reflect: true, type: Number })
   count?: number;
 
@@ -91,32 +117,6 @@ export default class GlideCoreDropdownOption extends LitElement {
     );
   }
 
-  /**
-   * @default undefined
-   */
-  @property({ reflect: true })
-  @required
-  get label(): string | undefined {
-    return this.#label;
-  }
-
-  set label(label) {
-    this.#label = label;
-
-    // Wait for the label to render. A rerender won't be scheduled by Lit
-    // until after this setter finishes. So awaiting `this.updateComplete`
-    // won't fly.
-    setTimeout(() => {
-      this.#updateLabelOverflow();
-    });
-
-    this.dispatchEvent(
-      new Event('private-label-change', {
-        bubbles: true,
-      }),
-    );
-  }
-
   // Private because it's only meant to be used by Dropdown.
   @property({ attribute: 'private-indeterminate', type: Boolean })
   privateIndeterminate = false;
@@ -152,7 +152,7 @@ export default class GlideCoreDropdownOption extends LitElement {
   }
 
   // Private because it's only meant to be used by Dropdown.
-  @property({ attribute: 'private-size', reflect: true })
+  @property({ attribute: 'private-size', reflect: true, useDefault: true })
   privateSize: 'large' | 'small' = 'large';
 
   // An option is considered active when it's interacted with via keyboard or hovered.

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -108,6 +108,10 @@ export default class GlideCoreDropdown
 
   static override styles = styles;
 
+  @property({ reflect: true })
+  @required
+  label?: string;
+
   @property({ attribute: 'add-button-label', reflect: true })
   addButtonLabel?: string;
 
@@ -157,11 +161,7 @@ export default class GlideCoreDropdown
   @property({ attribute: 'hide-label', reflect: true, type: Boolean })
   hideLabel = false;
 
-  @property({ reflect: true })
-  @required
-  label?: string;
-
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   name = '';
 
   /**
@@ -222,7 +222,7 @@ export default class GlideCoreDropdown
     }
   }
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   orientation: 'horizontal' | 'vertical' = 'horizontal';
 
   @property({ reflect: true })

--- a/src/eslint/plugin.ts
+++ b/src/eslint/plugin.ts
@@ -17,6 +17,7 @@ import { eventDispatchFromThis } from './rules/event-dispatch-from-this.js';
 import { stringEventName } from './rules/string-event-name.js';
 import { slotTypeComment } from './rules/slot-type-comment.js';
 import { publicPropertyExpressionType } from './rules/public-property-expression-type.js';
+import { useDefaultWithPropertyDecorator } from './rules/use-default-with-property-decorator.js';
 
 export default {
   rules: {
@@ -41,5 +42,6 @@ export default {
     'string-event-name': stringEventName,
     'slot-type-comment': slotTypeComment,
     'public-property-expression-type': publicPropertyExpressionType,
+    'use-default-with-property-decorator': useDefaultWithPropertyDecorator,
   },
 };

--- a/src/eslint/rules/use-default-with-property-decorator.test.ts
+++ b/src/eslint/rules/use-default-with-property-decorator.test.ts
@@ -1,0 +1,72 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { useDefaultWithPropertyDecorator } from './use-default-with-property-decorator.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run(
+  'use-default-with-property-decorator',
+  useDefaultWithPropertyDecorator,
+  {
+    valid: [
+      {
+        code: `
+          class Component {
+            @property({ reflect: true })
+            name = "";
+          }
+        `,
+      },
+      {
+        code: `
+          class Component extends LitElement {
+            @property({ reflect: true, useDefault: true })
+            name = "";
+          }
+        `,
+      },
+      {
+        code: `
+          class Component extends LitElement {
+            @property({ reflect: true })
+            name: string;
+          }
+        `,
+      },
+      {
+        code: `
+          class Component extends LitElement {
+            @property({ useDefault: false })
+            name = "";
+          }
+        `,
+      },
+      {
+        code: `
+          class Component extends LitElement {
+            @property()
+            name = "";
+          }
+        `,
+      },
+      {
+        code: `
+          class Component extends LitElement {
+            @property({ reflect: true, type: Boolean })
+            disabled = false
+          }
+        `,
+      },
+    ],
+    invalid: [
+      {
+        code: `
+          class Component extends LitElement {
+            @property({ reflect: true })
+            name = "";
+          }
+        `,
+        errors: [{ messageId: 'useDefaultWithPropertyDecorator' }],
+      },
+    ],
+  },
+);

--- a/src/eslint/rules/use-default-with-property-decorator.ts
+++ b/src/eslint/rules/use-default-with-property-decorator.ts
@@ -1,0 +1,111 @@
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+
+// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
+
+const createRule = ESLintUtils.RuleCreator<{
+  recommended: boolean;
+}>((name) => {
+  return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;
+});
+
+export const useDefaultWithPropertyDecorator = createRule({
+  name: 'use-default-with-property-decorator',
+  meta: {
+    docs: {
+      description:
+        "Ensures Lit's `@property()` decorator uses `useDefault` when the property is reflected and has a default value that's a literal.",
+      recommended: true,
+    },
+    type: 'suggestion',
+    messages: {
+      useDefaultWithPropertyDecorator:
+        "Add `useDefault: true` to your decorator's options so the property's default value isn't reflected.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      PropertyDefinition(node) {
+        const isExtendsLitElement =
+          node.parent.parent.superClass?.type === AST_NODE_TYPES.Identifier &&
+          node.parent.parent.superClass.name === 'LitElement';
+
+        const hasLiteralValue = node.value?.type === AST_NODE_TYPES.Literal;
+
+        const propertyDecorator = node.decorators.find((decorator) => {
+          return (
+            decorator.expression.type === AST_NODE_TYPES.CallExpression &&
+            decorator.expression.callee.type === AST_NODE_TYPES.Identifier &&
+            decorator.expression.callee.name === 'property'
+          );
+        });
+
+        if (
+          isExtendsLitElement &&
+          hasLiteralValue &&
+          propertyDecorator &&
+          propertyDecorator?.expression.type === AST_NODE_TYPES.CallExpression
+        ) {
+          const hasReflect = propertyDecorator.expression.arguments.some(
+            (argument) => {
+              return (
+                argument.type === AST_NODE_TYPES.ObjectExpression &&
+                argument.properties.some((property) => {
+                  return (
+                    property.type === AST_NODE_TYPES.Property &&
+                    property.key.type === AST_NODE_TYPES.Identifier &&
+                    property.key.name === 'reflect' &&
+                    property.value.type === AST_NODE_TYPES.Literal &&
+                    property.value.value === true
+                  );
+                })
+              );
+            },
+          );
+
+          const isBoolean = propertyDecorator.expression.arguments.some(
+            (argument) => {
+              return (
+                argument.type === AST_NODE_TYPES.ObjectExpression &&
+                argument.properties.some((property) => {
+                  return (
+                    property.type === AST_NODE_TYPES.Property &&
+                    property.key.type === AST_NODE_TYPES.Identifier &&
+                    property.key.name === 'type' &&
+                    property.value.type === AST_NODE_TYPES.Identifier &&
+                    property.value.name === 'Boolean'
+                  );
+                })
+              );
+            },
+          );
+
+          const hasUseDefault = propertyDecorator.expression.arguments.some(
+            (argument) => {
+              return (
+                argument.type === AST_NODE_TYPES.ObjectExpression &&
+                argument.properties.some((property) => {
+                  return (
+                    property.type === AST_NODE_TYPES.Property &&
+                    property.key.type === AST_NODE_TYPES.Identifier &&
+                    property.key.name === 'useDefault' &&
+                    property.value.type === AST_NODE_TYPES.Literal &&
+                    property.value.value === true
+                  );
+                })
+              );
+            },
+          );
+
+          if (hasReflect && !isBoolean && !hasUseDefault) {
+            context.report({
+              node,
+              messageId: 'useDefaultWithPropertyDecorator',
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/src/icon-button.ts
+++ b/src/icon-button.ts
@@ -40,13 +40,20 @@ export default class GlideCoreIconButton extends LitElement {
 
   static override styles = styles;
 
-  @property({ attribute: 'aria-controls', reflect: true })
+  /**
+   * For screenreaders
+   **/
+  @property({ reflect: true })
+  @required
+  label?: string;
+
+  @property({ attribute: 'aria-controls', reflect: true, useDefault: true })
   ariaControls: string | null = null;
 
-  @property({ attribute: 'aria-expanded', reflect: true })
+  @property({ attribute: 'aria-expanded', reflect: true, useDefault: true })
   override ariaExpanded: 'true' | 'false' | null = null;
 
-  @property({ attribute: 'aria-haspopup', reflect: true })
+  @property({ attribute: 'aria-haspopup', reflect: true, useDefault: true })
   override ariaHasPopup:
     | 'true'
     | 'false'
@@ -59,14 +66,7 @@ export default class GlideCoreIconButton extends LitElement {
 
   @property({ type: Boolean, reflect: true }) disabled = false;
 
-  /**
-   * For screenreaders
-   **/
-  @property()
-  @required
-  label?: string;
-
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   variant: 'primary' | 'secondary' | 'tertiary' = 'primary';
 
   @property({ reflect: true })

--- a/src/inline-alert.ts
+++ b/src/inline-alert.ts
@@ -43,7 +43,7 @@ export default class GlideCoreInlineAlert extends LitElement {
 
   static override styles = styles;
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   variant: 'informational' | 'medium' | 'high' | 'critical' = 'informational';
 
   @property({ reflect: true, type: Boolean })

--- a/src/input.ts
+++ b/src/input.ts
@@ -93,6 +93,73 @@ export default class GlideCoreInput extends LitElement implements FormControl {
   static override styles = styles;
 
   @property({ reflect: true })
+  @required
+  label?: string;
+
+  @property({ reflect: true, useDefault: true })
+  override autocapitalize:
+    | 'on'
+    | 'off'
+    | 'none'
+    | 'sentences'
+    | 'words'
+    | 'characters' = 'on';
+
+  @property({ reflect: true, useDefault: true })
+  autocomplete: 'on' | 'off' = 'on';
+
+  @property({ reflect: true, type: Boolean })
+  clearable = false;
+
+  @property({ reflect: true, type: Boolean })
+  disabled = false;
+
+  @property({ attribute: 'hide-label', reflect: true, type: Boolean })
+  hideLabel = false;
+
+  @property({
+    type: Number,
+    converter(value) {
+      return value && Number.parseInt(value, 10);
+    },
+    reflect: true,
+  })
+  maxlength?: number;
+
+  @property({ reflect: true, useDefault: true })
+  name = '';
+
+  @property({ reflect: true, useDefault: true })
+  orientation: 'horizontal' | 'vertical' = 'horizontal';
+
+  /** For 'password' type, whether to show a button to toggle the password's visibility */
+  @property({ attribute: 'password-toggle', reflect: true, type: Boolean })
+  passwordToggle = false;
+
+  @property({ reflect: true })
+  placeholder?: string;
+
+  @property({ reflect: true, useDefault: true })
+  pattern: string | undefined = '';
+
+  // Private because it's only meant to be used by Form Controls Layout.
+  @property()
+  privateSplit?: 'left' | 'middle' | 'right';
+
+  @property({ reflect: true, type: Boolean })
+  readonly = false;
+
+  @property({ reflect: true, type: Boolean })
+  required = false;
+
+  // It's typed by TypeScript as a boolean. But we treat it as a string throughout.
+  @property({ reflect: true, type: Boolean, useDefault: true })
+  override spellcheck = false;
+
+  @property({ reflect: true })
+  tooltip?: string;
+
+  @property({ reflect: true, useDefault: true })
   type:
     | 'date'
     | 'email'
@@ -104,79 +171,12 @@ export default class GlideCoreInput extends LitElement implements FormControl {
     | 'time'
     | 'url' = 'text';
 
-  @property({ reflect: true })
-  name = '';
-
   // Intentionally not reflected to match native.
   @property()
   value = '';
 
   @property({ reflect: true })
-  @required
-  label?: string;
-
-  @property({ attribute: 'hide-label', type: Boolean })
-  hideLabel = false;
-
-  @property({ reflect: true })
-  orientation: 'horizontal' | 'vertical' = 'horizontal';
-
-  @property({ reflect: true })
-  pattern: string | undefined = '';
-
-  @property({ reflect: true })
-  placeholder?: string;
-
-  @property({ type: Boolean })
-  clearable = false;
-
-  // It's typed by TypeScript as a boolean. But we treat it as a string throughout.
-  @property({ reflect: true, type: Boolean })
-  override spellcheck = false;
-
-  @property({ reflect: true })
-  override autocapitalize:
-    | 'on'
-    | 'off'
-    | 'none'
-    | 'sentences'
-    | 'words'
-    | 'characters' = 'on';
-
-  @property({ reflect: true })
-  autocomplete: 'on' | 'off' = 'on';
-
-  /** For 'password' type, whether to show a button to toggle the password's visibility */
-  @property({ attribute: 'password-toggle', type: Boolean })
-  passwordToggle = false;
-
-  @property({ reflect: true, type: Boolean })
-  required = false;
-
-  @property({ type: Boolean })
-  readonly = false;
-
-  @property({ reflect: true, type: Boolean })
-  disabled = false;
-
-  // Private because it's only meant to be used by Form Controls Layout.
-  @property()
-  privateSplit?: 'left' | 'middle' | 'right';
-
-  @property({
-    type: Number,
-    converter(value) {
-      return value && Number.parseInt(value, 10);
-    },
-    reflect: true,
-  })
-  maxlength?: number;
-
-  @property({ reflect: true })
   readonly version: string = packageJson.version;
-
-  @property({ reflect: true })
-  tooltip?: string;
 
   get form(): HTMLFormElement | null {
     return this.#internals.form;

--- a/src/label.ts
+++ b/src/label.ts
@@ -53,7 +53,7 @@ export default class GlideCoreLabel extends LitElement {
   @property({ reflect: true, type: Boolean })
   hide = false;
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   orientation: 'horizontal' | 'vertical' = 'horizontal';
 
   @property({ reflect: true, type: Boolean })

--- a/src/menu.button.ts
+++ b/src/menu.button.ts
@@ -34,6 +34,10 @@ export default class GlideCoreMenuButton extends LitElement {
 
   static override styles = styles;
 
+  @property({ reflect: true })
+  @required
+  label?: string;
+
   /**
    * @default false
    */
@@ -49,10 +53,6 @@ export default class GlideCoreMenuButton extends LitElement {
       this.dispatchEvent(new Event('private-disabled', { bubbles: true }));
     }
   }
-
-  @property({ reflect: true })
-  @required
-  label?: string;
 
   // A button is considered active when it's interacted with via keyboard or hovered.
   // Private because it's only meant to be used by Menu.

--- a/src/menu.link.ts
+++ b/src/menu.link.ts
@@ -36,6 +36,10 @@ export default class GlideCoreMenuLink extends LitElement {
 
   static override styles = styles;
 
+  @property({ reflect: true })
+  @required
+  label?: string;
+
   /**
    * @default false
    */
@@ -51,10 +55,6 @@ export default class GlideCoreMenuLink extends LitElement {
       this.dispatchEvent(new Event('private-disabled', { bubbles: true }));
     }
   }
-
-  @property({ reflect: true })
-  @required
-  label?: string;
 
   @property({ reflect: true })
   url?: string;

--- a/src/menu.options.ts
+++ b/src/menu.options.ts
@@ -48,10 +48,14 @@ export default class GlideCoreMenuOptions extends LitElement {
 
   static override styles = styles;
 
-  @property({ attribute: 'aria-activedescendant', reflect: true })
+  @property({
+    attribute: 'aria-activedescendant',
+    reflect: true,
+    useDefault: true,
+  })
   ariaActivedescendant = '';
 
-  @property({ attribute: 'aria-labelledby', reflect: true })
+  @property({ attribute: 'aria-labelledby', reflect: true, useDefault: true })
   ariaLabelledby = '';
 
   @property()

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -91,7 +91,7 @@ export default class GlideCoreMenu extends LitElement {
     }
   }
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   placement:
     | 'bottom'
     | 'left'

--- a/src/modal.icon-button.ts
+++ b/src/modal.icon-button.ts
@@ -33,7 +33,7 @@ export default class GlideCoreModalIconButton extends LitElement {
 
   static override styles = styles;
 
-  @property()
+  @property({ reflect: true })
   @required
   label?: string;
 
@@ -44,7 +44,7 @@ export default class GlideCoreModalIconButton extends LitElement {
     return html`
       <glide-core-icon-button label=${ifDefined(this.label)} variant="tertiary">
         <slot ${assertSlot()}>
-          <!-- 
+          <!--
             An icon
             @required
             @type {Element}

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -62,12 +62,12 @@ export default class GlideCoreModal extends LitElement {
 
   static override styles = styles;
 
-  @property({ attribute: 'back-button', type: Boolean, reflect: true })
-  backButton = false;
-
   @property({ reflect: true })
   @required
   label?: string;
+
+  @property({ attribute: 'back-button', type: Boolean, reflect: true })
+  backButton = false;
 
   /**
    * @default false
@@ -100,7 +100,7 @@ export default class GlideCoreModal extends LitElement {
   @property({ reflect: true })
   severity?: 'critical' | 'informational' | 'medium';
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   size?: 'small' | 'medium' | 'large' | 'xlarge' = 'medium';
 
   @property({ reflect: true })

--- a/src/radio-group.radio.ts
+++ b/src/radio-group.radio.ts
@@ -36,6 +36,20 @@ export default class GlideCoreRadioGroupRadio extends LitElement {
   static override styles = styles;
 
   /**
+   * @default undefined
+   */
+  @property({ reflect: true })
+  @required
+  get label(): string | undefined {
+    return this.#label;
+  }
+
+  set label(label: string) {
+    this.#label = label;
+    this.ariaLabel = label.toString();
+  }
+
+  /**
    * @default false
    */
   @property({ type: Boolean, reflect: true })
@@ -104,20 +118,6 @@ export default class GlideCoreRadioGroupRadio extends LitElement {
   set privateInvalid(invalid: boolean) {
     this.#privateInvalid = invalid;
     this.ariaInvalid = invalid.toString();
-  }
-
-  /**
-   * @default undefined
-   */
-  @property({ reflect: true })
-  @required
-  get label(): string | undefined {
-    return this.#label;
-  }
-
-  set label(label: string) {
-    this.#label = label;
-    this.ariaLabel = label.toString();
   }
 
   // Private because it's only meant to be used by Radio Group.

--- a/src/radio-group.ts
+++ b/src/radio-group.ts
@@ -79,6 +79,10 @@ export default class GlideCoreRadioGroup
 
   static override styles = styles;
 
+  @property({ reflect: true })
+  @required
+  label?: string;
+
   /**
    * @default false
    */
@@ -122,11 +126,7 @@ export default class GlideCoreRadioGroup
   @property({ attribute: 'hide-label', type: Boolean })
   hideLabel = false;
 
-  @property({ reflect: true })
-  @required
-  label?: string;
-
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   name = '';
 
   @property({ reflect: true })

--- a/src/spinner.ts
+++ b/src/spinner.ts
@@ -39,7 +39,7 @@ export default class GlideCoreSpinner extends LitElement {
   @required
   label?: string;
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   size: 'large' | 'medium' | 'small' = 'medium';
 
   @property({ reflect: true })

--- a/src/split-button.primary-button.ts
+++ b/src/split-button.primary-button.ts
@@ -37,13 +37,17 @@ export default class GlideCoreSplitButtonPrimaryButton extends LitElement {
 
   static override styles = styles;
 
-  @property({ attribute: 'aria-controls', reflect: true })
+  @property({ reflect: true })
+  @required
+  label?: string;
+
+  @property({ attribute: 'aria-controls', reflect: true, useDefault: true })
   ariaControls: string | null = null;
 
-  @property({ attribute: 'aria-expanded', reflect: true })
+  @property({ attribute: 'aria-expanded', reflect: true, useDefault: true })
   override ariaExpanded: 'true' | 'false' | null = null;
 
-  @property({ attribute: 'aria-haspopup', reflect: true })
+  @property({ attribute: 'aria-haspopup', reflect: true, useDefault: true })
   override ariaHasPopup:
     | 'true'
     | 'false'
@@ -56,10 +60,6 @@ export default class GlideCoreSplitButtonPrimaryButton extends LitElement {
 
   @property({ reflect: true, type: Boolean })
   disabled = false;
-
-  @property({ reflect: true })
-  @required
-  label?: string;
 
   @property()
   privateSize: 'large' | 'small' = 'large';
@@ -86,7 +86,7 @@ export default class GlideCoreSplitButtonPrimaryButton extends LitElement {
       ?disabled=${this.disabled}
     >
       <slot name="icon">
-        <!-- 
+        <!--
           An icon before the label
           @type {Element}
         -->

--- a/src/split-button.primary-link.ts
+++ b/src/split-button.primary-link.ts
@@ -35,16 +35,16 @@ export default class GlideCoreSplitButtonPrimaryLink extends LitElement {
 
   static override styles = styles;
 
-  @property({ reflect: true, type: Boolean })
-  disabled = false;
+  @property({ reflect: true })
+  @required
+  url?: string;
 
   @property({ reflect: true })
   @required
   label?: string;
 
-  @property({ reflect: true })
-  @required
-  url?: string;
+  @property({ reflect: true, type: Boolean })
+  disabled = false;
 
   @property()
   privateSize: 'large' | 'small' = 'large';

--- a/src/split-button.secondary-button.ts
+++ b/src/split-button.secondary-button.ts
@@ -43,17 +43,17 @@ export default class GlideCoreSplitButtonSecondaryButton extends LitElement {
 
   static override styles = styles;
 
-  @property({ reflect: true, type: Boolean })
-  disabled = false;
-
   @property({ reflect: true })
   @required
   label?: string;
 
+  @property({ reflect: true, type: Boolean })
+  disabled = false;
+
   @property({ attribute: 'menu-open', reflect: true, type: Boolean })
   menuOpen = false;
 
-  @property({ attribute: 'menu-placement', reflect: true })
+  @property({ attribute: 'menu-placement', reflect: true, useDefault: true })
   menuPlacement: 'bottom-end' | 'top-end' = 'bottom-end';
 
   @property({ type: Boolean })

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -57,7 +57,7 @@ export default class GlideCoreTag extends LitElement {
   @property({ reflect: true, type: Boolean })
   removable = false;
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   size: 'small' | 'medium' | 'large' = 'medium';
 
   @property({ reflect: true })

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -29,7 +29,7 @@ declare global {
  * @attr {number} [maxlength]
  * @attr {string} [name='']
  * @attr {'horizontal'|'vertical'} [orientation='horizontal']
- * @attr {string} [placeholder='']
+ * @attr {string} [placeholder]
  * @attr {boolean} [readonly=false]
  * @attr {boolean} [required=false]
  * @attr {boolean} [spellcheck=false]
@@ -84,31 +84,27 @@ export default class GlideCoreTextarea
 
   static override styles = styles;
 
-  // Intentionally not reflected to match native.
-  @property()
-  value = '';
-
   @property({ reflect: true })
   @required
   label?: string;
 
-  @property({ attribute: 'hide-label', reflect: true, type: Boolean })
-  hideLabel = false;
+  @property({ reflect: true, useDefault: true })
+  override autocapitalize:
+    | 'on'
+    | 'off'
+    | 'none'
+    | 'sentences'
+    | 'words'
+    | 'characters' = 'on';
 
-  @property({ reflect: true })
-  orientation: 'horizontal' | 'vertical' = 'horizontal';
-
-  @property({ reflect: true })
-  placeholder?: string = '';
-
-  @property({ reflect: true, type: Boolean })
-  required = false;
-
-  @property({ reflect: true, type: Boolean })
-  readonly = false;
+  @property({ reflect: true, useDefault: true })
+  autocomplete: 'on' | 'off' = 'on';
 
   @property({ reflect: true, type: Boolean })
   disabled = false;
+
+  @property({ attribute: 'hide-label', reflect: true, type: Boolean })
+  hideLabel = false;
 
   @property({
     type: Number,
@@ -119,31 +115,35 @@ export default class GlideCoreTextarea
   })
   maxlength?: number;
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   name = '';
 
-  // It's typed by TypeScript as a boolean. But we treat it as a string throughout.
-  @property({ reflect: true, type: Boolean })
-  override spellcheck = false;
+  @property({ reflect: true, useDefault: true })
+  orientation: 'horizontal' | 'vertical' = 'horizontal';
 
   @property({ reflect: true })
-  override autocapitalize:
-    | 'on'
-    | 'off'
-    | 'none'
-    | 'sentences'
-    | 'words'
-    | 'characters' = 'on';
-
-  @property({ reflect: true })
-  autocomplete: 'on' | 'off' = 'on';
+  placeholder?: string;
 
   // Private because it's only meant to be used by Form Controls Layout.
   @property()
   privateSplit?: 'left' | 'middle' | 'right';
 
+  // It's typed by TypeScript as a boolean. But we treat it as a string throughout.
+  @property({ reflect: true, type: Boolean, useDefault: true })
+  override spellcheck = false;
+
+  @property({ reflect: true, type: Boolean })
+  required = false;
+
+  @property({ reflect: true, type: Boolean })
+  readonly = false;
+
   @property({ reflect: true })
   tooltip?: string;
+
+  // Intentionally not reflected to match native.
+  @property()
+  value = '';
 
   @property({ reflect: true })
   readonly version: string = packageJson.version;

--- a/src/toggle.ts
+++ b/src/toggle.ts
@@ -42,6 +42,10 @@ export default class GlideCoreToggle extends LitElement {
 
   static override styles = styles;
 
+  @property({ reflect: true })
+  @required
+  label?: string;
+
   @property({ type: Boolean })
   checked = false;
 
@@ -51,11 +55,7 @@ export default class GlideCoreToggle extends LitElement {
   @property({ attribute: 'hide-label', type: Boolean })
   hideLabel = false;
 
-  @property({ reflect: true })
-  @required
-  label?: string;
-
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   orientation: 'horizontal' | 'vertical' = 'horizontal';
 
   // Private because it's only meant to be used by Form Controls Layout.

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -55,6 +55,27 @@ export default class GlideCoreTooltip extends LitElement {
   static override styles = styles;
 
   /**
+   * @default undefined
+   */
+  @property({ reflect: true })
+  @required
+  get label(): string | undefined {
+    return this.#label;
+  }
+
+  set label(label: string) {
+    this.#label = label;
+
+    const container = this.querySelector(
+      'glide-core-private-tooltip-container',
+    );
+
+    if (container) {
+      container.label = label;
+    }
+  }
+
+  /**
    * @default false
    */
   @property({ reflect: true, type: Boolean })
@@ -85,27 +106,6 @@ export default class GlideCoreTooltip extends LitElement {
       target.setAttribute('aria-describedby', container.id);
     } else if (container && target) {
       target.removeAttribute('aria-describedby');
-    }
-  }
-
-  /**
-   * @default undefined
-   */
-  @property({ reflect: true })
-  @required
-  get label(): string | undefined {
-    return this.#label;
-  }
-
-  set label(label: string) {
-    this.#label = label;
-
-    const container = this.querySelector(
-      'glide-core-private-tooltip-container',
-    );
-
-    if (container) {
-      container.label = label;
     }
   }
 


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

### Minor

All components now use Lit's new [`useDefault`](https://lit.dev/docs/components/properties/#property-options) option with `@property()` decorators. 

### Patch

- Modal Icon Button's `label` attribute is now reflected.
- Icon Button's `label` attribute is now reflected.
- Input's `clearable`, `hide-label`, `password-toggle`, and `readonly` attributes are now reflected.
- Textarea's `placeholder` attribute is now `undefined` by default instead of an empty string, matching our other components.
- All component attributes whose value is a primitive no longer reflect their values when they're at their default, matching native.


## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

You'll have to check out the branch to fully test this one because [many](https://github.com/CrowdStrike/glide-core/blob/main/src/button.stories.ts#L55) [of](https://github.com/CrowdStrike/glide-core/blob/main/src/checkbox-group.stories.ts#L42) [our](https://github.com/CrowdStrike/glide-core/blob/main/src/dropdown.stories.ts#L58) [stories](https://github.com/CrowdStrike/glide-core/blob/main/src/input.stories.ts#L44) set attributes to their default value so that the controls corresponding to those attributes are populated with the default. 

That's why, when you inspect the DOM, you'll see those attributes are reflected. To test them, you'll need to modify stories locally and set each or some controls' default value to an empty string.

If you only want to partially test this, you can look at simply look at attributes like `name`, whose default value is an empty string.



<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
