### PR TITLE
Prevent required form controls' asterisk from disappearing

### DIFF
--- a/.changeset/swift-ladybugs-cross.md
+++ b/.changeset/swift-ladybugs-cross.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- The asterisk of required form controls is no longer hidden when form controls' labels are truncated.
+- Textarea now has a minimum width.

--- a/src/checkbox-group.stories.ts
+++ b/src/checkbox-group.stories.ts
@@ -12,7 +12,7 @@ const meta: Meta = {
   decorators: [
     withActions,
     (story) =>
-      html`<form action="/" style="width: max-content;">
+      html`<form action="/">
         <script type="ignore">
           import '@crowdstrike/glide-core/checkbox-group.js';
           import '@crowdstrike/glide-core/checkbox.js';

--- a/src/label.styles.ts
+++ b/src/label.styles.ts
@@ -44,7 +44,6 @@ export default [
 
     .tooltips {
       align-items: center;
-      column-gap: var(--glide-core-spacing-base-xs);
       display: flex;
 
       /*
@@ -65,6 +64,7 @@ export default [
 
     .optional-tooltip {
       display: none;
+      margin-inline-end: var(--glide-core-spacing-base-xs);
 
       &.vertical {
         order: 1;
@@ -135,6 +135,10 @@ export default [
 
     .required-symbol {
       color: var(--glide-core-color-advisory-stroke-error-primary);
+      font-family: var(--glide-core-typography-family-primary);
+      font-size: var(--glide-core-typography-size-body-default);
+      font-weight: var(--glide-core-typography-weight-bold);
+      line-height: 100%;
     }
 
     .control-and-summary {

--- a/src/label.test.basics.ts
+++ b/src/label.test.basics.ts
@@ -34,7 +34,7 @@ it('can be required', async () => {
     </glide-core-private-label>`,
   );
 
-  const label = host.shadowRoot?.querySelector('[data-test="label"]');
+  const label = host.shadowRoot?.querySelector('[data-test="required-symbol"]');
   expect(label?.textContent?.includes('*')).to.be.true;
 });
 

--- a/src/label.ts
+++ b/src/label.ts
@@ -150,12 +150,18 @@ export default class GlideCoreLabel extends LitElement {
             >
               <!-- @type {HTMLLabelElement} -->
             </slot>
-
-            ${this.required
-              ? html`<span aria-hidden="true" class="required-symbol">*</span>`
-              : ''}
           </div>
         </glide-core-tooltip>
+
+        ${this.required
+          ? html`<span
+              aria-hidden="true"
+              class="required-symbol"
+              data-test="required-symbol"
+            >
+              &nbsp;*
+            </span>`
+          : ''}
       </div>
 
       <div class="control-and-summary" part="private-control-and-summary">

--- a/src/textarea.styles.ts
+++ b/src/textarea.styles.ts
@@ -56,6 +56,7 @@ export default [
       font-weight: var(--glide-core-typography-weight-regular);
       max-block-size: 5lh;
       min-block-size: 3lh;
+      min-inline-size: 3.75rem;
       padding: var(--glide-core-spacing-base-xs)
         var(--glide-core-spacing-base-sm);
       resize: vertical;


### PR DESCRIPTION
## 🚀 Description

> ### Patch
> - The asterisk of required form controls is no longer hidden when form controls' labels are truncated.
> - Textarea now has a minimum width.

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

### The asterisk of required form controls is no longer hidden when form controls' labels are truncated

1. Navigate to every form control "With Error" story in Storybook.
2. Dump a [bunch of text](https://www.lipsum.com) into the control's `label`.
3. Verify the label is truncated with an ellipsis.
4. Verify hovering the label shows the full text.
5. Verify the asterisk is visible.

### Textarea now has a minimum width

1. Navigate to Textarea in Storybook.
4. Dump a [bunch of text](https://www.lipsum.com) into Textarea's `label`.
5. Verify Textarea holds its minimum width.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
