### PR TITLE
Fix for Tab Group's story selected attribute updating

### DIFF
--- a/src/tab.group.stories.ts
+++ b/src/tab.group.stories.ts
@@ -72,7 +72,8 @@ const meta: Meta = {
           addons.getChannel().emit(UPDATE_STORY_ARGS, {
             storyId: context.id,
             updatedArgs: {
-              [`<glide-core-tab>.${event.target.panel}.selected`]: true,
+              '<glide-core-tab>.1.selected': event.target.panel === '1',
+              '<glide-core-tab>.2.selected': event.target.panel === '2',
             },
           });
         }


### PR DESCRIPTION
## 🚀 Description

@danwenzel was demoing something earlier and I noticed the tab `selected` state in Storybook wasn't updating properly. This fixes that issue. Borrowed from Button Group.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

- Go to Tab's storybook
- Click the second tab
- Verify `selected` is removed from the first, added to the second tab
- Click the first tab
- Verify `selected` is removed from the second, added to the first
