### PR TITLE
Add Menu `loading` attribute

### DIFF
--- a/.changeset/eleven-brooms-matter.md
+++ b/.changeset/eleven-brooms-matter.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Button and Icon Button now support an `aria-description` attribute.

--- a/.changeset/mighty-crabs-speak.md
+++ b/.changeset/mighty-crabs-speak.md
@@ -2,4 +2,4 @@
 '@crowdstrike/glide-core': patch
 ---
 
-Dropdown now has a `loading` attribute that shows a skeleton with a fixed number of rows. Add the attribute whenever you asynchronously update Dropdown's default slot. Remove it after the slot has been updated.
+Dropdown and Menu now have a `loading` attribute that shows a skeleton with a fixed number of rows. Add the attribute whenever you asynchronously update Dropdown's default slot. Remove it after the slot has been updated.

--- a/.changeset/sweet-seals-smash.md
+++ b/.changeset/sweet-seals-smash.md
@@ -2,4 +2,4 @@
 '@crowdstrike/glide-core': minor
 ---
 
-Dropdown Option, Menu Button, and Menu Link's `id` attribute has always been set internally by these components for accessibility. It's now marked as read-only to reflect that it shouldn't be changed. We've also marked `role` and `tabindex` as read-only for the same reason.
+Dropdown Option, Menu Options, Menu Button, and Menu Link's `id` attribute has always been set internally by these components for accessibility. It's now marked as read-only to reflect that it shouldn't be changed. We've also marked `role` and `tabindex` as read-only for the same reason.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -643,6 +643,16 @@
             },
             {
               "kind": "field",
+              "name": "ariaDescription",
+              "type": {
+                "text": "string | null"
+              },
+              "default": "null",
+              "attribute": "aria-description",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "disabled",
               "type": {
                 "text": "boolean"
@@ -741,6 +751,14 @@
               },
               "fieldName": "label",
               "required": true
+            },
+            {
+              "name": "aria-description",
+              "type": {
+                "text": "string | null"
+              },
+              "default": "null",
+              "fieldName": "ariaDescription"
             },
             {
               "name": "disabled",
@@ -3302,6 +3320,16 @@
             },
             {
               "kind": "field",
+              "name": "ariaDescription",
+              "type": {
+                "text": "string | null"
+              },
+              "default": "null",
+              "attribute": "aria-description",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "ariaExpanded",
               "type": {
                 "text": "'true' | 'false' | null"
@@ -3372,6 +3400,14 @@
               },
               "default": "null",
               "fieldName": "ariaControls"
+            },
+            {
+              "name": "aria-description",
+              "type": {
+                "text": "string | null"
+              },
+              "default": "null",
+              "fieldName": "ariaDescription"
             },
             {
               "name": "aria-expanded",
@@ -5048,12 +5084,53 @@
             },
             {
               "kind": "field",
+              "name": "id",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "id",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "privateLoading",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "privateLoading"
+            },
+            {
+              "kind": "field",
               "name": "privateSize",
               "type": {
                 "text": "'large' | 'small'"
               },
               "default": "'large'",
               "attribute": "privateSize"
+            },
+            {
+              "kind": "field",
+              "name": "role",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "default": "'menu'",
+              "attribute": "role",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "tabIndex",
+              "type": {
+                "text": "number"
+              },
+              "readonly": true,
+              "default": "-1",
+              "attribute": "tabindex",
+              "reflects": true
             },
             {
               "kind": "field",
@@ -5092,12 +5169,46 @@
               "fieldName": "ariaLabelledby"
             },
             {
+              "name": "id",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "fieldName": "id"
+            },
+            {
+              "name": "privateLoading",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "privateLoading"
+            },
+            {
               "name": "privateSize",
               "type": {
                 "text": "'large' | 'small'"
               },
               "default": "'large'",
               "fieldName": "privateSize"
+            },
+            {
+              "name": "role",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "default": "'menu'",
+              "fieldName": "role"
+            },
+            {
+              "name": "tabindex",
+              "type": {
+                "text": "number"
+              },
+              "readonly": true,
+              "default": "-1",
+              "fieldName": "tabIndex"
             },
             {
               "name": "version",
@@ -5213,6 +5324,16 @@
             },
             {
               "kind": "field",
+              "name": "loading",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "loading",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "offset",
               "type": {
                 "text": "number"
@@ -5271,6 +5392,14 @@
             }
           ],
           "attributes": [
+            {
+              "name": "loading",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "loading"
+            },
             {
               "name": "offset",
               "type": {

--- a/src/aria-snapshots/menu-test-aria-ts-glide-core-menu-button-disabled.yml
+++ b/src/aria-snapshots/menu-test-aria-ts-glide-core-menu-button-disabled.yml
@@ -1,5 +1,5 @@
-- button "Target"
-- menu "Target":
+- button "Toggle"
+- menu "Toggle":
   - menuitem "One":
     - button "One" [disabled]
   - menuitem "Two":

--- a/src/aria-snapshots/menu-test-aria-ts-glide-core-menu-link-disabled.yml
+++ b/src/aria-snapshots/menu-test-aria-ts-glide-core-menu-link-disabled.yml
@@ -1,5 +1,5 @@
-- button "Target"
-- menu "Target":
+- button "Toggle"
+- menu "Toggle":
   - menuitem "One":
     - button "One"
   - menuitem "Two":

--- a/src/aria-snapshots/menu-test-aria-ts-loading.yml
+++ b/src/aria-snapshots/menu-test-aria-ts-loading.yml
@@ -1,0 +1,2 @@
+- button "Toggle"
+- menu "Toggle"

--- a/src/aria-snapshots/menu-test-aria-ts-open-false-.yml
+++ b/src/aria-snapshots/menu-test-aria-ts-open-false-.yml
@@ -1,1 +1,1 @@
-- button "Target"
+- button "Toggle"

--- a/src/aria-snapshots/menu-test-aria-ts-open-true-.yml
+++ b/src/aria-snapshots/menu-test-aria-ts-open-true-.yml
@@ -1,5 +1,5 @@
-- button "Target"
-- menu "Target":
+- button "Toggle"
+- menu "Toggle":
   - menuitem "One":
     - button "One"
   - menuitem "Two":

--- a/src/button.test.basics.ts
+++ b/src/button.test.basics.ts
@@ -14,8 +14,14 @@ it('registers itself', async () => {
 
 it('is accessible', async () => {
   const host = await fixture(
-    html`<glide-core-button label="Label"></glide-core-button>`,
+    html`<glide-core-button
+      aria-description="Description"
+      label="Label"
+    ></glide-core-button>`,
   );
+
+  const button = host.shadowRoot?.querySelector('[data-test="button"]');
+  expect(button?.ariaDescription).to.equal('Description');
 
   await expect(host).to.be.accessible();
 });

--- a/src/button.test.interactions.ts
+++ b/src/button.test.interactions.ts
@@ -1,0 +1,14 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import GlideCoreButton from './button.js';
+
+it('is accessible', async () => {
+  const host = await fixture<GlideCoreButton>(
+    html`<glide-core-button label="Label"></glide-core-button>`,
+  );
+
+  host.ariaDescription = 'Description';
+  await host.updateComplete;
+
+  const button = host.shadowRoot?.querySelector('[data-test="button"]');
+  expect(button?.ariaDescription).to.equal('Description');
+});

--- a/src/button.ts
+++ b/src/button.ts
@@ -17,6 +17,7 @@ declare global {
 
 /**
  * @attr {string} label
+ * @attr {string|null} [aria-description=null]
  * @attr {boolean} [disabled=false]
  * @attr {string} [name='']
  * @attr {'large'|'small'} [size='large']
@@ -51,6 +52,25 @@ export default class GlideCoreButton extends LitElement {
   @required
   label?: string;
 
+  // A getter and setter because Lit Analzyer doesn't recognize "aria-description"
+  // as a valid attribute on the `<button>` and doesn't provide a way to selectively
+  // disable rules.
+  /**
+   * @default null
+   */
+  @property({ attribute: 'aria-description', reflect: true })
+  override get ariaDescription(): string | null {
+    return this.#ariaDescription;
+  }
+
+  override set ariaDescription(description: string | null) {
+    this.#ariaDescription = description;
+
+    if (this.#buttonElementRef.value) {
+      this.#buttonElementRef.value.ariaDescription = description;
+    }
+  }
+
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
@@ -83,6 +103,12 @@ export default class GlideCoreButton extends LitElement {
     this.#buttonElementRef.value?.click();
   }
 
+  override firstUpdated() {
+    if (this.#buttonElementRef.value && this.ariaDescription) {
+      this.#buttonElementRef.value.ariaDescription = this.ariaDescription;
+    }
+  }
+
   override render() {
     return html`<glide-core-tooltip
       label=${this.tooltip ?? ''}
@@ -101,6 +127,7 @@ export default class GlideCoreButton extends LitElement {
           'prefix-icon': this.hasPrefixIcon,
           'suffix-icon': this.hasSuffixIcon,
         })}
+        data-test="button"
         slot="target"
         @click=${this.#onClick}
         ${ref(this.#buttonElementRef)}
@@ -142,6 +169,8 @@ export default class GlideCoreButton extends LitElement {
 
   @state()
   private hasSuffixIcon = false;
+
+  #ariaDescription: string | null = null;
 
   #buttonElementRef = createRef<HTMLButtonElement>();
 

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -8,7 +8,7 @@ export default [
   css`
     ${focusOutline('.add-button:focus-visible')}
     ${opacityAndScaleAnimation('.options-and-footer:popover-open')}
-    ${skeleton('.loading')}
+    ${skeleton('.loading-feedback')}
     ${visuallyHidden('.item-count')}
     ${visuallyHidden('.selected-option-labels')}
   `,

--- a/src/dropdown.test.basics.ts
+++ b/src/dropdown.test.basics.ts
@@ -44,7 +44,7 @@ it('can be open', async () => {
   expect(options?.checkVisibility()).to.be.true;
 });
 
-it('can be loading', async () => {
+it('shows loading feedback', async () => {
   const host = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" loading open>
       <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
@@ -54,8 +54,11 @@ it('can be loading', async () => {
   // Wait for Floating UI.
   await aTimeout(0);
 
-  const loading = host.shadowRoot?.querySelector('[data-test="loading"]');
-  expect(loading?.checkVisibility()).to.be.true;
+  const feedback = host.shadowRoot?.querySelector(
+    '[data-test="loading-feedback"]',
+  );
+
+  expect(feedback?.checkVisibility()).to.be.true;
 });
 
 it('selects options when `value` is set initially', async () => {

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -783,7 +783,7 @@ export default class GlideCoreDropdown
                   aria-controls="options"
                   aria-describedby="description"
                   aria-expanded=${this.open && !this.disabled}
-                  aria-labelledby="selected-option-labels label loading ${this
+                  aria-labelledby="selected-option-labels label loading-feedback ${this
                     .isCommunicateItemCountToScreenreaders
                     ? 'item-count'
                     : ''}"
@@ -924,7 +924,7 @@ export default class GlideCoreDropdown
                 aria-expanded=${this.open && !this.disabled}
                 aria-haspopup="listbox"
                 aria-hidden=${this.filterable || this.isFilterable}
-                aria-labelledby="selected-option-labels label loading"
+                aria-labelledby="selected-option-labels label loading-feedback"
                 class="primary-button"
                 data-test="primary-button"
                 id="primary-button"
@@ -1009,11 +1009,11 @@ export default class GlideCoreDropdown
             ${when(this.loading, () => {
               return html`<div
                 aria-label=${this.#localize.term('loading')}
-                class="loading"
-                data-test="loading"
-                id="loading"
+                class="loading-feedback"
+                data-test="loading-feedback"
+                id="loading-feedback"
               >
-                ${map(range(7), () => html`<div class="bone"></div>`)}
+                ${map(range(7), () => html`<div></div>`)}
               </div>`;
             })}
             ${when(this.isNoResults && !this.loading, () => {

--- a/src/icon-button.test.basics.ts
+++ b/src/icon-button.test.basics.ts
@@ -15,10 +15,13 @@ it('registers itself', async () => {
 
 it('is accessible', async () => {
   const host = await fixture<GlideCoreIconButton>(
-    html`<glide-core-icon-button label="Label">
+    html`<glide-core-icon-button aria-description="Description" label="Label">
       <div>Icon</div>
     </glide-core-icon-button>`,
   );
+
+  const button = host.shadowRoot?.querySelector('[data-test="button"]');
+  expect(button?.ariaDescription).to.equal('Description');
 
   await expect(host).to.be.accessible();
 });

--- a/src/icon-button.test.events.ts
+++ b/src/icon-button.test.events.ts
@@ -1,0 +1,134 @@
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
+import GlideCoreIconButton from './icon-button.js';
+import { click } from './library/mouse.js';
+
+it('dispatches a "click" event on click', async () => {
+  const host = await fixture<GlideCoreIconButton>(
+    html`<glide-core-icon-button label="Label">
+      <div>Icon</div>
+    </glide-core-icon-button>`,
+  );
+
+  click(host);
+  const event = await oneEvent(host, 'click');
+
+  expect(event instanceof PointerEvent).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
+});
+
+it('does not dispatch a "click" event on click when disabled', async () => {
+  const host = await fixture<GlideCoreIconButton>(html`
+    <glide-core-icon-button label="Label" disabled>
+      <div>Icon</div>
+    </glide-core-icon-button>
+  `);
+
+  const spy = sinon.spy();
+  host.addEventListener('click', spy);
+
+  await click(host);
+
+  expect(spy.callCount).to.equal(0);
+});
+
+it('dispatches a "click" event on `click()`', async () => {
+  const host = await fixture<GlideCoreIconButton>(
+    html`<glide-core-icon-button label="Label">
+      <div>Icon</div>
+    </glide-core-icon-button>`,
+  );
+
+  setTimeout(() => {
+    host.click();
+  });
+
+  const event = await oneEvent(host, 'click');
+
+  expect(event instanceof PointerEvent).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
+});
+
+it('does not dispatch a "click" event on `click()` when disabled', async () => {
+  const host = await fixture<GlideCoreIconButton>(html`
+    <glide-core-icon-button label="Label" disabled>
+      <div>Icon</div>
+    </glide-core-icon-button>
+  `);
+
+  const spy = sinon.spy();
+  host.addEventListener('click', spy);
+
+  host.click();
+
+  expect(spy.callCount).to.equal(0);
+});
+
+it('dispatches a "click" event on Enter', async () => {
+  const host = await fixture<GlideCoreIconButton>(html`
+    <glide-core-icon-button label="Label">
+      <div>Icon</div>
+    </glide-core-icon-button>
+  `);
+
+  await sendKeys({ press: 'Tab' });
+  sendKeys({ press: 'Enter' });
+
+  const event = await oneEvent(host, 'click');
+
+  expect(event instanceof PointerEvent).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
+});
+
+it('does not dispatch a "click" event on Enter when disabled', async () => {
+  const host = await fixture<GlideCoreIconButton>(html`
+    <glide-core-icon-button label="Label" disabled>
+      <div>Icon</div>
+    </glide-core-icon-button>
+  `);
+
+  const spy = sinon.spy();
+  host.addEventListener('click', spy);
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Enter' });
+
+  expect(spy.callCount).to.equal(0);
+});
+
+it('dispatches a "click" event on Space', async () => {
+  const host = await fixture<GlideCoreIconButton>(html`
+    <glide-core-icon-button label="Label">
+      <div>Icon</div>
+    </glide-core-icon-button>
+  `);
+
+  await sendKeys({ press: 'Tab' });
+  sendKeys({ press: ' ' });
+
+  const event = await oneEvent(host, 'click');
+
+  expect(event instanceof PointerEvent).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
+});
+
+it('does not dispatch a "click" event on Space when disabled', async () => {
+  const host = await fixture<GlideCoreIconButton>(html`
+    <glide-core-icon-button label="Label" disabled>
+      <div>Icon</div>
+    </glide-core-icon-button>
+  `);
+
+  const spy = sinon.spy();
+  host.addEventListener('click', spy);
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: ' ' });
+
+  expect(spy.callCount).to.equal(0);
+});

--- a/src/icon-button.test.interactions.ts
+++ b/src/icon-button.test.interactions.ts
@@ -1,0 +1,16 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import GlideCoreIconButton from './icon-button.js';
+
+it('is accessible', async () => {
+  const host = await fixture<GlideCoreIconButton>(
+    html`<glide-core-icon-button label="Label">
+      <div>Icon</div>
+    </glide-core-icon-button>`,
+  );
+
+  host.ariaDescription = 'Description';
+  await host.updateComplete;
+
+  const button = host.shadowRoot?.querySelector('[data-test="button"]');
+  expect(button?.ariaDescription).to.equal('Description');
+});

--- a/src/icon-button.ts
+++ b/src/icon-button.ts
@@ -19,6 +19,7 @@ declare global {
 /**
  * @attr {string} label - For screenreaders
  * @attr {string|null} [aria-controls=null]
+ * @attr {string|null} [aria-description=null]
  * @attr {'true'|'false'|null} [aria-expanded=null]
  * @attr {'true'|'false'|'menu'|'listbox'|'tree'|'grid'|'dialog'|null} [aria-haspopup=null]
  * @attr {boolean} [disabled=false]
@@ -50,6 +51,25 @@ export default class GlideCoreIconButton extends LitElement {
   @property({ attribute: 'aria-controls', reflect: true, useDefault: true })
   ariaControls: string | null = null;
 
+  // A getter and setter because Lit Analzyer doesn't recognize "aria-description"
+  // as a valid attribute on the `<button>` and doesn't provide a way to selectively
+  // disable rules.
+  /**
+   * @default null
+   */
+  @property({ attribute: 'aria-description', reflect: true })
+  override get ariaDescription(): string | null {
+    return this.#ariaDescription;
+  }
+
+  override set ariaDescription(description: string | null) {
+    this.#ariaDescription = description;
+
+    if (this.#buttonElementRef.value) {
+      this.#buttonElementRef.value.ariaDescription = description;
+    }
+  }
+
   @property({ attribute: 'aria-expanded', reflect: true, useDefault: true })
   override ariaExpanded: 'true' | 'false' | null = null;
 
@@ -74,6 +94,12 @@ export default class GlideCoreIconButton extends LitElement {
 
   override click() {
     this.#buttonElementRef.value?.click();
+  }
+
+  override firstUpdated() {
+    if (this.#buttonElementRef.value && this.ariaDescription) {
+      this.#buttonElementRef.value.ariaDescription = this.ariaDescription;
+    }
   }
 
   override render() {
@@ -104,6 +130,8 @@ export default class GlideCoreIconButton extends LitElement {
       </button>
     `;
   }
+
+  #ariaDescription: string | null = null;
 
   #buttonElementRef = createRef<HTMLButtonElement>();
 

--- a/src/menu.options.styles.ts
+++ b/src/menu.options.styles.ts
@@ -1,6 +1,10 @@
 import { css } from 'lit';
+import skeleton from './styles/skeleton.js';
 
 export default [
+  css`
+    ${skeleton('.loading-feedback')}
+  `,
   css`
     :host {
       display: inline-block;
@@ -27,6 +31,12 @@ export default [
         font-family: var(--glide-core-typography-family-primary);
         font-size: var(--glide-core-typography-size-body-small);
         font-weight: var(--glide-core-typography-weight-regular);
+      }
+    }
+
+    .default-slot {
+      &.loading {
+        display: none;
       }
     }
   `,

--- a/src/menu.stories.ts
+++ b/src/menu.stories.ts
@@ -93,7 +93,7 @@ const meta: Meta = {
         type: {
           summary: 'boolean',
           detail: `
-// Add this attribute when asychronously updating Menu Options' default slot. Remove it after the
+// Add this attribute when asynchronously updating Menu Options' default slot. Remove it after the
 // slot has been updated.
 `,
         },

--- a/src/menu.stories.ts
+++ b/src/menu.stories.ts
@@ -44,6 +44,7 @@ const meta: Meta = {
     'slot="default"': '',
     'slot="target"': '',
     'addEventListener(event, handler)': '',
+    loading: false,
     offset: 4,
     open: false,
     placement: 'bottom-start',
@@ -83,6 +84,18 @@ const meta: Meta = {
           summary: 'method',
           detail:
             '(event: "click" | "toggle", handler: (event: Event) => void): void',
+        },
+      },
+    },
+    loading: {
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+          detail: `
+// Add this attribute when asychronously updating Menu Options' default slot. Remove it after the
+// slot has been updated.
+`,
         },
       },
     },
@@ -264,9 +277,10 @@ const meta: Meta = {
         ? nothing
         : arguments_.placement}
       size=${arguments_.size === 'large' ? nothing : arguments_.size}
+      ?loading=${arguments_.loading}
       ?open=${arguments_.open}
     >
-      <glide-core-button label="Target" slot="target"></glide-core-button>
+      <glide-core-button label="Toggle" slot="target"></glide-core-button>
 
       <glide-core-menu-options>
         <glide-core-menu-button
@@ -298,9 +312,10 @@ export const WithIcons: StoryObj = {
         ? nothing
         : arguments_.placement}
       size=${arguments_.size === 'large' ? nothing : arguments_.size}
+      ?loading=${arguments_.loading}
       ?open=${arguments_.open}
     >
-      <glide-core-button label="Target" slot="target"></glide-core-button>
+      <glide-core-button label="Toggle" slot="target"></glide-core-button>
 
       <glide-core-menu-options>
         <glide-core-menu-button

--- a/src/menu.test.aria.ts
+++ b/src/menu.test.aria.ts
@@ -3,6 +3,21 @@ import type GlideCoreMenu from './menu.js';
 import type GlideCoreMenuButton from './menu.button.js';
 import type GlideCoreMenuLink from './menu.link.js';
 
+test('loading', async ({ page }, test) => {
+  await page.goto('?id=menu--menu');
+
+  await page
+    .locator('glide-core-menu')
+    .evaluate<void, GlideCoreMenu>((element) => {
+      element.loading = true;
+      element.open = true;
+    });
+
+  await expect(page.locator('glide-core-menu')).toMatchAriaSnapshot({
+    name: `${test.titlePath.join('.')}.yml`,
+  });
+});
+
 test('open=${true}', async ({ page }, test) => {
   await page.goto('?id=menu--menu');
 

--- a/src/menu.test.basics.ts
+++ b/src/menu.test.basics.ts
@@ -31,30 +31,11 @@ it('is accessible', async () => {
   const options = host.querySelector('glide-core-menu-options');
 
   expect(target?.getAttribute('aria-controls')).to.equal(options?.id);
-  expect(target?.getAttribute('aria-haspopup')).to.equal('true');
-  expect(options?.ariaLabelledby).to.equal(target?.id);
-  await expect(host).to.be.accessible();
-});
-
-it('sets accessibility attributes', async () => {
-  const host = await fixture(
-    html`<glide-core-menu>
-      <button slot="target">Target</button>
-
-      <glide-core-menu-options>
-        <glide-core-menu-link label="Label"></glide-core-menu-link>
-      </glide-core-menu-options>
-    </glide-core-menu>`,
-  );
-
-  const target = host.querySelector('button');
-  const options = host.querySelector('glide-core-menu-options');
-
-  expect(target?.getAttribute('aria-expanded')).to.equal('false');
-  expect(target?.getAttribute('aria-haspopup')).to.equal('true');
   expect(target?.ariaExpanded).to.equal('false');
   expect(target?.ariaHasPopup).to.equal('true');
   expect(options?.ariaLabelledby).to.equal(target?.id);
+
+  await expect(host).to.be.accessible();
 });
 
 it('can be open', async () => {
@@ -169,6 +150,30 @@ it('adds `tabIndex` to its target when it is a `<span>`', async () => {
 
   const target = host.querySelector('span');
   expect(target?.tabIndex).to.equal(0);
+});
+
+it('shows loading feedback', async () => {
+  const host = await fixture<GlideCoreMenu>(
+    html`<glide-core-menu loading open>
+      <button slot="target">Target</button>
+
+      <glide-core-menu-options>
+        <glide-core-menu-link label="Label"></glide-core-menu-link>
+      </glide-core-menu-options>
+    </glide-core-menu>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  const target = host.querySelector('button');
+
+  const feedback = host
+    ?.querySelector('glide-core-menu-options')
+    ?.shadowRoot?.querySelector('[data-test="loading-feedback"]');
+
+  expect(target?.ariaDescription).to.equal('Loading');
+  expect(feedback?.checkVisibility()).to.be.true;
 });
 
 it('throws when subclassed', async () => {

--- a/src/menu.test.interactions.ts
+++ b/src/menu.test.interactions.ts
@@ -1574,6 +1574,60 @@ it('retains its active option when an option is programmatically added', async (
   expect(options[2]?.privateActive).to.be.false;
 });
 
+it('shows loading feedback', async () => {
+  const host = await fixture<GlideCoreMenu>(
+    html`<glide-core-menu open>
+      <button slot="target">Target</button>
+
+      <glide-core-menu-options>
+        <glide-core-menu-link label="Label"></glide-core-menu-link>
+      </glide-core-menu-options>
+    </glide-core-menu>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  host.loading = true;
+  await host.updateComplete;
+
+  const target = host.querySelector('button');
+
+  const feedback = host
+    ?.querySelector('glide-core-menu-options')
+    ?.shadowRoot?.querySelector('[data-test="loading-feedback"]');
+
+  expect(target?.ariaDescription).to.equal('Loading');
+  expect(feedback?.checkVisibility()).to.be.true;
+});
+
+it('hides loading feedback', async () => {
+  const host = await fixture<GlideCoreMenu>(
+    html`<glide-core-menu loading open>
+      <button slot="target">Target</button>
+
+      <glide-core-menu-options>
+        <glide-core-menu-link label="Label"></glide-core-menu-link>
+      </glide-core-menu-options>
+    </glide-core-menu>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  host.loading = false;
+  await host.updateComplete;
+
+  const target = host.querySelector('button');
+
+  const feedback = host
+    ?.querySelector('glide-core-menu-options')
+    ?.shadowRoot?.querySelector('[data-test="loading-feedback"]');
+
+  expect(target?.ariaDescription).to.be.null;
+  expect(feedback?.checkVisibility()).to.not.be.ok;
+});
+
 it('has `set offset()` coverage', async () => {
   const host = await fixture<GlideCoreMenu>(html`
     <glide-core-menu>

--- a/src/menu.test.visuals.ts
+++ b/src/menu.test.visuals.ts
@@ -9,6 +9,21 @@ for (const story of stories.Menu) {
   test.describe(story.id, () => {
     for (const theme of story.themes) {
       test.describe(theme, () => {
+        test('loading', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-menu')
+            .evaluate<void, GlideCoreMenu>((element) => {
+              element.loading = true;
+              element.open = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
         test('offset', async ({ page }, test) => {
           await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -5,6 +5,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { nanoid } from 'nanoid';
 import packageJson from '../package.json' with { type: 'json' };
 import GlideCoreMenuButton from './menu.button.js';
+import { LocalizeController } from './library/localize.js';
 import GlideCoreMenuLink from './menu.link.js';
 import GlideCoreMenuOptions from './menu.options.js';
 import assertSlot from './library/assert-slot.js';
@@ -19,6 +20,7 @@ declare global {
 }
 
 /**
+ * @attr {boolean} [loading=false]
  * @attr {number} [offset=4]
  * @attr {boolean} [open=false]
  * @attr {'bottom'|'left'|'right'|'top'|'bottom-start'|'bottom-end'|'left-start'|'left-end'|'right-start'|'right-end'|'top-start'|'top-end'} [placement='bottom-start']
@@ -41,6 +43,28 @@ export default class GlideCoreMenu extends LitElement {
   };
 
   static override styles = styles;
+
+  /**
+   * @default false
+   */
+  @property({ reflect: true, type: Boolean })
+  get loading(): boolean {
+    return this.#isLoading;
+  }
+
+  set loading(isLoading: boolean) {
+    this.#isLoading = isLoading;
+
+    const options = this.querySelector('glide-core-menu-options');
+
+    if (options && this.#targetElement) {
+      options.privateLoading = isLoading;
+
+      this.#targetElement.ariaDescription = isLoading
+        ? this.#localize.term('loading')
+        : null;
+    }
+  }
 
   /**
    * @default 4
@@ -157,6 +181,16 @@ export default class GlideCoreMenu extends LitElement {
   }
 
   override firstUpdated() {
+    const options = this.querySelector('glide-core-menu-options');
+
+    if (options && this.#targetElement) {
+      options.privateLoading = this.loading;
+
+      this.#targetElement.ariaDescription = this.loading
+        ? this.#localize.term('loading')
+        : null;
+    }
+
     if (this.#defaultSlotElementRef.value) {
       // `popover` is used so the options can break out of Modal or another container
       // that has `overflow: hidden`. And elements with `popover` are positioned
@@ -263,9 +297,13 @@ export default class GlideCoreMenu extends LitElement {
 
   #isDefaultSlotClick = false;
 
+  #isLoading = false;
+
   #isOpen = false;
 
   #isTargetSlotMouseUp = false;
+
+  #localize = new LocalizeController(this);
 
   #offset: number | undefined;
 


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Minor
> Menu Options' `id` attribute has always been set internally for accessibility. It's now marked as read-only to reflect that it shouldn't be changed. We've also marked `role` and `tabindex` as read-only for the same reason.

> ### Patch
> - Button and Icon Button now support an `aria-description` attribute.
> - Menu now has a `loading` attribute that shows a skeleton with a fixed number of rows. Add the attribute whenever you asynchronously update Menu's default slot. Remove it after the slot has been updated.





## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to Menu in Storybook.
2. Set `loading` to `true`.
3. Verify a skeleton loader is shown.
4. Set `loading` to `false`.
5. Verify the skeleton loader is removed.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
