### PR TITLE
Rename `url` to `href`

### DIFF
--- a/.changeset/short-steaks-float.md
+++ b/.changeset/short-steaks-float.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Menu Link and Split Button Primary Link's `url` attribute has been renamed to `href` to match both Link and native.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -4832,11 +4832,11 @@
             },
             {
               "kind": "field",
-              "name": "url",
+              "name": "href",
               "type": {
                 "text": "string | undefined"
               },
-              "attribute": "url",
+              "attribute": "href",
               "reflects": true
             },
             {
@@ -4921,11 +4921,11 @@
               "fieldName": "disabled"
             },
             {
-              "name": "url",
+              "name": "href",
               "type": {
                 "text": "string | undefined"
               },
-              "fieldName": "url"
+              "fieldName": "href"
             },
             {
               "name": "id",
@@ -6833,6 +6833,15 @@
             },
             {
               "kind": "field",
+              "name": "href",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "href",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "privateSize",
               "type": {
                 "text": "'large' | 'small'"
@@ -6848,15 +6857,6 @@
               },
               "default": "'primary'",
               "attribute": "privateVariant"
-            },
-            {
-              "kind": "field",
-              "name": "url",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "url",
-              "reflects": true
             },
             {
               "kind": "field",
@@ -6887,6 +6887,13 @@
               "fieldName": "disabled"
             },
             {
+              "name": "href",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "href"
+            },
+            {
               "name": "privateSize",
               "type": {
                 "text": "'large' | 'small'"
@@ -6901,13 +6908,6 @@
               },
               "default": "'primary'",
               "fieldName": "privateVariant"
-            },
-            {
-              "name": "url",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "url"
             },
             {
               "name": "version",

--- a/src/link.stories.ts
+++ b/src/link.stories.ts
@@ -51,9 +51,9 @@ const meta: Meta = {
     /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
     return html`
       <glide-core-link
+        label=${arguments_.label || nothing}
         download=${arguments_.download || nothing}
         href=${arguments_.href || nothing}
-        label=${arguments_.label || nothing}
         target=${arguments_.target || nothing}
         ?disabled=${arguments_.disabled || nothing}
       ></glide-core-link>

--- a/src/menu.link.ts
+++ b/src/menu.link.ts
@@ -19,6 +19,7 @@ declare global {
 /**
  * @attr {string} label
  * @attr {boolean} [disabled=false]
+ * @attr {string} [href]
  *
  * @readonly
  * @attr {string} [id]
@@ -28,8 +29,6 @@ declare global {
  *
  * @readonly
  * @attr {number} [tabindex=-1]
- *
- * @attr {string} [url]
  *
  * @readonly
  * @attr {string} [version]
@@ -67,7 +66,7 @@ export default class GlideCoreMenuLink extends LitElement {
   }
 
   @property({ reflect: true })
-  url?: string;
+  href?: string;
 
   // On the host instead of inside the shadow DOM so screenreaders can find it when
   // Menu uses it with `aria-activedescendant`.
@@ -111,7 +110,7 @@ export default class GlideCoreMenuLink extends LitElement {
         disabled: this.disabled,
       })}
       data-test="component"
-      href=${ifDefined(this.url)}
+      href=${ifDefined(this.href)}
       @click=${this.#onClick}
       ${ref(this.#componentElementRef)}
     >

--- a/src/menu.stories.ts
+++ b/src/menu.stories.ts
@@ -56,7 +56,7 @@ const meta: Meta = {
     '<glide-core-menu-button>.version': '',
     '<glide-core-menu-link>.label': 'Three',
     '<glide-core-menu-link>.disabled': false,
-    '<glide-core-menu-link>.url': '/',
+    '<glide-core-menu-link>.href': '/',
     '<glide-core-menu-link>.version': '',
   },
   argTypes: {
@@ -204,8 +204,8 @@ const meta: Meta = {
         type: { summary: 'boolean' },
       },
     },
-    '<glide-core-menu-link>.url': {
-      name: 'url',
+    '<glide-core-menu-link>.href': {
+      name: 'href',
       table: {
         category: 'Menu Link',
         type: { summary: 'string' },
@@ -240,11 +240,13 @@ const meta: Meta = {
     context.canvasElement
       .querySelector('glide-core-menu')
       ?.addEventListener('click', (event: Event) => {
-        const link =
+        const menuLink =
           event.target instanceof Element &&
           event.target.closest('glide-core-menu-link');
 
-        if (link && link.url === '/' && window.top) {
+        // If the URL is anything but `/`, then the user has changed the URL and wants
+        // to navigate to it.
+        if (menuLink && menuLink.href === '/' && window.top) {
           event.preventDefault();
 
           // The Storybook user expects to navigate when the link is clicked but
@@ -274,7 +276,7 @@ const meta: Meta = {
         <glide-core-menu-button label="Two"></glide-core-menu-button>
         <glide-core-menu-link
           label=${arguments_['<glide-core-menu-link>.label']}
-          url=${arguments_['<glide-core-menu-link>.url']}
+          href=${arguments_['<glide-core-menu-link>.href']}
           ?disabled=${arguments_['<glide-core-menu-link>.disabled']}
         ></glide-core-menu-link>
       </glide-core-menu-options>
@@ -320,7 +322,7 @@ export const WithIcons: StoryObj = {
 
         <glide-core-menu-link
           label="Share"
-          url="/"
+          href="/"
           ?disabled=${arguments_['<glide-core-menu-link>.disabled']}
         >
           <glide-core-example-icon

--- a/src/menu.test.basics.ts
+++ b/src/menu.test.basics.ts
@@ -22,7 +22,7 @@ it('is accessible', async () => {
 
       <glide-core-menu-options>
         <glide-core-menu-button label="Label"></glide-core-menu-button>
-        <glide-core-menu-link label="Label" url="/"></glide-core-menu-link>
+        <glide-core-menu-link label="Label" href="/"></glide-core-menu-link>
       </glide-core-menu-options>
     </glide-core-menu>`,
   );

--- a/src/split-button.primary-link.test.basics.ts
+++ b/src/split-button.primary-link.test.basics.ts
@@ -16,7 +16,7 @@ it('is accessible', async () => {
   const host = await fixture<GlideCoreSplitButtonPrimaryLink>(html`
     <glide-core-split-button-primary-link
       label="Label"
-      url="/"
+      href="/"
     ></glide-core-split-button-primary-link>
   `);
 

--- a/src/split-button.primary-link.test.focus.ts
+++ b/src/split-button.primary-link.test.focus.ts
@@ -5,7 +5,7 @@ it('focuses itself when `focus()` is called', async () => {
   const host = await fixture<GlideCoreSplitButtonPrimaryLink>(html`
     <glide-core-split-button-primary-link
       label="Label"
-      url="/"
+      href="/"
     ></glide-core-split-button-primary-link>
   `);
 

--- a/src/split-button.primary-link.ts
+++ b/src/split-button.primary-link.ts
@@ -17,7 +17,7 @@ declare global {
 /**
  * @attr {string} label
  * @attr {boolean} [disabled=false]
- * @attr {string} [url]
+ * @attr {string} [href]
  *
  * @readonly
  * @attr {string} [version]
@@ -42,14 +42,14 @@ export default class GlideCoreSplitButtonPrimaryLink extends LitElement {
   @property({ reflect: true, type: Boolean })
   disabled = false;
 
+  @property({ reflect: true })
+  href?: string;
+
   @property()
   privateSize: 'large' | 'small' = 'large';
 
   @property()
   privateVariant: 'primary' | 'secondary' = 'primary';
-
-  @property({ reflect: true })
-  url?: string;
 
   @property({ reflect: true })
   readonly version: string = packageJson.version;
@@ -84,7 +84,7 @@ export default class GlideCoreSplitButtonPrimaryLink extends LitElement {
         [this.privateSize]: true,
       })}
       data-test="component"
-      href=${ifDefined(this.url)}
+      href=${ifDefined(this.href)}
     >
       <slot name="icon">
         <!-- @type {Element} -->

--- a/src/split-button.stories.ts
+++ b/src/split-button.stories.ts
@@ -3,12 +3,12 @@ import './menu.button.js';
 import './menu.link.js';
 import './split-button.js';
 import './split-button.primary-button.js';
-import './split-button.primary-link.js';
 import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/web-components';
+import GlideCoreSplitButtonPrimaryLink from './split-button.primary-link.js';
 import GlideCoreSplitButtonSecondaryButton from './split-button.secondary-button.js';
 
 const meta: Meta = {
@@ -49,11 +49,33 @@ const meta: Meta = {
     context.canvasElement
       .querySelector('glide-core-split-button')
       ?.addEventListener('click', (event: Event) => {
-        const isMenuLink =
+        const menuLink =
           event.target instanceof Element &&
           event.target.closest('glide-core-menu-link');
 
-        if (isMenuLink && window.top) {
+        // If the URL is anything but `/`, then the user has changed the URL and wants
+        // to navigate to it.
+        if (menuLink && menuLink.href === '/' && window.top) {
+          event.preventDefault();
+
+          // The Storybook user expects to navigate when the link is clicked but
+          // doesn't expect to be redirected to the first story. So we refresh the
+          // page to give the impression of a navigation while keeping the user
+          // on the same page.
+          window.top.location.reload();
+        }
+      });
+
+    context.canvasElement
+      .querySelector('glide-core-split-button-primary-link')
+      ?.addEventListener('click', (event: Event) => {
+        // If the URL is anything but `/`, then the user has changed the URL and wants
+        // to navigate to it.
+        if (
+          event.target instanceof GlideCoreSplitButtonPrimaryLink &&
+          event.target.href === '/' &&
+          window.top
+        ) {
           event.preventDefault();
 
           // The Storybook user expects to navigate when the link is clicked but
@@ -117,7 +139,7 @@ const meta: Meta = {
         >
           <glide-core-menu-button label="One"></glide-core-menu-button>
           <glide-core-menu-button label="Two"></glide-core-menu-button>
-          <glide-core-menu-link label="Three" url="/"></glide-core-menu-link>
+          <glide-core-menu-link label="Three" href="/"></glide-core-menu-link>
         </glide-core-split-button-secondary-button>
       </glide-core-split-button>
     `;
@@ -136,8 +158,8 @@ const meta: Meta = {
     '<glide-core-split-button-primary-button>.version': '',
     '<glide-core-split-button-primary-link>.label': 'Label',
     '<glide-core-split-button-primary-link>.disabled': false,
+    '<glide-core-split-button-primary-link>.href': '/',
     '<glide-core-split-button-primary-link>[slot="icon"]': '',
-    '<glide-core-split-button-primary-link>.url': '/',
     '<glide-core-split-button-primary-link>.version': '',
     '<glide-core-split-button-secondary-button>.label': 'Label',
     '<glide-core-split-button-secondary-button>[slot="default"]': '',
@@ -257,20 +279,20 @@ const meta: Meta = {
         type: { summary: 'boolean' },
       },
     },
+    '<glide-core-split-button-primary-link>.href': {
+      name: 'href',
+      type: { name: 'string' },
+      table: {
+        category: 'Split Button Primary Link',
+        type: { summary: 'string' },
+      },
+    },
     '<glide-core-split-button-primary-link>[slot="icon"]': {
       name: 'slot="icon"',
       control: false,
       table: {
         category: 'Split Button Primary Link',
         type: { summary: 'Element' },
-      },
-    },
-    '<glide-core-split-button-primary-link>.url': {
-      name: 'url',
-      type: { name: 'string', required: true },
-      table: {
-        category: 'Split Button Primary Link',
-        type: { summary: 'string' },
       },
     },
     '<glide-core-split-button-primary-link>.version': {
@@ -398,7 +420,7 @@ export const WithIcon: StoryObj = {
         >
           <glide-core-menu-button label="One"></glide-core-menu-button>
           <glide-core-menu-button label="Two"></glide-core-menu-button>
-          <glide-core-menu-link label="Three" url="/"></glide-core-menu-link>
+          <glide-core-menu-link label="Three" href="/"></glide-core-menu-link>
         </glide-core-split-button-secondary-button>
       </glide-core-split-button>
     `;
@@ -416,7 +438,7 @@ export const WithPrimaryLink: StoryObj = {
       >
         <glide-core-split-button-primary-link
           label=${arguments_['<glide-core-split-button-primary-link>.label']}
-          url=${arguments_['<glide-core-split-button-primary-link>.url']}
+          href=${arguments_['<glide-core-split-button-primary-link>.href']}
           ?disabled=${arguments_[
             '<glide-core-split-button-primary-link>.disabled'
           ]}
@@ -444,7 +466,7 @@ export const WithPrimaryLink: StoryObj = {
         >
           <glide-core-menu-button label="One"></glide-core-menu-button>
           <glide-core-menu-button label="Two"></glide-core-menu-button>
-          <glide-core-menu-link label="Three" url="/"></glide-core-menu-link>
+          <glide-core-menu-link label="Three" href="/"></glide-core-menu-link>
         </glide-core-split-button-secondary-button>
       </glide-core-split-button>
     `;

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -275,13 +275,13 @@ export default class GlideCoreTooltip extends LitElement {
           <slot
             class="target-slot"
             data-test="target-slot"
+            name="target"
             @focusin=${this.#onTargetSlotFocusin}
             @focusout=${this.#onTargetSlotFocusout}
             @keydown=${this.#onTargetSlotKeydown}
             @slotchange=${this.#onTargetSlotChange}
             ${assertSlot()}
             ${ref(this.#targetSlotElementRef)}
-            name="target"
           >
             <!--
               The element to which the tooltip will anchor.


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

### Minor

> Menu Link and Split Button Primary Link's `url` attribute has been renamed to `href` to match both Link and native.


## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

We're good if the build and tests pass.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
