### PR TITLE
Disable pointer events on Icon Button's slotted content

### DIFF
--- a/.changeset/selfish-bikes-beam.md
+++ b/.changeset/selfish-bikes-beam.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Icon Button is now clickable with Playwright without the use of `force: true`.

--- a/src/icon-button.styles.ts
+++ b/src/icon-button.styles.ts
@@ -133,5 +133,34 @@ export default [
         }
       }
     }
+
+    .default-slot {
+      &::slotted(*) {
+        /*
+          So that teams clicking Icon Button using Playwright don't have to use "force: true".
+          Playwright uses "elementsFromPoint()" internally to locate elements. But there's a
+          Chromium bug¹ where that method returns content slotted into the element clicked
+          instead of the element itself.
+
+          Or it may² be a specification issue. Either way, to reproduce it, use the "getByRole"
+          locator to locate and click Icon Button: "page.getByRole('button').click()". The
+          click will fail with a Playwright "intercepts pointer events" error related to the
+          slotted content.
+
+          It's not clear if Playwright can work around it like it has³ other "elementsFromPoint()"
+          problems or if the fix needs to come from Chromium. I'll file a bug with Playwright and
+          update this comment if I find out.
+
+          In the meantime, disabling pointer events on the slotted content prevents it from being
+          included in the array returned by "elementsFromPoint()". As a result, Playwright won't
+          falsely believe it's intercepting events.
+
+          1. https://issues.chromium.org/issues/40755138
+          2. https://github.com/w3c/csswg-drafts/issues/556
+          3. https://github.com/microsoft/playwright/blob/00429efc4ac67ece5d9ba220d7470ea97c0ca265/packages/injected/src/injectedScript.ts#L962-L968
+        */
+        pointer-events: none;
+      }
+    }
   `,
 ];

--- a/src/icon-button.ts
+++ b/src/icon-button.ts
@@ -120,7 +120,11 @@ export default class GlideCoreIconButton extends LitElement {
         ?disabled=${this.disabled}
         ${ref(this.#buttonElementRef)}
       >
-        <slot ${assertSlot()} ${ref(this.#defaultSlotElementRef)}>
+        <slot
+          class="default-slot"
+          ${assertSlot()}
+          ${ref(this.#defaultSlotElementRef)}
+        >
           <!--
             An icon
             @required


### PR DESCRIPTION
## 🚀 Description

So that teams clicking Icon Button using Playwright don't have to use "force: true". Playwright uses [`elementsFromPoint()`](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementsFromPoint) internally to locate elements. But there's a Chromium [bug](https://issues.chromium.org/issues/40755138) where that method returns content slotted into the element clicked instead of the element itself.

Or it [may](https://issues.chromium.org/issues/40755138) be a specification issue. Either way, to reproduce it, use the `getByRole()` locator to locate and click Icon Button: `page.getByRole('button').click()`. The click will fail with a Playwright "intercepts pointer events" error related to the slotted content.

It's not clear if Playwright can work around it like it [has](https://github.com/microsoft/playwright/blob/00429efc4ac67ece5d9ba220d7470ea97c0ca265/packages/injected/src/injectedScript.ts#L962-L968) other `elementsFromPoint()` problems or if the fix needs to come from Chromium. I'll file a bug with Playwright and update my code comment if I find out.

In the meantime, disabling pointer events on the slotted content prevents it from being included in the array returned by `elementsFromPoint()`. As a result, Playwright won't falsely believe it's intercepting events.

**A note on test coverage**. 

We use Playwright but only for visual and ARIA snapshots. So we don't have a place to test something like this. We debated, in a thread, adding a one-off suite just for this. But we decided that, while not ideal, that a one-off wasn't worth it considering we're covered by upstream tests. So we'll no doubt be alerted by teams if we regress, and a regression won't affect the end user. Plus there's a giant code comment above `pointer-events: none` that will deter ambitious developers from removing it.

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

N/A

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
