### PR TITLE
Remove Tag's `size` attribute

### DIFF
--- a/.changeset/chatty-rings-flow.md
+++ b/.changeset/chatty-rings-flow.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Tag's height has been slightly reduced.

--- a/.changeset/fresh-emus-act.md
+++ b/.changeset/fresh-emus-act.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Tag's `size` attribute has been removed. Tag is now always large. Please get in touch with us if you have a use for `size="small"` or `size="medium"`.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -7842,16 +7842,6 @@
             },
             {
               "kind": "field",
-              "name": "size",
-              "type": {
-                "text": "'small' | 'medium' | 'large'"
-              },
-              "default": "'medium'",
-              "attribute": "size",
-              "reflects": true
-            },
-            {
-              "kind": "field",
               "name": "version",
               "type": {
                 "text": "string"
@@ -7915,14 +7905,6 @@
               },
               "default": "false",
               "fieldName": "removable"
-            },
-            {
-              "name": "size",
-              "type": {
-                "text": "'small' | 'medium' | 'large'"
-              },
-              "default": "'medium'",
-              "fieldName": "size"
             },
             {
               "name": "version",

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -707,7 +707,6 @@ export default class GlideCoreDropdown
                         data-id=${id}
                         label=${ifDefined(label)}
                         removable
-                        size="large"
                         ?disabled=${this.disabled || this.readonly}
                         ?private-editable=${editable}
                         @edit=${this.#onTagEdit}

--- a/src/tag.stories.ts
+++ b/src/tag.stories.ts
@@ -39,7 +39,6 @@ const meta: Meta = {
     'addEventListener(event, handler)': '',
     disabled: false,
     removable: false,
-    size: 'medium',
     'slot="icon"': '',
     version: '',
   },
@@ -69,18 +68,6 @@ const meta: Meta = {
       table: {
         defaultValue: {
           summary: 'false',
-        },
-      },
-    },
-    size: {
-      control: { type: 'radio' },
-      options: ['small', 'medium', 'large'],
-      table: {
-        defaultValue: {
-          summary: '"medium"',
-        },
-        type: {
-          summary: '"small" | "medium" | "large"',
         },
       },
     },
@@ -115,7 +102,6 @@ export const WithIcon: StoryObj = {
     return html`
       <glide-core-tag
         label=${arguments_.label || nothing}
-        size=${arguments_.size === 'medium' ? nothing : arguments_.size}
         ?disabled=${arguments_.disabled}
         ?removable=${arguments_.removable}
       >

--- a/src/tag.styles.ts
+++ b/src/tag.styles.ts
@@ -32,39 +32,21 @@ export default [
       background-color: var(
         --glide-core-color-static-surface-container-secondary
       );
+      block-size: 1.5rem;
       border: 1px solid var(--glide-core-color-interactive-stroke-primary);
       border-radius: var(--glide-core-rounding-base-radius-round);
+      box-sizing: border-box;
       color: var(--glide-core-color-interactive-text-default);
+      column-gap: var(--glide-core-spacing-base-xs);
       display: flex;
       font-family: var(--glide-core-typography-family-primary);
+      font-size: var(--glide-core-typography-size-body-small);
       font-weight: var(--glide-core-typography-weight-regular);
       justify-content: center;
       line-height: 1;
       max-inline-size: max-content;
       opacity: 1;
-
-      &.large {
-        column-gap: var(--glide-core-spacing-base-xs);
-        font-size: var(--glide-core-typography-size-body-small);
-        min-block-size: 0.875rem;
-        padding: var(--glide-core-spacing-base-xxs)
-          var(--glide-core-spacing-base-sm);
-      }
-
-      &.medium {
-        column-gap: var(--glide-core-spacing-base-xs);
-        font-size: var(--glide-core-typography-size-body-small);
-        min-block-size: var(--glide-core-spacing-base-md);
-        padding: var(--glide-core-spacing-base-xxxs)
-          var(--glide-core-spacing-base-xs);
-      }
-
-      &.small {
-        column-gap: var(--glide-core-spacing-base-xxs);
-        font-size: 0.625rem;
-        min-block-size: var(--glide-core-spacing-base-md);
-        padding: 0 var(--glide-core-spacing-base-xs);
-      }
+      padding-inline: var(--glide-core-spacing-base-sm);
 
       &.added {
         @media (prefers-reduced-motion: no-preference) {
@@ -128,34 +110,15 @@ export default [
     }
 
     .icon-slot {
-      &.large {
-        &::slotted(*) {
-          block-size: 1rem;
-          inline-size: 1rem;
-        }
-      }
-
-      &.medium {
-        &::slotted(*) {
-          block-size: 0.75rem;
-          inline-size: 0.75rem;
-        }
-      }
-
-      &.small {
-        &::slotted(*) {
-          block-size: 0.625rem;
-          inline-size: 0.625rem;
-        }
-      }
-
       &.hidden {
         display: none;
       }
 
       &::slotted(*) {
         align-items: center;
+        block-size: 1rem;
         display: flex;
+        inline-size: 1rem;
         justify-content: center;
       }
     }
@@ -166,14 +129,6 @@ export default [
       border-radius: 0.0625rem;
       display: flex;
       padding: 0;
-
-      &.medium {
-        --private-size: 0.75rem;
-      }
-
-      &.small {
-        --private-size: 0.625rem;
-      }
 
       &.disabled {
         color: var(--glide-core-color-interactive-icon-default--disabled);

--- a/src/tag.test.visuals.ts
+++ b/src/tag.test.visuals.ts
@@ -75,48 +75,6 @@ for (const story of stories.Tag) {
             `${test.titlePath.join('.')}.png`,
           );
         });
-
-        test('size="small"', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-          await page
-            .locator('glide-core-tag')
-            .evaluate<void, GlideCoreTag>((element) => {
-              element.size = 'small';
-            });
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
-
-        test('size="medium"', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-          await page
-            .locator('glide-core-tag')
-            .evaluate<void, GlideCoreTag>((element) => {
-              element.size = 'medium';
-            });
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
-
-        test('size="large"', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-          await page
-            .locator('glide-core-tag')
-            .evaluate<void, GlideCoreTag>((element) => {
-              element.size = 'large';
-            });
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
       });
     }
   });

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -22,7 +22,6 @@ declare global {
  * @attr {string} label
  * @attr {boolean} [disabled=false]
  * @attr {boolean} [removable=false]
- * @attr {'small'|'medium'|'large'} [size='medium']
  *
  * @readonly
  * @attr {string} [version]
@@ -57,9 +56,6 @@ export default class GlideCoreTag extends LitElement {
   @property({ reflect: true, type: Boolean })
   removable = false;
 
-  @property({ reflect: true, useDefault: true })
-  size: 'small' | 'medium' | 'large' = 'medium';
-
   @property({ reflect: true })
   readonly version: string = packageJson.version;
 
@@ -88,20 +84,13 @@ export default class GlideCoreTag extends LitElement {
           component: true,
           added: true,
           disabled: this.disabled,
-          [this.size]: true,
         })}
         data-test="component"
         data-animation-duration=${this.#animationDuration}
         style="--private-animation-duration: ${this.#animationDuration}ms"
         ${ref(this.#componentElementRef)}
       >
-        <slot
-          class=${classMap({
-            'icon-slot': true,
-            [this.size]: true,
-          })}
-          name="icon"
-        >
+        <slot class="icon-slot" name="icon">
           <!-- @type {Element} -->
         </slot>
 
@@ -112,7 +101,6 @@ export default class GlideCoreTag extends LitElement {
             aria-label=${this.#localize.term('editTag', this.label!)}
             class=${classMap({
               'edit-button': true,
-              [this.size]: true,
               disabled: this.disabled,
             })}
             data-test="edit-button"
@@ -131,7 +119,6 @@ export default class GlideCoreTag extends LitElement {
               aria-label=${this.#localize.term('removeTag', this.label!)}
               class=${classMap({
                 'removal-button': true,
-                [this.size]: true,
                 disabled: this.disabled,
               })}
               data-test="removal-button"


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Minor
> Tag's `size` attribute has been removed. Tag is now always large. Please get in touch with us if you have a use for `size="small"`.


`size="small"` and `size="medium"` were initially mocked up, so we built them. But there doesn't appear to be a use  for them. So Design asked me to remove them. I searched through consumers' code and only found one use: `size="medium"` is being used in a story.

> ### Patch
> Tag's height has been slightly reduced.


## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing


The visual test report should have us covered. Multi-select Dropdown uses Tag, and Tag's height has decreased. So you'll also see some Dropdown diffs in the report.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
