### PR TITLE
Disabled Dropdown, Input, and Textarea border color update

### DIFF
--- a/.changeset/five-teachers-juggle.md
+++ b/.changeset/five-teachers-juggle.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+The disabled border color for Dropdown, Input, and Textarea components was updated to match designs.

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -74,7 +74,9 @@ export default [
         background: var(
           --glide-core-color-interactive-surface-container--disabled
         );
-        border-color: var(--glide-core-color-static-stroke-secondary);
+        border-color: var(
+          --glide-core-color-interactive-surface-container--disabled
+        );
         color: var(--glide-core-color-interactive-text-default--disabled);
       }
 

--- a/src/input.styles.ts
+++ b/src/input.styles.ts
@@ -79,7 +79,7 @@ export default [
           --glide-core-color-interactive-surface-container--disabled
         );
         border-color: var(
-          --glide-core-color-interactive-stroke-primary--disabled
+          --glide-core-color-interactive-surface-container--disabled
         );
         color: var(--glide-core-color-interactive-text-default--disabled);
       }

--- a/src/textarea.styles.ts
+++ b/src/textarea.styles.ts
@@ -95,7 +95,7 @@ export default [
           --glide-core-color-interactive-surface-container--disabled
         );
         border: 0.0625rem solid
-          var(--glide-core-color-interactive-stroke-primary--disabled);
+          var(--glide-core-color-interactive-surface-container--disabled);
         color: var(--glide-core-color-interactive-text-default--disabled);
       }
     }


### PR DESCRIPTION
## 🚀 Description

Dropdown, Input, and Textarea disabled border color was updated to match designs.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

N/A
