### PR TITLE
Fix Button Group bug

### DIFF
--- a/.changeset/short-avocados-report.md
+++ b/.changeset/short-avocados-report.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Button Group now only shows the last selected button as selected when multiple Button Group Buttons are selected initially.

--- a/src/button-group.button.ts
+++ b/src/button-group.button.ts
@@ -82,8 +82,22 @@ export default class GlideCoreButtonGroupButton extends LitElement {
     this.#componentElementRef.value?.focus(options);
   }
 
+  @state()
+  private get lastSelectedButton(): GlideCoreButtonGroupButton | undefined {
+    const buttons = this.parentElement?.querySelectorAll(
+      'glide-core-button-group-button',
+    );
+
+    if (buttons && buttons.length > 0) {
+      return [...buttons].findLast(
+        (button) => button.selected && !button.disabled,
+      );
+    }
+  }
+
   privateSelect() {
     this.selected = true;
+    this.requestUpdate();
 
     this.dispatchEvent(
       new Event('selected', { bubbles: true, composed: true }),
@@ -92,11 +106,11 @@ export default class GlideCoreButtonGroupButton extends LitElement {
 
   override render() {
     return html`<div
-      aria-checked=${this.selected}
+      aria-checked=${this.selected && this === this.lastSelectedButton}
       aria-disabled=${this.disabled}
       class=${classMap({
         component: true,
-        selected: this.selected,
+        selected: this.selected && this === this.lastSelectedButton,
         disabled: this.disabled,
         [this.privateOrientation]: true,
         icon: this.hasIcon,

--- a/src/button-group.test.basics.ts
+++ b/src/button-group.test.basics.ts
@@ -56,7 +56,7 @@ it('sets the orientation of its buttons when horizontal', async () => {
   expect(buttons[1]?.privateOrientation).to.equal('horizontal');
 });
 
-it('sets the orientation of its buttons when vertical', async () => {
+it('sets `privateOrientation` on its buttons', async () => {
   const host = await fixture(
     html`<glide-core-button-group label="Label" orientation="vertical">
       <glide-core-button-group-button
@@ -138,6 +138,36 @@ it('selects no buttons when all are disabled', async () => {
 
   expect(buttons[0]?.selected).to.be.false;
   expect(buttons[1]?.selected).to.be.false;
+});
+
+it('selects the last selected button when multiple are selected', async () => {
+  const host = await fixture(
+    html`<glide-core-button-group label="Label">
+      <glide-core-button-group-button
+        label="One"
+        selected
+      ></glide-core-button-group-button>
+
+      <glide-core-button-group-button
+        label="Two"
+        selected
+      ></glide-core-button-group-button>
+    </glide-core-button-group>`,
+  );
+
+  const buttons = host.querySelectorAll('glide-core-button-group-button');
+
+  await buttons[0]?.updateComplete;
+  await buttons[1]?.updateComplete;
+
+  const radios = [
+    ...host.querySelectorAll('glide-core-button-group-button'),
+  ].map((button) => {
+    return button.shadowRoot?.querySelector('[data-test="radio"]');
+  });
+
+  expect(radios[0]?.ariaChecked).to.equal('false');
+  expect(radios[1]?.ariaChecked).to.equal('true');
 });
 
 it('throws when `label` is empty', async () => {

--- a/src/button-group.test.interactions.ts
+++ b/src/button-group.test.interactions.ts
@@ -113,7 +113,7 @@ it('selects a button on Space', async () => {
   expect(buttons[1]?.selected).to.be.true;
 });
 
-it('does not select a disabled button', async () => {
+it('retains the currently selected button as selected when a disabled button is clicked', async () => {
   const host = await fixture(
     html`<glide-core-button-group label="Label">
       <glide-core-button-group-button


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> Button Group now only shows the last selected button as selected when multiple Button Group Buttons are selected initially.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

The test I added should have us covered. But if you want to test manually:

1. Check out the branch.
2. Modify Button Group's story so that more than one Button Group Button is selected initially.
3. Verify that only the last selected Button Group Button appears as selected.
<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
