### PR TITLE
Tab/TabGroup should respect `selected`

### DIFF
--- a/.changeset/cool-students-flow.md
+++ b/.changeset/cool-students-flow.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Tabs can now be selected by applying the selected attribute.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -7455,6 +7455,12 @@
               "type": {
                 "text": "Event"
               }
+            },
+            {
+              "name": "private-selected",
+              "type": {
+                "text": "Event"
+              }
             }
           ],
           "attributes": [

--- a/src/tab.group.test.interactions.ts
+++ b/src/tab.group.test.interactions.ts
@@ -1,9 +1,46 @@
-import './tab.js';
 import { emulateMedia, sendKeys } from '@web/test-runner-commands';
 import { assert, expect, fixture, html, waitUntil } from '@open-wc/testing';
+import GlideCoreTab from './tab.js';
 import { click } from './library/mouse.js';
 import GlideCoreTabGroup from './tab.group.js';
 import './tab.panel.js';
+
+it('sets the selected tab using the `selected` attribute', async () => {
+  const host = await fixture<GlideCoreTabGroup>(html`
+    <glide-core-tab-group>
+      <glide-core-tab panel="1" slot="nav">One</glide-core-tab>
+      <glide-core-tab panel="2" slot="nav" selected>Two</glide-core-tab>
+      <glide-core-tab-panel name="1">One</glide-core-tab-panel>
+      <glide-core-tab-panel name="2">Two</glide-core-tab-panel>
+    </glide-core-tab-group>
+  `);
+
+  const tabs = host.querySelectorAll('glide-core-tab');
+
+  expect(tabs[0]?.selected).to.be.false;
+  expect(tabs[1]?.selected).to.be.true;
+});
+
+it('sets the selected tab by setting `selected` programmatically', async () => {
+  const host = await fixture<GlideCoreTabGroup>(html`
+    <glide-core-tab-group>
+      <glide-core-tab panel="1" slot="nav" selected>One</glide-core-tab>
+      <glide-core-tab panel="2" slot="nav">Two</glide-core-tab>
+      <glide-core-tab-panel name="1">One</glide-core-tab-panel>
+      <glide-core-tab-panel name="2">Two</glide-core-tab-panel>
+    </glide-core-tab-group>
+  `);
+
+  const tab = host.querySelector<GlideCoreTab>('glide-core-tab:nth-of-type(2)');
+
+  assert(tab);
+  tab.selected = true;
+
+  const tabs = host.querySelectorAll('glide-core-tab');
+
+  expect(tabs[0]?.selected).to.be.false;
+  expect(tabs[1]?.selected).to.be.true;
+});
 
 it('changes tabs on click', async () => {
   const host = await fixture<GlideCoreTabGroup>(html`

--- a/src/tab.test.events.ts
+++ b/src/tab.test.events.ts
@@ -1,0 +1,17 @@
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import GlideCoreTab from './tab.js';
+
+it('dispatches a "private-selected" event when selected', async () => {
+  const host = await fixture<GlideCoreTab>(
+    html`<glide-core-tab panel="1">One</glide-core-tab>`,
+  );
+
+  setTimeout(() => {
+    host.selected = true;
+  });
+
+  const event = await oneEvent(host, 'private-selected');
+
+  expect(event instanceof Event).to.be.true;
+  expect(event.bubbles).to.be.true;
+});

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -57,9 +57,8 @@ export default class GlideCoreTab extends LitElement {
 
     if (isSelected && hasChanged) {
       this.dispatchEvent(
-        new Event('selected', {
+        new Event('private-selected', {
           bubbles: true,
-          composed: true,
         }),
       );
     }
@@ -71,6 +70,14 @@ export default class GlideCoreTab extends LitElement {
   protected override firstUpdated() {
     this.setAttribute('role', 'tab');
     this.id = this.#id;
+  }
+
+  privateSelect() {
+    this.selected = true;
+
+    this.dispatchEvent(
+      new Event('selected', { bubbles: true, composed: true }),
+    );
   }
 
   override render() {


### PR DESCRIPTION
## 🚀 Description

On `main`, Tab doesn't respect when you set `selected` to anything but the first Tab. It also doesn't set programmatically setting `selected`. This PR fixes that.

We can't make any breaking changes to Tab/Tab Group at the moment. But we will be able to later this sprint. There's more I'd like to update here to bring things in line with our other components, but that'll need to wait a few more weeks.

So while I do want to make more changes, we need to sit tight a bit longer and get this patched with most of the code as-is.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

> The initially selected Tab can now be set with `selected`.

1. Tests cover this use case.
2. But if you want to test, pull this branch, edit the tab group stories and set `selected` on the second tab.

> The selected Tab can now be set programmatically with `selected`.

1. Go to [storybook](https://glide-core.crowdstrike-ux.workers.dev/fix-tab-selected?path=/docs/tab-group--overview).
2. Target the second Tab ("With Icon").
3. Set the selected state `$0.selected = true`.
4. Verify the second Tab is now selected, the first is not.
5. The first Tab should also have `aria-selected="false"` now.
