### PR TITLE
Throw when multiple Button Group Buttons are selected

### DIFF
--- a/.changeset/clean-seals-scream.md
+++ b/.changeset/clean-seals-scream.md
@@ -2,4 +2,4 @@
 '@crowdstrike/glide-core': minor
 ---
 
-Button Group now throws in development when more than one Button Group Button is rendered with a `selected` attribute.
+Button Group now throws when more than one Button Group Button is rendered with a `selected` attribute.

--- a/.changeset/clean-seals-scream.md
+++ b/.changeset/clean-seals-scream.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Button Group now throws in development when more than one Button Group Button is rendered with a `selected` attribute.

--- a/src/button-group.test.basics.ts
+++ b/src/button-group.test.basics.ts
@@ -185,3 +185,21 @@ it('throws when its default slot is the wrong type', async () => {
     );
   });
 });
+
+it('throws when more than one button is selected', async () => {
+  await expectWindowError(() => {
+    return fixture(html`
+      <glide-core-button-group label="Label">
+        <glide-core-button-group-button
+          label="One"
+          selected
+        ></glide-core-button-group-button>
+
+        <glide-core-button-group-button
+          label="Two"
+          selected
+        ></glide-core-button-group-button>
+      </glide-core-button-group>
+    `);
+  });
+});

--- a/src/library/expect-window-error.ts
+++ b/src/library/expect-window-error.ts
@@ -24,7 +24,7 @@ export default async function (callback: () => unknown) {
   expect(spy.callCount).to.be.greaterThan(0);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-  expect(spy.args.at(0)?.at(4) instanceof TypeError).to.be.true;
+  expect(spy.args.at(0)?.at(4) instanceof Error).to.be.true;
 
   // eslint-disable-next-line unicorn/prefer-add-event-listener
   window.onerror = onerror;


### PR DESCRIPTION
## 🚀 Description

> ### Minor
> Button Group now throws when more than one Button Group Button is rendered with a `selected` attribute.

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

The test I added should have us covered. But if you want to test manually:

1. Check out this branch.
2. Modify Button Group's story so that more than one Button Group Button is selected initially.
3. Verify there's an error in the console.
<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
