### PR TITLE
Remove Tag's `color` attribute

### DIFF
--- a/.changeset/mean-beds-suffer.md
+++ b/.changeset/mean-beds-suffer.md
@@ -2,7 +2,6 @@
 '@crowdstrike/glide-core': patch
 ---
 
-- Tag now supports a `color` attribute whose value can be `"green"`, `"indigo"`, or `"red"`. Tag's `removable` attribute and "icon" slot are unsupported when its `color` attribute is used.
 - Tag now has a border.
 - Tag's removal button is now larger.
 - Tag's optional icon is now larger when `size="large"`.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -7378,11 +7378,11 @@
             },
             {
               "kind": "field",
-              "name": "color",
+              "name": "label",
               "type": {
-                "text": "'green' | 'indigo' | 'red' | undefined"
+                "text": "string | undefined"
               },
-              "attribute": "color",
+              "attribute": "label",
               "reflects": true
             },
             {
@@ -7393,15 +7393,6 @@
               },
               "default": "false",
               "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "label",
               "reflects": true
             },
             {
@@ -7469,11 +7460,12 @@
           ],
           "attributes": [
             {
-              "name": "color",
+              "name": "label",
               "type": {
-                "text": "'green' | 'indigo' | 'red' | undefined"
+                "text": "string | undefined"
               },
-              "fieldName": "color"
+              "fieldName": "label",
+              "required": true
             },
             {
               "name": "disabled",
@@ -7482,14 +7474,6 @@
               },
               "default": "false",
               "fieldName": "disabled"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "label",
-              "required": true
             },
             {
               "name": "private-editable",

--- a/src/figma/constants.ts
+++ b/src/figma/constants.ts
@@ -25,15 +25,6 @@ export const extendedVariables = [
   'Color/Template/Surface/container-detail',
   'Color/Tooltip/Surface/container',
   'Color/Tooltip/Text/shortcut',
-  'Tag/Stroke/freeTrial',
-  'Tag/Stroke/new',
-  'Tag/Stroke/updated',
-  'Tag/Surface/freeTrial',
-  'Tag/Surface/new',
-  'Tag/Surface/updated',
-  'Tag/Text/freeTrial',
-  'Tag/Text/new',
-  'Tag/Text/updated',
 ];
 
 export const figmaFileId = 'A4B1kaT5HVLqcijwK4GXzt';

--- a/src/styles/variables/color-dark.css
+++ b/src/styles/variables/color-dark.css
@@ -137,13 +137,4 @@
   --glide-core-private-color-template-surface-container-detail: #2c2c2c;
   --glide-core-private-color-tooltip-surface-container: #dcdcdc;
   --glide-core-private-color-tooltip-text-shortcut: #5b5b5b;
-  --glide-core-private-color-tag-surface-updated: #313153;
-  --glide-core-private-color-tag-surface-freetrial: #2a3d38;
-  --glide-core-private-color-tag-surface-new: #482d39;
-  --glide-core-private-color-tag-stroke-updated: #464685;
-  --glide-core-private-color-tag-stroke-freetrial: #467468;
-  --glide-core-private-color-tag-stroke-new: #8e4e6a;
-  --glide-core-private-color-tag-text-updated: #bab9f2;
-  --glide-core-private-color-tag-text-freetrial: #adcec5;
-  --glide-core-private-color-tag-text-new: #e1b3c7;
 }

--- a/src/styles/variables/color-light.css
+++ b/src/styles/variables/color-light.css
@@ -138,13 +138,4 @@
   --glide-core-private-color-template-surface-container-detail: #ffffffe5;
   --glide-core-private-color-tooltip-surface-container: #212121;
   --glide-core-private-color-tooltip-text-shortcut: #adadad;
-  --glide-core-private-color-tag-surface-updated: #f0effb;
-  --glide-core-private-color-tag-surface-freetrial: #ebf6f3;
-  --glide-core-private-color-tag-surface-new: #feebf3;
-  --glide-core-private-color-tag-stroke-updated: #b2b1ec;
-  --glide-core-private-color-tag-stroke-freetrial: #9cd1c3;
-  --glide-core-private-color-tag-stroke-new: #fdadd1;
-  --glide-core-private-color-tag-text-updated: #3d3c77;
-  --glide-core-private-color-tag-text-freetrial: #275b4e;
-  --glide-core-private-color-tag-text-new: #862450;
 }

--- a/src/tag.stories.ts
+++ b/src/tag.stories.ts
@@ -26,7 +26,6 @@ const meta: Meta = {
     return html`
       <glide-core-tag
         label=${arguments_.label || nothing}
-        color=${arguments_.color || nothing}
         size=${arguments_.size === 'medium' ? nothing : arguments_.size}
         ?disabled=${arguments_.disabled}
         ?removable=${arguments_.removable}
@@ -38,7 +37,6 @@ const meta: Meta = {
   args: {
     label: 'Label',
     'addEventListener(event, handler)': '',
-    color: '',
     disabled: false,
     removable: false,
     size: 'medium',
@@ -57,17 +55,6 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail: '(event: "remove", handler: (event: Event) => void): void',
-        },
-      },
-    },
-    color: {
-      control: { type: 'select' },
-      options: ['', 'green', 'indigo', 'red'],
-      table: {
-        type: {
-          summary: 'green | indigo | red',
-          detail:
-            '// `removable` and `slot="icon"` are unsupported when `color` is set',
         },
       },
     },
@@ -128,7 +115,6 @@ export const WithIcon: StoryObj = {
     return html`
       <glide-core-tag
         label=${arguments_.label || nothing}
-        color=${arguments_.color || nothing}
         size=${arguments_.size === 'medium' ? nothing : arguments_.size}
         ?disabled=${arguments_.disabled}
         ?removable=${arguments_.removable}

--- a/src/tag.styles.ts
+++ b/src/tag.styles.ts
@@ -73,33 +73,9 @@ export default [
       }
 
       &.disabled {
-        background: var(
-          --glide-core-color-static-surface-container-secondary
-        ) !important;
-        border-color: var(
-          --glide-core-color-interactive-stroke-primary
-        ) !important;
-        color: var(
-          --glide-core-color-interactive-icon-default--disabled
-        ) !important;
-      }
-
-      &.green {
-        background-color: var(--glide-core-private-color-tag-surface-freetrial);
-        border-color: var(--glide-core-private-color-tag-stroke-freetrial);
-        color: var(--glide-core-private-color-tag-text-freetrial);
-      }
-
-      &.indigo {
-        background-color: var(--glide-core-private-color-tag-surface-updated);
-        border-color: var(--glide-core-private-color-tag-stroke-updated);
-        color: var(--glide-core-private-color-tag-text-updated);
-      }
-
-      &.red {
-        background-color: var(--glide-core-private-color-tag-surface-new);
-        border-color: var(--glide-core-private-color-tag-stroke-new);
-        color: var(--glide-core-private-color-tag-text-new);
+        background: var(--glide-core-color-static-surface-container-secondary);
+        border-color: var(--glide-core-color-interactive-stroke-primary);
+        color: var(--glide-core-color-interactive-icon-default--disabled);
       }
 
       &.removed {

--- a/src/tag.test.visuals.ts
+++ b/src/tag.test.visuals.ts
@@ -7,100 +7,7 @@ for (const story of stories.Tag) {
   test.describe(story.id, () => {
     for (const theme of story.themes) {
       test.describe(theme, () => {
-        test.describe('color="green"', () => {
-          test('disabled=${true}', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-            await page
-              .locator('glide-core-tag')
-              .evaluate<void, GlideCoreTag>((element) => {
-                element.color = 'green';
-                element.disabled = true;
-              });
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-
-          test('disabled=${false}', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-            await page
-              .locator('glide-core-tag')
-              .evaluate<void, GlideCoreTag>((element) => {
-                element.color = 'green';
-              });
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-        });
-
-        test.describe('color="indigo"', () => {
-          test('disabled=${true}', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-            await page
-              .locator('glide-core-tag')
-              .evaluate<void, GlideCoreTag>((element) => {
-                element.color = 'indigo';
-                element.disabled = true;
-              });
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-
-          test('disabled=${false}', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-            await page
-              .locator('glide-core-tag')
-              .evaluate<void, GlideCoreTag>((element) => {
-                element.color = 'indigo';
-              });
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-        });
-
-        test.describe('color="red"', () => {
-          test('disabled=${true}', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-            await page
-              .locator('glide-core-tag')
-              .evaluate<void, GlideCoreTag>((element) => {
-                element.color = 'red';
-                element.disabled = true;
-              });
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-
-          test('disabled=${false}', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-            await page
-              .locator('glide-core-tag')
-              .evaluate<void, GlideCoreTag>((element) => {
-                element.color = 'red';
-              });
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-        });
-
-        test('disabled', async ({ page }, test) => {
+        test('disabled=${true}', async ({ page }, test) => {
           await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
           await page
@@ -108,6 +15,15 @@ for (const story of stories.Tag) {
             .evaluate<void, GlideCoreTag>((element) => {
               element.disabled = true;
             });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('disabled=${false}', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+          await page.locator('glide-core-tag').waitFor();
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -20,7 +20,6 @@ declare global {
 
 /**
  * @attr {string} label
- * @attr {'green'|'indigo'|'red'} [color]
  * @attr {boolean} [disabled=false]
  * @attr {boolean} [removable=false]
  * @attr {'small'|'medium'|'large'} [size='medium']
@@ -45,14 +44,11 @@ export default class GlideCoreTag extends LitElement {
   static override styles = styles;
 
   @property({ reflect: true })
-  color?: 'green' | 'indigo' | 'red';
+  @required
+  label?: string;
 
   @property({ reflect: true, type: Boolean })
   disabled = false;
-
-  @property({ reflect: true })
-  @required
-  label?: string;
 
   // Private because it's only meant to be used by Dropdown.
   @property({ attribute: 'private-editable', reflect: true, type: Boolean })
@@ -92,9 +88,6 @@ export default class GlideCoreTag extends LitElement {
           component: true,
           added: true,
           disabled: this.disabled,
-          green: this.color === 'green',
-          indigo: this.color === 'indigo',
-          red: this.color === 'red',
           [this.size]: true,
         })}
         data-test="component"
@@ -106,7 +99,6 @@ export default class GlideCoreTag extends LitElement {
           class=${classMap({
             'icon-slot': true,
             [this.size]: true,
-            hidden: Boolean(this.color),
           })}
           name="icon"
         >
@@ -141,7 +133,6 @@ export default class GlideCoreTag extends LitElement {
                 'removal-button': true,
                 [this.size]: true,
                 disabled: this.disabled,
-                hidden: Boolean(this.color),
               })}
               data-test="removal-button"
               type="button"


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Design requested that we remove the `color` attribute from Tag because they've found it to be application specific.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

Maybe spotcheck Storybook. But the visual test report should largely have us covered.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
