### PR TITLE
Fix Dropdown automatic filterability

### DIFF
--- a/.changeset/warm-chefs-end.md
+++ b/.changeset/warm-chefs-end.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown automatically becomes filterable when it contains more than 10 options. Previously, however, Dropdown became unfilterable if its options were reduced to 10 or fewer after initial render. Dropdown now remains filterable or unfilterable throughout its lifecycle based on the number options present on first render. You can still force Dropdown to be filterable, regardless of options, using the `filterable` attribute.

--- a/.changeset/warm-chefs-end.md
+++ b/.changeset/warm-chefs-end.md
@@ -2,4 +2,4 @@
 '@crowdstrike/glide-core': patch
 ---
 
-Dropdown automatically becomes filterable when it contains more than 10 options. Previously, however, Dropdown became unfilterable if its options were reduced to 10 or fewer after initial render. Dropdown now remains filterable or unfilterable throughout its lifecycle based on the number options present on first render. You can still force Dropdown to be filterable, regardless of options, using the `filterable` attribute.
+Dropdown automatically becomes filterable when it contains more than 10 options. Previously, however, Dropdown became unfilterable if its options were reduced to 10 or fewer after initial render. Dropdown now remains filterable or unfilterable throughout its lifecycle based on the number of options present on first render. You can still force Dropdown to be filterable, regardless of options, using the `filterable` attribute.

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -434,9 +434,10 @@ export default class GlideCoreCheckboxGroup
     this.addEventListener('invalid', (event) => {
       event?.preventDefault(); // Canceled so a native validation message isn't shown.
 
-      // We only want to focus the input if the invalid event resulted from either:
-      // 1. Form submission
-      // 2. a call to reportValidity that did NOT result from the input blur event
+      // We only want to focus the input if the "invalid" event resulted from either:
+      //
+      // 1. A form submission.
+      // 2. A call of `reportValidity()` that did not result from the input's "blur" event.
       if (this.isCheckingValidity || this.isBlurring) {
         return;
       }

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -551,9 +551,10 @@ export default class GlideCoreCheckbox
     this.addEventListener('invalid', (event) => {
       event?.preventDefault(); // Canceled so a native validation message isn't shown.
 
-      // We only want to focus the input if the invalid event resulted from either:
-      // 1. Form submission
-      // 2. a call to reportValidity that did NOT result from the checkbox blur event
+      // We only want to focus the input if the "invalid" event resulted from either:
+      //
+      // 1. A form submission.
+      // 2. A call of `reportValidity()` that did not result from the input's "blur" event.
       if (this.isCheckingValidity || this.isBlurring) {
         return;
       }

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -87,6 +87,29 @@ it('filters', async () => {
   expect(options.length).to.equal(1);
 });
 
+it('remains automatically filterable when an option is removed', async () => {
+  const host = await fixture<GlideCoreDropdown>(
+    html`<glide-core-dropdown label="Label" open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Four"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Five"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Six"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Seven"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Eight"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Nine"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Ten"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Eleven"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  host.querySelector('glide-core-dropdown-option:last-of-type')?.remove();
+
+  const input = host.shadowRoot?.querySelector('[data-test="input"]');
+  expect(input?.checkVisibility()).to.be.true;
+});
+
 it('unfilters when an option is selected via click', async () => {
   const host = await fixture<GlideCoreDropdown>(
     html`<glide-core-dropdown label="Label" filterable>
@@ -1006,7 +1029,6 @@ it('sets `aria-activedescendant` on Meta + ArrowUp', async () => {
   await aTimeout(0);
 
   await sendKeys({ press: 'Tab' });
-
   await sendKeys({ press: 'ArrowDown' });
   await sendKeys({ down: 'Meta' });
   await sendKeys({ press: 'ArrowUp' });

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -1372,7 +1372,7 @@ export default class GlideCoreDropdown
   async #onDefaultSlotChange() {
     if (this.#isFirstDefaultSlotChange) {
       // It's a requirement of Design for Dropdown to automatically become filterable
-      // when there are more than 10 options. But it's also bad user experience for
+      // when there are more than 10 options. But it's also a bad user experience for
       // Dropdown to suddenly become unfilterable when a developer using Dropdown reduces
       // the number of options in the slot in response to the user filtering.
       //

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -1139,9 +1139,10 @@ export default class GlideCoreDropdown
     this.addEventListener('invalid', (event) => {
       event.preventDefault(); // Canceled so a native validation message isn't shown.
 
-      // We only want to focus the input if the invalid event resulted from either:
-      // 1. Form submission
-      // 2. a call to reportValidity that did NOT result from the checkbox blur event
+      // We only want to focus the input if the "invalid" event resulted from either:
+      //
+      // 1. A form submission.
+      // 2. A call of `reportValidity()` that did not result from Checkbox's "blur" event.
       if (this.isCheckingValidity || this.isBlurring) {
         return;
       }
@@ -1246,6 +1247,8 @@ export default class GlideCoreDropdown
   #isEditingOrRemovingTag = false;
 
   #isFilterable = false;
+
+  #isFirstDefaultSlotChange = true;
 
   #isMultiple = false;
 
@@ -1367,7 +1370,18 @@ export default class GlideCoreDropdown
   }
 
   async #onDefaultSlotChange() {
-    this.isFilterable = this.#optionElements.length > 10;
+    if (this.#isFirstDefaultSlotChange) {
+      // It's a requirement of Design for Dropdown to automatically become filterable
+      // when there are more than 10 options. But it's also bad user experience for
+      // Dropdown to suddenly become unfilterable when a developer using Dropdown reduces
+      // the number of options in the slot in response to the user filtering.
+      //
+      // So we lock in Dropdown as either filterable or unfilterable with the first slot
+      // change. Consumers can still force filterability using the `filterable` attribute.
+      this.isFilterable = this.#optionElements.length > 10;
+      this.#isFirstDefaultSlotChange = false;
+    }
+
     this.tagOverflowLimit = this.selectedOptions.length;
 
     for (const option of this.#optionElements) {

--- a/src/input.ts
+++ b/src/input.ts
@@ -498,9 +498,10 @@ export default class GlideCoreInput extends LitElement implements FormControl {
     this.addEventListener('invalid', (event) => {
       event?.preventDefault(); // Canceled so a native validation message isn't shown.
 
-      // We only want to focus the input if the invalid event resulted from either:
-      // 1. Form submission
-      // 2. a call to reportValidity that did NOT result from the input blur event
+      // We only want to focus the input if the "invalid" event resulted from either:
+      //
+      // 1. A form submission.
+      // 2. A call of `reportValidity()` that did not result from the input's "blur" event.
       if (this.isCheckingValidity || this.isBlurring) {
         return;
       }

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -353,9 +353,10 @@ export default class GlideCoreTextarea
     this.addEventListener('invalid', (event) => {
       event?.preventDefault(); // Canceled so a native validation message isn't shown.
 
-      // We only want to focus the input if the invalid event resulted from either:
-      // 1. Form submission
-      // 2. a call to reportValidity that did NOT result from the input blur event
+      // We only want to focus the input if the "invalid" event resulted from either:
+      //
+      // 1. A form submission.
+      // 2. A call of `reportValidity()` that did not result from the input's "blur" event.
       if (this.isCheckingValidity || this.isBlurring) {
         return;
       }


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> Dropdown automatically becomes filterable when it contains more than 10 options. Previously, however, Dropdown became unfilterable if its options were reduced to 10 or fewer after initial render. Dropdown now remains filterable or unfilterable throughout its lifecycle based on the number options present on first render. You can still force Dropdown to be filterable, regardless of options, using the `filterable` attribute.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

A tricky one to test. The test I added should have us covered. Otherwise, your best bet is to clone the branch and rig up Dropdown's story with more than 10 options, then remove some of those options using DevTools and verify that Dropdown remains filterable.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
