### PR TITLE
Tab Group bugfixes

### DIFF
--- a/.changeset/dull-queens-watch.md
+++ b/.changeset/dull-queens-watch.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Tab Panel and Tab's `id` and `role` attributes have always been set internally by those components for accessibility. Both attributes are now typed as read-only to signal they shouldn't be changed externally.

--- a/.changeset/silly-forks-juggle.md
+++ b/.changeset/silly-forks-juggle.md
@@ -1,0 +1,8 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Tab now updates the width of its selected indicator when a Tab's content changes.
+- Tab's selected indicator now spans the full width of Tab.
+- Tab Group no longer unnecessarily shows its overflow buttons when the content of a Tab is reduced.
+- Tab Panel and Tab are now accessibly labeled and associated with each other when they're added to Tab Group after initial render.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -7475,6 +7475,27 @@
               "readonly": true,
               "attribute": "version",
               "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "role",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "default": "'tabpanel'",
+              "attribute": "role",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "id",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "id",
+              "reflects": true
             }
           ],
           "attributes": [
@@ -7498,6 +7519,23 @@
               },
               "readonly": true,
               "fieldName": "version"
+            },
+            {
+              "name": "role",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "default": "'tabpanel'",
+              "fieldName": "role"
+            },
+            {
+              "name": "id",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "fieldName": "id"
             }
           ],
           "superclass": {
@@ -7613,6 +7651,27 @@
               "readonly": true,
               "attribute": "version",
               "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "id",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "id",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "role",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "default": "'tab'",
+              "attribute": "role",
+              "reflects": true
             }
           ],
           "events": [
@@ -7661,6 +7720,23 @@
               },
               "readonly": true,
               "fieldName": "version"
+            },
+            {
+              "name": "id",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "fieldName": "id"
+            },
+            {
+              "name": "role",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "default": "'tab'",
+              "fieldName": "role"
             }
           ],
           "superclass": {

--- a/src/tab.group.styles.ts
+++ b/src/tab.group.styles.ts
@@ -40,26 +40,24 @@ export default [
       @media (prefers-reduced-motion: no-preference) {
         scroll-behavior: smooth;
       }
+    }
 
-      &::after {
-        background: var(--glide-core-color-interactive-stroke-active);
-        block-size: 0.125rem;
-        content: '';
-        inline-size: var(--private-selected-tab-indicator-width);
-        inset-block-end: 0;
-        inset-inline: 0;
-        position: absolute;
-        transform-origin: left;
-        translate: var(--private-selected-tab-indicator-translate, 0) 0;
-      }
+    .selected-tab-indicator {
+      background: var(--glide-core-color-interactive-stroke-active);
+      block-size: 0.125rem;
+      content: '';
+      inline-size: var(--private-selected-tab-indicator-width);
+      inset-block-end: 0;
+      inset-inline: 0;
+      position: absolute;
+      transform-origin: left;
+      translate: var(--private-selected-tab-indicator-translate, 0) 0;
 
       &.animated {
         @media (prefers-reduced-motion: no-preference) {
-          &::after {
-            transition:
-              inline-size 250ms,
-              translate 250ms;
-          }
+          transition:
+            inline-size 250ms,
+            translate 250ms;
         }
       }
     }

--- a/src/tab.group.test.basics.ts
+++ b/src/tab.group.test.basics.ts
@@ -1,4 +1,5 @@
-import { expect, fixture, html } from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
+import { emulateMedia } from '@web/test-runner-commands';
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import TabGroup from './tab.group.js';
@@ -30,6 +31,35 @@ it('selects the first tab when none is selected', async () => {
 
   expect(tabs[0]?.selected).to.be.true;
   expect(tabs[1]?.selected).to.be.false;
+});
+
+it('sets the width of its selected tab indicator to that of the selected tab', async () => {
+  // The selected tab indicator transitions its width and position. The transitions
+  // are disabled to simplify and speed up the test.
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  const host = await fixture(html`
+    <glide-core-tab-group>
+      <glide-core-tab slot="nav" panel="1">One</glide-core-tab>
+      <glide-core-tab slot="nav" panel="2">Two</glide-core-tab>
+
+      <glide-core-tab-panel name="1">One</glide-core-tab-panel>
+      <glide-core-tab-panel name="2">Two</glide-core-tab-panel>
+    </glide-core-tab-group>
+  `);
+
+  const firstTab = host
+    .querySelector('glide-core-tab')
+    ?.shadowRoot?.querySelector('[data-test="component"]');
+
+  const selectedTabIndicator = host.shadowRoot?.querySelector(
+    '[data-test="selected-tab-indicator"]',
+  );
+
+  assert(firstTab);
+  assert(selectedTabIndicator);
+
+  expect(selectedTabIndicator.clientWidth).to.equal(firstTab.clientWidth);
 });
 
 it('throws when subclassed', async () => {

--- a/src/tab.panel.ts
+++ b/src/tab.panel.ts
@@ -18,6 +18,12 @@ declare global {
  * @attr {string} name - The corresponding Tab should have a `panel` attribute with this name
  *
  * @readonly
+ * @attr {string} [id]
+ *
+ * @readonly
+ * @attr {string} [role='tabpanel']
+ *
+ * @readonly
  * @attr {string} [version]
  *
  * @slot {Element | string} - The content of the panel
@@ -56,10 +62,11 @@ export default class TabPanel extends LitElement {
   @property({ reflect: true })
   readonly version: string = packageJson.version;
 
-  protected override firstUpdated() {
-    this.setAttribute('role', 'tabpanel');
-    this.id = this.#id;
-  }
+  @property({ reflect: true })
+  override readonly role = 'tabpanel';
+
+  @property({ reflect: true })
+  override readonly id: string = nanoid();
 
   override render() {
     return html`<div
@@ -78,8 +85,6 @@ export default class TabPanel extends LitElement {
       </slot>
     </div>`;
   }
-
-  #id = nanoid();
 
   #isSelected = false;
 }

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -17,6 +17,13 @@ declare global {
 /**
  * @attr {string} panel
  * @attr {boolean} [disabled=false]
+ *
+ * @readonly
+ * @attr {string} [id]
+ *
+ * @readonly
+ * @attr {string} [role='tab']
+ *
  * @attr {boolean} [selected=false]
  *
  * @readonly
@@ -67,10 +74,11 @@ export default class Tab extends LitElement {
   @property({ reflect: true })
   readonly version: string = packageJson.version;
 
-  protected override firstUpdated() {
-    this.setAttribute('role', 'tab');
-    this.id = this.#id;
-  }
+  @property({ reflect: true })
+  override readonly id: string = nanoid();
+
+  @property({ reflect: true })
+  override readonly role = 'tab';
 
   privateSelect() {
     this.selected = true;
@@ -86,6 +94,7 @@ export default class Tab extends LitElement {
         component: true,
         disabled: this.disabled,
       })}
+      data-test="component"
     >
       <div class="container">
         <slot name="icon">
@@ -118,8 +127,6 @@ export default class Tab extends LitElement {
       }
     }
   }
-
-  #id = nanoid();
 
   #isSelected = false;
 }


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->


> ### Minor
> Tab Panel and Tab's `id` and `role` attributes have always been set internally by those components for accessibility. Both attributes are now typed as read-only to signal they shouldn't be changed externally.

> ### Patch
> - Tab now updates the width of its selected indicator when a Tab's content changes.
> - Tab's selected indicator now spans the full width of Tab.
> - Tab Group no longer unnecessarily shows its overflow buttons when the content of a Tab is reduced.
> - Tab Panel and Tab are now accessibly labeled and associated with each other when they're added to Tab Group after initial render.


## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing


### Tab now updates the width of its selected indicator when a Tab's content changes

1. Navigate to Tab Group in Storybook.
2. Use DevTools to change the content of the selected Tab.
3. Verify the Tab's selected indicator updates to the Tab's new width.

### Tab's selected indicator now spans the full width of Tab

Take a look at the visual test report diffs.

### Tab Group no longer unnecessarily shows its overflow buttons when the content of a Tab is reduced


1. Navigate to Tab Group in Storybook.
2. Use DevTools to reduce the content of the selected Tab. Removing only a character or two will do.
3. Verify Tab Group's overflow buttons are not shown.

### Tab Panel and Tab are now accessibly labeled and associated with each other when they're added to Tab Group after initial render

This one's hard to test in Storybook because Lit often throws when a component's slot is changed by setting `innerHTML` on the host. But the test I added should have us covered.


<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
