### PR TITLE
Skip Storybook deploy in merge queue

### DIFF
--- a/.github/workflows/on-pull-request-opened-and-synchronize.yml
+++ b/.github/workflows/on-pull-request-opened-and-synchronize.yml
@@ -7,7 +7,7 @@ on:
     types: [checks_requested]
 
 concurrency:
-  group: ${{ github.event.pull_request.head.ref || github.ref }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -189,12 +189,12 @@ jobs:
           path: blob-report
 
   deploy-visual-test-report:
+    name: Deploy Test Report
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-    name: Deploy Test Report
     if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
     needs:
       - test-visuals
     steps:
@@ -208,7 +208,7 @@ jobs:
           pattern: visual-test-report-blob-*
       - name: Merge blob reports
         run: |
-          PLAYWRIGHT_HTML_ATTACHMENTS_BASE_URL=https://${{ vars.CLOUDFLARE_CUSTOM_DOMAIN }}/${{ github.event.pull_request.head.ref }}/visual-test-report/data/ pnpm exec playwright merge-reports --reporter html ./visual-test-report-blob
+          PLAYWRIGHT_HTML_ATTACHMENTS_BASE_URL=https://${{ vars.CLOUDFLARE_CUSTOM_DOMAIN }}/${{ github.head_ref  }}/visual-test-report/data/ pnpm exec playwright merge-reports --reporter html ./visual-test-report-blob
       # TODO: Remove after this is resolved: https://www.cloudflarestatus.com/incidents/t5nrjmpxc1cj
       - name: Install AWS CLI
         run: |
@@ -227,13 +227,13 @@ jobs:
           aws configure set aws_access_key_id $CLOUDFLARE_R2_ACCESS_KEY_ID
           aws configure set aws_secret_access_key $CLOUDFLARE_R2_SECRET_ACCESS_KEY
       - name: Deploy HTML report
-        run: aws s3 sync ./playwright-report s3://${{ vars.CLOUDFLARE_R2_BUCKET_NAME }}/${{ github.event.pull_request.head.ref }}/visual-test-report --endpoint-url ${{ vars.CLOUDFLARE_R2_ENDPOINT }}
+        run: aws s3 sync ./playwright-report s3://${{ vars.CLOUDFLARE_R2_BUCKET_NAME }}/${{ github.head_ref }}/visual-test-report --endpoint-url ${{ vars.CLOUDFLARE_R2_ENDPOINT }}
       - uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728
         with:
           header: visual-test-report
           message: |+
             ## ${{ needs.test-visuals.outputs.failed && '⚠️' || '✅' }} Visual Test Report
-            https://${{ vars.CLOUDFLARE_CUSTOM_DOMAIN }}/${{ github.event.pull_request.head.ref }}/visual-test-report
+            https://${{ vars.CLOUDFLARE_CUSTOM_DOMAIN }}/${{ github.head_ref }}/visual-test-report
 
   build:
     name: Build
@@ -245,7 +245,7 @@ jobs:
       - uses: ./.github/actions/pnpm
       - run: pnpm start
         env:
-          BASE_URL: ${{ github.event.pull_request.head.ref }}
+          BASE_URL: ${{ github.head_ref }}
           NODE_ENV: production
       - name: Upload Storybook
         uses: actions/upload-artifact@v4
@@ -258,9 +258,18 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    # Ubuntu instead of MacOS because the performance difference is
-    # negligible and Ubuntu includes the AWS CLI.
+
+    # Ubuntu instead of MacOS because the performance difference is negligible and
+    # Ubuntu includes the AWS CLI.
     runs-on: ubuntu-latest
+
+    # Both `github.head_ref` and `github.event.pull_request.head.ref` are empty when
+    # a workflow is run in a merge queue. Take a look at the Deploy Storybook task
+    # below. Because those variables will be empty, letting that task run in a merge
+    # queue means the branch will be deployed to the root of R2 and thus to production.
+    # The point of this job is the Deploy Storybook task. So we just skip the entire job.
+    if: github.event_name != 'merge_group'
+
     needs:
       - build
     steps:
@@ -287,10 +296,10 @@ jobs:
           name: storybook
           path: storybook
       - name: Deploy Storybook
-        run: aws s3 sync ./storybook s3://${{ vars.CLOUDFLARE_R2_BUCKET_NAME }}/${{ github.event.pull_request.head.ref }} --endpoint-url ${{ vars.CLOUDFLARE_R2_ENDPOINT }}
+        run: aws s3 sync ./storybook s3://${{ vars.CLOUDFLARE_R2_BUCKET_NAME }}/${{ github.head_ref  }} --endpoint-url ${{ vars.CLOUDFLARE_R2_ENDPOINT }}
       - uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728
         with:
           header: storybook
           message: |+
             ## Storybook
-            https://${{ vars.CLOUDFLARE_CUSTOM_DOMAIN }}/${{ github.event.pull_request.head.ref }}
+            https://${{ vars.CLOUDFLARE_CUSTOM_DOMAIN }}/${{ github.head_ref  }}

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -1121,7 +1121,7 @@ export default class GlideCoreDropdown
     // Unfortunately, the host is the only thing on which this event is dispatched
     // because it's the host that is form-associated.
     this.addEventListener('invalid', (event) => {
-      event?.preventDefault(); // Canceled so a native validation message isn't shown.
+      event.preventDefault(); // Canceled so a native validation message isn't shown.
 
       // We only want to focus the input if the invalid event resulted from either:
       // 1. Form submission


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

I reverted most of https://github.com/CrowdStrike/glide-core/pull/857. It turns out that both `github.event.pull_request.head.ref ` and `github.head_ref ` are empty when a workflow is run in a merge queue. 

Our Deploy Storybook job is really the only thing that can't run in a merge queue. So I've [guarded](https://github.com/CrowdStrike/glide-core/pull/860/files#diff-370651b45a4dc2321f4d0bc2da9ce9aa59e03af7a7f441bd02415dd66c4c3a6fR271) against that job running via a `github.event_name != 'merge_group'` check.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

N/A

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
