### PR TITLE
Replace Label's Resize Observer with "mouseover"

### DIFF
--- a/src/label.test.interactions.ts
+++ b/src/label.test.interactions.ts
@@ -1,0 +1,25 @@
+import { assert, expect, fixture, html } from '@open-wc/testing';
+import GlideCoreLabel from './label.js';
+import GlideCoreTooltip from './tooltip.js';
+import { hover } from './library/mouse.js';
+
+it('shows a label tooltip on hover', async () => {
+  const host = await fixture<GlideCoreLabel>(
+    html`<glide-core-private-label label="Label">
+      <label for="input"> ${'x'.repeat(500)} </label>
+      <input id="input" slot="control" />
+    </glide-core-private-label>`,
+  );
+
+  const tooltip = host.shadowRoot
+    ?.querySelector<GlideCoreTooltip>('[data-test="label-tooltip"]')
+    ?.shadowRoot?.querySelector<HTMLElement>('[data-test="tooltip"]');
+
+  assert(tooltip);
+  tooltip.dataset.openDelay = '0';
+
+  const label = host.shadowRoot?.querySelector('[data-test="label"]');
+  await hover(label);
+
+  expect(tooltip.checkVisibility()).to.be.true;
+});

--- a/src/label.ts
+++ b/src/label.ts
@@ -268,7 +268,7 @@ export default class GlideCoreLabel extends LitElement {
       // `getBoundingClientRect()` is used so we're comparing apples to apples.
       //
       // `clientWidth` on `defaultSlotAssignedElement` is zero if the element is
-      // `display` is `inline`. The label, on the other hand, isn't inline.
+      // `display: inline`. The label, on the other hand, isn't inline.
       //
       // But `clientWidth` returns an integer and `getBoundingClientRect().width`
       // return a float. So using `clientWidth` with `#labelElementRef.value` would

--- a/src/label.ts
+++ b/src/label.ts
@@ -80,9 +80,15 @@ export default class GlideCoreLabel extends LitElement {
   label?: string;
 
   override render() {
-    // `aria-hidden` is used on the tooltip so the contents of the label
-    // aren't read twice to screen readers. The label is truncated using
-    // CSS. So the full text of the label is always available them.
+    // `aria-hidden` is used on the tooltip so the contents of the label aren't
+    // read twice to screen readers. The label is truncated using CSS. So the full
+    // text of the label is always available them.
+
+    // Lit-a11y doesn't know that we're only using a "mouseover" event to hide and
+    // show Tooltip, which is hidden from screenreaders because the truncated text
+    // is available to them without a tooltip.
+    //
+    /* eslint-disable lit-a11y/mouse-events-have-key-events */
     return html`<div
       class=${classMap({
         component: true,
@@ -129,6 +135,7 @@ export default class GlideCoreLabel extends LitElement {
 
         <glide-core-tooltip
           class="label-tooltip"
+          data-test="label-tooltip"
           label=${this.label ?? ''}
           placement="right"
           ?disabled=${!this.isLabelTooltip}
@@ -141,13 +148,10 @@ export default class GlideCoreLabel extends LitElement {
             })}
             data-test="label"
             slot="target"
+            @mouseover=${this.#onLabelMouseOver}
             ${ref(this.#labelElementRef)}
           >
-            <slot
-              @slotchange=${this.#onDefaultSlotChange}
-              ${assertSlot()}
-              ${ref(this.#defaultSlotElementRef)}
-            >
+            <slot ${assertSlot()} ${ref(this.#defaultSlotElementRef)}>
               <!-- @type {HTMLLabelElement} -->
             </slot>
           </div>
@@ -238,34 +242,6 @@ export default class GlideCoreLabel extends LitElement {
 
   #summarySlotElementRef = createRef<HTMLSlotElement>();
 
-  #onDefaultSlotChange() {
-    const defaultSlotAssignedElement = this.#defaultSlotElementRef.value
-      ?.assignedElements()
-      .at(0);
-
-    const observer = new ResizeObserver(() => {
-      // `getBoundingClientRect` is used so we're comparing apples to apples.
-      //
-      // `clientWidth` on `defaultSlotAssignedElement` is zero if the element
-      // is `display` is `inline`. `labelElement`, on the other hand, isn't
-      // inline.
-      //
-      // But `clientWidth` returns an integer and `getBoundingClientRect().width`
-      // return a float. So using `clientWidth` for `labelElement` would mean the
-      // width of `defaultSlotAssignedElement` is always fractionally greater than
-      // that of `labelElement`.
-      if (defaultSlotAssignedElement && this.#labelElementRef.value) {
-        this.isLabelTooltip =
-          defaultSlotAssignedElement.getBoundingClientRect().width >
-          this.#labelElementRef.value.getBoundingClientRect().width;
-      }
-    });
-
-    if (this.#labelElementRef.value) {
-      observer.observe(this.#labelElementRef.value);
-    }
-  }
-
   #onDescriptionSlotResize() {
     // The "description" slot has a top margin that needs to be conditionally
     // applied only if content is slotted so there's not stray whitespace
@@ -281,6 +257,27 @@ export default class GlideCoreLabel extends LitElement {
       this.#descriptionSlotElementRef.value &&
         this.#descriptionSlotElementRef.value.offsetHeight > 0,
     );
+  }
+
+  #onLabelMouseOver() {
+    const defaultSlotAssignedElement = this.#defaultSlotElementRef.value
+      ?.assignedElements()
+      .at(0);
+
+    if (defaultSlotAssignedElement && this.#labelElementRef.value) {
+      // `getBoundingClientRect()` is used so we're comparing apples to apples.
+      //
+      // `clientWidth` on `defaultSlotAssignedElement` is zero if the element is
+      // `display` is `inline`. The label, on the other hand, isn't inline.
+      //
+      // But `clientWidth` returns an integer and `getBoundingClientRect().width`
+      // return a float. So using `clientWidth` with `#labelElementRef.value` would
+      // mean the width of `defaultSlotAssignedElement` is always fractionally
+      // greater than that of `#labelElementRef.value`.
+      this.isLabelTooltip =
+        defaultSlotAssignedElement.getBoundingClientRect().width >
+        this.#labelElementRef.value.getBoundingClientRect().width;
+    }
   }
 
   #onSummarySlotChange() {

--- a/src/label.ts
+++ b/src/label.ts
@@ -82,7 +82,7 @@ export default class GlideCoreLabel extends LitElement {
   override render() {
     // `aria-hidden` is used on the tooltip so the contents of the label aren't
     // read twice to screen readers. The label is truncated using CSS. So the full
-    // text of the label is always available them.
+    // text of the label is always available to them.
 
     // Lit-a11y doesn't know that we're only using a "mouseover" event to hide and
     // show Tooltip, which is hidden from screenreaders because the truncated text


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

We haven't see performance issues with Resize Observer, so in a way this is a premature optimization. But it's not cheap, and it was excessive for Label to be taking measurements before it needed to.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to a form control in Storybook.
2. Give the control a `label` long enough that it's truncated.
3. Hover over the label.
4. Verify a tooltip is shown.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
