### PR TITLE
Dropdown filtering fixes

### DIFF
--- a/.changeset/dull-pens-clap.md
+++ b/.changeset/dull-pens-clap.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown now retains its filter query when Dropdown Options are added or removed from its default slot after initial render.

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -41,7 +41,7 @@ const meta: Meta = {
     'checkValidity()': '',
     disabled: false,
     filterable: false,
-    'filter(query, options)': '',
+    'filter(query)': '',
     'hide-label': false,
     multiple: false,
     name: '',
@@ -129,13 +129,13 @@ const meta: Meta = {
         },
       },
     },
-    'filter(query, options)': {
+    'filter(query)': {
       control: false,
       table: {
         type: {
           summary: 'method',
           detail: `
-async (query: string): Promise<GlideCoreDropdownOption[]> {
+async (query: string): Promise<GlideCoreDropdownOption[]> => {
   const options = [...this.querySelectorAll('glide-core-dropdown-option)];
 
   return options.filter(({ label }) => {
@@ -146,7 +146,7 @@ async (query: string): Promise<GlideCoreDropdownOption[]> {
 // When overriding this method, return the options you want visible. The rest will be hidden.
 //
 // If you fetch when filtering, this is the place to do it. Just make sure you've updated
-// Dropdown's default slot with the new set of options before you query-select and filter them.
+// Dropdown's default slot with the new set of options before you query for and filter them.
 `,
         },
       },

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -1496,3 +1496,57 @@ it('does not allow its "toggle" event to propagate', async () => {
 
   expect(spy.callCount).to.equal(0);
 });
+
+it('retains its filter query when `multiple` and its default slot changes', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" filterable multiple>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  host.focus();
+  await sendKeys({ type: 'one' });
+
+  const option = document.createElement('glide-core-dropdown-option');
+  option.label = 'Two';
+  host.append(option);
+
+  // Wait for `#onDefaultSlotChange()`.
+  await aTimeout(0);
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(input?.value).to.equal('one');
+});
+
+it('retains its filter query when not `multiple` and its default slot changes', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" filterable>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  host.focus();
+  await sendKeys({ type: 'one' });
+
+  const option = document.createElement('glide-core-dropdown-option');
+  option.label = 'Two';
+  host.append(option);
+
+  // Wait for `#onDefaultSlotChange()`.
+  await aTimeout(0);
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(input?.value).to.equal('one');
+});


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Dropdown now retains its filter query when Dropdown Options are added or removed from its default slot after initial render.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

This is a tough one to manually test because, by design, Dropdown clears the user's filter query when Dropdown loses focus. If you want to check out the branch, I can tell you how to rig Dropdown up to test this. Otherwise, maybe just take a close look at the tests, which should have us covered.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
