### PR TITLE
Fix Tooltip "toggle" bug

### DIFF
--- a/.changeset/ten-monkeys-rhyme.md
+++ b/.changeset/ten-monkeys-rhyme.md
@@ -2,5 +2,5 @@
 '@crowdstrike/glide-core': patch
 ---
 
-- Button no longer emits a "toggle" event on hover when not disabled.
+- Button no longer emits a "toggle" event on hover, unless it is disabled and has a tooltip.
 - Tooltip no longer emits a "toggle" event on hover hover when disabled.

--- a/.changeset/ten-monkeys-rhyme.md
+++ b/.changeset/ten-monkeys-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Button no longer emits a "toggle" event on hover when not disabled.
+- Tooltip no longer emits a "toggle" event on hover hover when disabled.

--- a/src/dropdown.option.test.events.ts
+++ b/src/dropdown.option.test.events.ts
@@ -1,6 +1,7 @@
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import sinon from 'sinon';
 import GlideCoreDropdownOption from './dropdown.option.js';
+import { hover } from './library/mouse.js';
 
 it('dispatches a "private-label-change" event', async () => {
   const host = await fixture<GlideCoreDropdownOption>(
@@ -53,15 +54,18 @@ it('dispatches a "private-value-change" event', async () => {
 it('does not allow its "toggle" event to propagate', async () => {
   const host = await fixture<GlideCoreDropdownOption>(
     html`<glide-core-dropdown-option
-      label="Label"
+      label=${'x'.repeat(500)}
     ></glide-core-dropdown-option>`,
   );
 
   const spy = sinon.spy();
   host.addEventListener('toggle', spy);
 
+  await hover(host);
   host.privateIsTooltipOpen = true;
-  await host.updateComplete;
+
+  // Wait for the Resize Observer to do its thing.
+  await aTimeout(0);
 
   expect(spy.callCount).to.equal(0);
 });

--- a/src/tooltip.test.events.ts
+++ b/src/tooltip.test.events.ts
@@ -2,7 +2,7 @@ import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import sinon from 'sinon';
 import GlideCoreTooltip from './tooltip.js';
 
-it('dispatches a "toggle" event on open', async () => {
+it('dispatches a "toggle" event when opened programmatically', async () => {
   const host = await fixture<GlideCoreTooltip>(
     html`<glide-core-tooltip label="Label">
       <button slot="target">Target</button>
@@ -20,7 +20,7 @@ it('dispatches a "toggle" event on open', async () => {
   expect(event.composed).to.be.true;
 });
 
-it('dispatches a "toggle" event on close', async () => {
+it('dispatches a "toggle" event when closed programmatically', async () => {
   const host = await fixture<GlideCoreTooltip>(
     html`<glide-core-tooltip label="Label" open>
       <button slot="target">Target</button>
@@ -38,7 +38,7 @@ it('dispatches a "toggle" event on close', async () => {
   expect(event.composed).to.be.true;
 });
 
-it('does not dispatch a "toggle" event when already open', async () => {
+it('does not dispatch a "toggle" event when opened programmatically and already open', async () => {
   const host = await fixture<GlideCoreTooltip>(
     html`<glide-core-tooltip label="Label" open>
       <button slot="target">Target</button>
@@ -54,9 +54,41 @@ it('does not dispatch a "toggle" event when already open', async () => {
   expect(spy.callCount).to.equal(0);
 });
 
-it('does not dispatch a "toggle" event when already closed', async () => {
+it('does not dispatch a "toggle" event when closed programmatically and already closed', async () => {
   const host = await fixture<GlideCoreTooltip>(
     html`<glide-core-tooltip label="Label">
+      <button slot="target">Target</button>
+    </glide-core-tooltip>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('toggle', spy);
+
+  host.open = false;
+  await aTimeout(0);
+
+  expect(spy.callCount).to.equal(0);
+});
+
+it('does not dispatch a "toggle" event when opened programmatically and disabled', async () => {
+  const host = await fixture<GlideCoreTooltip>(
+    html`<glide-core-tooltip label="Label" disabled>
+      <button slot="target">Target</button>
+    </glide-core-tooltip>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('toggle', spy);
+
+  host.open = true;
+  await aTimeout(0);
+
+  expect(spy.callCount).to.equal(0);
+});
+
+it('does not dispatch a "toggle" event when closed programmatically and disabled', async () => {
+  const host = await fixture<GlideCoreTooltip>(
+    html`<glide-core-tooltip label="Label" disabled open>
       <button slot="target">Target</button>
     </glide-core-tooltip>`,
   );

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -152,7 +152,7 @@ export default class GlideCoreTooltip extends LitElement {
       this.dispatchEvent(
         new Event('toggle', { bubbles: true, composed: true }),
       );
-    } else if (hasChanged) {
+    } else if (hasChanged && !this.disabled) {
       this.#hide();
 
       this.dispatchEvent(


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

- Button no longer emits a "toggle" event on hover when not disabled.
- Tooltip no longer emits a "toggle" event on hover hover when disabled.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to [Button](https://glide-core.crowdstrike-ux.workers.dev/fix-tooltip-toggle-bug?path=/story/button--button) in Storybook.
2. Manually add a "toggle" listener.
3. Hover Button.
4. Verify the listener's handler isn't called.



<br>

1. Navigate to [Tooltip](https://glide-core.crowdstrike-ux.workers.dev/fix-tooltip-toggle-bug?path=/story/tooltip--tooltip) in Storybook.
2. Disable Tooltip
3. Hover Tooltip.
4. Verify using the Actions pane that "toggle" wasn't emitted. 

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
