### PR TITLE
Add the Slider component

### DIFF
--- a/.changeset/gorgeous-pillows-look.md
+++ b/.changeset/gorgeous-pillows-look.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Added a Slider component.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -6456,6 +6456,469 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/slider.styles.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "default",
+          "declaration": {
+            "module": "src/slider.styles.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/slider.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "Slider",
+          "slots": [
+            {
+              "name": "description",
+              "description": "Additional information or context",
+              "type": {
+                "text": "Element | string"
+              }
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "formAssociated",
+              "type": {
+                "text": "boolean"
+              },
+              "static": true,
+              "default": "true"
+            },
+            {
+              "kind": "field",
+              "name": "shadowRootOptions",
+              "type": {
+                "text": "ShadowRootInit"
+              },
+              "static": true,
+              "default": "{ ...LitElement.shadowRootOptions, mode: shadowRootMode, delegatesFocus: true, }"
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "attribute": "name",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "number[]"
+              },
+              "default": "[]",
+              "attribute": "value"
+            },
+            {
+              "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "label",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "orientation",
+              "default": "'vertical'",
+              "type": {
+                "text": "'vertical'"
+              },
+              "attribute": "orientation",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "hideLabel",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "hide-label"
+            },
+            {
+              "kind": "field",
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "required",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "readonly",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "readonly"
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "disabled",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "max",
+              "type": {
+                "text": "number"
+              },
+              "default": "100",
+              "attribute": "max",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "min",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "attribute": "min",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "multiple",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "multiple"
+            },
+            {
+              "kind": "field",
+              "name": "step",
+              "type": {
+                "text": "number"
+              },
+              "default": "1",
+              "attribute": "step",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "privateSplit",
+              "type": {
+                "text": "'left' | 'middle' | undefined"
+              },
+              "attribute": "privateSplit"
+            },
+            {
+              "kind": "field",
+              "name": "version",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "version",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "tooltip",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "form",
+              "type": {
+                "text": "HTMLFormElement | null"
+              },
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "validity",
+              "type": {
+                "text": "ValidityState"
+              },
+              "readonly": true
+            },
+            {
+              "kind": "method",
+              "name": "checkValidity",
+              "return": {
+                "type": {
+                  "text": "boolean"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "formAssociatedCallback",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "formResetCallback",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "reportValidity",
+              "return": {
+                "type": {
+                  "text": "boolean"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "resetValidityFeedback",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "setCustomValidity",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "message",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "setValidity",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "flags",
+                  "optional": true,
+                  "type": {
+                    "text": "ValidityStateFlags"
+                  }
+                },
+                {
+                  "name": "message",
+                  "optional": true,
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            }
+          ],
+          "events": [
+            {
+              "name": "input",
+              "type": {
+                "text": "Event"
+              }
+            },
+            {
+              "name": "change",
+              "type": {
+                "text": "Event"
+              }
+            },
+            {
+              "name": "invalid",
+              "type": {
+                "text": "Event"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "fieldName": "name"
+            },
+            {
+              "name": "value",
+              "type": {
+                "text": "number[]"
+              },
+              "default": "[]",
+              "fieldName": "value"
+            },
+            {
+              "name": "label",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "label",
+              "required": true
+            },
+            {
+              "name": "orientation",
+              "default": "'vertical'",
+              "type": {
+                "text": "'vertical'"
+              },
+              "fieldName": "orientation"
+            },
+            {
+              "name": "hide-label",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "hideLabel"
+            },
+            {
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "required"
+            },
+            {
+              "name": "readonly",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "readonly"
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "disabled"
+            },
+            {
+              "name": "max",
+              "type": {
+                "text": "number"
+              },
+              "default": "100",
+              "fieldName": "max"
+            },
+            {
+              "name": "min",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "fieldName": "min"
+            },
+            {
+              "name": "multiple",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "multiple"
+            },
+            {
+              "name": "step",
+              "type": {
+                "text": "number"
+              },
+              "default": "1",
+              "fieldName": "step"
+            },
+            {
+              "name": "privateSplit",
+              "type": {
+                "text": "'left' | 'middle' | undefined"
+              },
+              "fieldName": "privateSplit"
+            },
+            {
+              "name": "version",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "fieldName": "version"
+            },
+            {
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "tooltip"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "glide-core-slider",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "default",
+          "declaration": {
+            "name": "Slider",
+            "module": "src/slider.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "glide-core-slider",
+          "declaration": {
+            "name": "Slider",
+            "module": "src/slider.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/spinner.styles.ts",
       "declarations": [],
       "exports": [

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -3074,7 +3074,7 @@
               "name": "",
               "description": "",
               "type": {
-                "text": "Checkbox | CheckboxGroup | Dropdown | RadioGroup | Input | TextArea"
+                "text": "Checkbox | CheckboxGroup | Dropdown | Input | RadioGroup | Slider | TextArea"
               }
             }
           ],
@@ -6535,10 +6535,10 @@
             {
               "kind": "field",
               "name": "orientation",
-              "default": "'vertical'",
               "type": {
-                "text": "'vertical'"
+                "text": "'horizontal' | 'vertical'"
               },
+              "default": "'horizontal'",
               "attribute": "orientation",
               "reflects": true
             },
@@ -6797,10 +6797,10 @@
             },
             {
               "name": "orientation",
-              "default": "'vertical'",
               "type": {
-                "text": "'vertical'"
+                "text": "'horizontal' | 'vertical'"
               },
+              "default": "'horizontal'",
               "fieldName": "orientation"
             },
             {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "lint:production:stylelint": "tsc --noCheck --outDir ./dist && stylelint '**/*.styles.ts' --custom-syntax postcss-lit --no-color",
     "test": "per-env",
     "test:development": "npm-run-all --parallel test:development:web-test-runner test:development:web-test-runner:serve-coverage",
-    "test:development:playwright": "playwright test --quiet --ui-port 6007 --update-snapshots",
+    "test:development:playwright": "playwright test --quiet --ui-port 6007 --update-snapshots --update-source-method=overwrite",
     "test:development:playwright:update": "rimraf ./src/aria-snapshots && playwright test --quiet --project aria --update-snapshots --update-source-method=overwrite --workers 100%",
     "test:development:vitest": "vitest --config ./vitest.config.js & chokidar './src/eslint/**' './src/stylelint/**' --ignore './src/eslint/rules/*.test.ts' './src/stylelint/*.test.ts' --initial --silent --command 'tsc --noCheck --outDir ./dist'",
     "test:development:vitest:comment": "Excluded from `test:development` because Vitest muddies the console when running alongside Web Test Runner.",

--- a/src/figma/constants.ts
+++ b/src/figma/constants.ts
@@ -23,6 +23,7 @@ export const extendedVariables = [
   'Color/Radio/Icon/default--disabled',
   'Color/Skeleton Loader/Surface/linear-gradient-middle',
   'Color/Skeleton Loader/Surface/linear-gradient-sides',
+  'Color/Slider and Scrollbar/Surface/handle',
   'Color/Tabs/Stroke/underline',
   'Color/Template/Surface/container-detail',
   'Color/Tooltip/Surface/container',

--- a/src/form-controls-layout.stories.ts
+++ b/src/form-controls-layout.stories.ts
@@ -5,10 +5,11 @@ import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/web-components';
-import RadioGroupRadioComponent from './radio-group.radio.js';
 import CheckboxGroupComponent from './checkbox-group.js';
 import DropdownComponent from './dropdown.js';
 import InputComponent from './input.js';
+import RadioGroupRadioComponent from './radio-group.radio.js';
+import SliderComponent from './slider.js';
 import TextareaComponent from './textarea.js';
 
 const meta: Meta = {
@@ -41,11 +42,12 @@ const meta: Meta = {
     '<glide-core-checkbox-group>.value': [],
     '<glide-core-dropdown>.open': false,
     '<glide-core-dropdown>.value': [],
+    '<glide-core-input>.value': '',
     '<glide-core-radio-group>.value': '',
     '<glide-core-radio-group-radio>.one.checked': false,
     '<glide-core-radio-group-radio>.two.checked': false,
     '<glide-core-radio-group-radio>.three.checked': false,
-    '<glide-core-input>.value': '',
+    '<glide-core-slider>.value': [],
     '<glide-core-textarea>.value': '',
   },
   argTypes: {
@@ -53,7 +55,7 @@ const meta: Meta = {
       table: {
         type: {
           summary:
-            'Checkbox | CheckboxGroup | Dropdown | RadioGroup | Input | TextArea',
+            'Checkbox | CheckboxGroup | Dropdown | Input | RadioGroup | Slider | TextArea',
         },
       },
       type: { name: 'function', required: true },
@@ -111,6 +113,11 @@ const meta: Meta = {
       },
     },
     '<glide-core-radio-group-radio>.three.checked': {
+      table: {
+        disable: true,
+      },
+    },
+    '<glide-core-slider>.value': {
       table: {
         disable: true,
       },
@@ -200,6 +207,19 @@ const meta: Meta = {
         });
       }
     });
+
+    const slider = context.canvasElement.querySelector('glide-core-slider');
+
+    if (slider instanceof SliderComponent) {
+      slider.addEventListener('change', () => {
+        addons.getChannel().emit(UPDATE_STORY_ARGS, {
+          storyId: context.id,
+          updatedArgs: {
+            '<glide-core-slider>.value': slider.value,
+          },
+        });
+      });
+    }
 
     const textarea = context.canvasElement.querySelector('glide-core-textarea');
 
@@ -299,6 +319,11 @@ const meta: Meta = {
             ]}
           ></glide-core-radio-group-radio>
         </glide-core-radio-group>
+
+        <glide-core-slider
+          label="Label"
+          .value=${arguments_['<glide-core-slider>.value'] || nothing}
+        ></glide-core-slider>
 
         <glide-core-textarea
           label="Label"

--- a/src/form-controls-layout.ts
+++ b/src/form-controls-layout.ts
@@ -5,8 +5,9 @@ import packageJson from '../package.json' with { type: 'json' };
 import Checkbox from './checkbox.js';
 import CheckboxGroup from './checkbox-group.js';
 import Dropdown from './dropdown.js';
-import RadioGroup from './radio-group.js';
 import Input from './input.js';
+import RadioGroup from './radio-group.js';
+import Slider from './slider.js';
 import TextArea from './textarea.js';
 import styles from './form-controls-layout.styles.js';
 import assertSlot from './library/assert-slot.js';
@@ -25,7 +26,7 @@ declare global {
  * @readonly
  * @attr {string} [version]
  *
- * @slot {Checkbox | CheckboxGroup | Dropdown | RadioGroup | Input | TextArea}
+ * @slot {Checkbox | CheckboxGroup | Dropdown | Input | RadioGroup | Slider | TextArea}
  */
 @customElement('glide-core-form-controls-layout')
 @final
@@ -68,13 +69,14 @@ export default class FormControlsLayout extends LitElement {
           Checkbox,
           CheckboxGroup,
           Dropdown,
-          RadioGroup,
           Input,
+          RadioGroup,
+          Slider,
           TextArea,
         ])}
         ${ref(this.#slotElementRef)}
       >
-        <!-- @type {Checkbox | CheckboxGroup | Dropdown | RadioGroup | Input | TextArea} -->
+        <!-- @type {Checkbox | CheckboxGroup | Dropdown | Input | RadioGroup | Slider | TextArea} -->
       </slot>
     </div>`;
   }

--- a/src/input.test.forms.ts
+++ b/src/input.test.forms.ts
@@ -36,7 +36,7 @@ it('can be reset if there was no initial value', async () => {
   expect(host.value).to.be.empty.string;
 });
 
-it('has `formData` value when it has a value', async () => {
+it('has a `formData` value when it has a value', async () => {
   const form = document.createElement('form');
 
   await fixture<Input>(
@@ -68,7 +68,7 @@ it('has no `formData` value when no value', async () => {
   expect(formData.get('name')).to.be.null;
 });
 
-it('has no `formData` value when it has a value but disabled', async () => {
+it('has no `formData` value when it has a value but is disabled', async () => {
   const form = document.createElement('form');
 
   await fixture<Input>(
@@ -87,7 +87,7 @@ it('has no `formData` value when it has a value but disabled', async () => {
   expect(formData.get('name')).to.be.null;
 });
 
-it('has no `formData` value when it has a value but without a `name`', async () => {
+it('has no `formData` value when it has a value but no `name`', async () => {
   const form = document.createElement('form');
 
   await fixture<Input>(

--- a/src/input.test.forms.ts
+++ b/src/input.test.forms.ts
@@ -36,7 +36,7 @@ it('can be reset if there was no initial value', async () => {
   expect(host.value).to.be.empty.string;
 });
 
-it('has `formData` value when it has a value', async () => {
+it('has a `formData` value when it has a value', async () => {
   const form = document.createElement('form');
 
   await fixture<Input>(

--- a/src/input.test.forms.ts
+++ b/src/input.test.forms.ts
@@ -36,7 +36,7 @@ it('can be reset if there was no initial value', async () => {
   expect(host.value).to.be.empty.string;
 });
 
-it('has a `formData` value when it has a value', async () => {
+it('has `formData` value when it has a value', async () => {
   const form = document.createElement('form');
 
   await fixture<Input>(

--- a/src/library/form-control.ts
+++ b/src/library/form-control.ts
@@ -10,7 +10,7 @@ export default interface FormControl {
   summary?: string;
   tooltip?: string;
   validity: ValidityState;
-  value: string | string[];
+  value: string | string[] | number[];
   checkValidity(): boolean;
   formAssociatedCallback(): void;
   formResetCallback(): void;

--- a/src/library/localize.ts
+++ b/src/library/localize.ts
@@ -43,4 +43,8 @@ export interface Translation extends DefaultTranslation {
   editTag: (name: string) => string;
   removeTag: (name: string) => string;
   itemCount: (count: string) => string;
+  maximum: (label: string) => string;
+  setMaximum: (label: string) => string;
+  minimum: (label: string) => string;
+  setMinimum: (label: string) => string;
 }

--- a/src/slider.stories.ts
+++ b/src/slider.stories.ts
@@ -89,11 +89,13 @@ const meta: Meta = {
       <glide-core-slider
         label=${arguments_.label || nothing}
         name=${arguments_.name || nothing}
-        orientation=${arguments_.orientation}
+        orientation=${arguments_.orientation === 'horizontal'
+          ? nothing
+          : arguments_.orientation}
         tooltip=${arguments_.tooltip || nothing}
         min=${arguments_.min || nothing}
         max=${arguments_.max || nothing}
-        step=${arguments_.step}
+        step=${arguments_.step === 1 ? nothing : arguments_.step}
         ?disabled=${arguments_.disabled}
         ?hide-label=${arguments_['hide-label']}
         ?multiple=${arguments_.multiple}

--- a/src/slider.stories.ts
+++ b/src/slider.stories.ts
@@ -150,15 +150,17 @@ const meta: Meta = {
       },
     },
     max: {
+      control: 'number',
       table: {
         defaultValue: { summary: '100' },
-        type: { summary: 'string' },
+        type: { summary: 'number' },
       },
     },
     min: {
+      control: 'number',
       table: {
         defaultValue: { summary: '0' },
-        type: { summary: 'string' },
+        type: { summary: 'number' },
       },
     },
     multiple: {
@@ -240,9 +242,10 @@ const meta: Meta = {
       },
     },
     step: {
+      control: 'number',
       table: {
-        defaultValue: { summary: '"1"' },
-        type: { summary: 'string' },
+        defaultValue: { summary: '1' },
+        type: { summary: 'number' },
       },
     },
     tooltip: {

--- a/src/slider.stories.ts
+++ b/src/slider.stories.ts
@@ -1,4 +1,3 @@
-import './icons/storybook.js';
 import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
@@ -57,10 +56,9 @@ const meta: Meta = {
     const slider = context.canvasElement.querySelector('glide-core-slider');
 
     if (context.name.includes('Error') && slider instanceof SliderComponent) {
-      // Slider is a bit unique in that it always
-      // has a `value` set. To force an error state,
-      // we have to use `setCustomValidity`.
-      slider.setCustomValidity('Error');
+      // Slider is a bit unique in that it always has a `value` set. To force an error
+      // state, we have to use `setCustomValidity`.
+      slider.setCustomValidity('Invalid');
       slider.reportValidity();
 
       // `reportValidity` scrolls the element into view, which means the "autodocs"
@@ -151,13 +149,13 @@ const meta: Meta = {
     },
     max: {
       table: {
-        defaultValue: { summary: '"100"' },
+        defaultValue: { summary: '100' },
         type: { summary: 'string' },
       },
     },
     min: {
       table: {
-        defaultValue: { summary: '"0"' },
+        defaultValue: { summary: '0' },
         type: { summary: 'string' },
       },
     },

--- a/src/slider.stories.ts
+++ b/src/slider.stories.ts
@@ -1,0 +1,269 @@
+import './icons/storybook.js';
+import { html, nothing } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { withActions } from '@storybook/addon-actions/decorator';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import SliderComponent from './slider.js';
+
+const meta: Meta = {
+  title: 'Slider',
+  decorators: [
+    withActions,
+    (story) =>
+      html`<form action="/">
+        <script type="ignore">
+          import '@crowdstrike/glide-core/slider.js';
+        </script>
+
+        ${story()}
+      </form>`,
+  ],
+  parameters: {
+    actions: {
+      handles: ['change', 'input', 'invalid'],
+    },
+    docs: {
+      story: {
+        autoplay: true,
+      },
+    },
+  },
+  args: {
+    label: 'Label',
+    'addEventListener(event, handler)': '',
+    'checkValidity()': '',
+    disabled: false,
+    'hide-label': false,
+    max: '',
+    min: '',
+    multiple: false,
+    name: '',
+    orientation: 'horizontal',
+    readonly: false,
+    'reportValidity()': '',
+    required: false,
+    'resetValidityFeedback()': '',
+    'setCustomValidity(message)': '',
+    'setValidity(flags, message)': '',
+    'slot="description"': '',
+    step: 1,
+    tooltip: '',
+    value: [],
+    version: '',
+  },
+  play(context) {
+    const slider = context.canvasElement.querySelector('glide-core-slider');
+
+    if (context.name.includes('Error') && slider instanceof SliderComponent) {
+      // Slider is a bit unique in that it always
+      // has a `value` set. To force an error state,
+      // we have to use `setCustomValidity`.
+      slider.setCustomValidity('error');
+      slider.reportValidity();
+
+      // `reportValidity` scrolls the element into view, which means the "autodocs"
+      // story upon load will be scrolled to the first error story. No good.
+      document.documentElement.scrollTop = 0;
+
+      if (document.activeElement instanceof HTMLElement) {
+        // Calling `reportValidity()` focuses the element. Focus is expected to be
+        // on `document.body` on page load.
+        document.activeElement.blur();
+      }
+    }
+  },
+  render(arguments_) {
+    /* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/prefer-nullish-coalescing */
+    return html`
+      <glide-core-slider
+        label=${arguments_.label || nothing}
+        name=${arguments_.name || nothing}
+        orientation=${arguments_.orientation}
+        tooltip=${arguments_.tooltip || nothing}
+        min=${arguments_.min || nothing}
+        max=${arguments_.max || nothing}
+        step=${arguments_.step}
+        ?disabled=${arguments_.disabled}
+        ?hide-label=${arguments_['hide-label']}
+        ?multiple=${arguments_.multiple}
+        ?required=${arguments_.required}
+        ?readonly=${arguments_.readonly}
+        .value=${arguments_.value}
+      >
+        ${arguments_['slot="description"']
+          ? html`<div slot="description">
+              ${unsafeHTML(arguments_['slot="description"'])}
+            </div>`
+          : nothing}
+      </glide-core-slider>
+    `;
+  },
+  argTypes: {
+    label: {
+      table: {
+        type: { summary: 'string' },
+      },
+      type: { name: 'string', required: true },
+    },
+    'addEventListener(event, handler)': {
+      control: false,
+      table: {
+        type: {
+          summary: 'method',
+          detail:
+            '(event: "change" | "input" | "invalid", handler: (event: Event) => void): void',
+        },
+      },
+    },
+    'checkValidity()': {
+      control: false,
+      table: {
+        type: {
+          summary: 'method',
+          detail: '(): boolean',
+        },
+      },
+    },
+    disabled: {
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    'hide-label': {
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    max: {
+      table: {
+        defaultValue: { summary: '"100"' },
+        type: { summary: 'string' },
+      },
+    },
+    min: {
+      table: {
+        defaultValue: { summary: '"0"' },
+        type: { summary: 'string' },
+      },
+    },
+    multiple: {
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    name: {
+      table: {
+        defaultValue: { summary: '""' },
+        type: { summary: 'string' },
+      },
+    },
+    orientation: {
+      control: false,
+      defaultValue: 'horizontal',
+      table: {
+        defaultValue: { summary: '"horizontal"' },
+        type: { summary: '"horizontal"' },
+      },
+    },
+    required: {
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    readonly: {
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    'reportValidity()': {
+      control: false,
+      table: {
+        type: {
+          summary: 'method',
+          detail: '(): boolean',
+        },
+      },
+    },
+    'resetValidityFeedback()': {
+      control: false,
+      table: {
+        type: {
+          summary: 'method',
+          detail: `
+(): void
+
+// Clears the validity feedback message and styling while maintaining the state of the component's\n// \`validity\` property.
+          `,
+        },
+      },
+    },
+    'setCustomValidity(message)': {
+      control: false,
+      table: {
+        type: {
+          summary: 'method',
+          detail: '(message: string): void',
+        },
+      },
+    },
+    'setValidity(flags, message)': {
+      control: false,
+      table: {
+        type: {
+          summary: 'method',
+          detail: '(flags?: ValidityStateFlags, message?: string): void',
+        },
+      },
+    },
+    'slot="description"': {
+      table: {
+        type: { summary: 'Element' },
+      },
+    },
+    step: {
+      table: {
+        defaultValue: { summary: '"1"' },
+        type: { summary: 'string' },
+      },
+    },
+    tooltip: {
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    value: {
+      table: {
+        defaultValue: { summary: '[]' },
+        type: {
+          summary: 'string[]',
+        },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_GLIDE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
+  },
+};
+
+export default meta;
+
+export const Slider: StoryObj = {
+  tags: ['!autodocs'],
+};
+
+export const WithError: StoryObj = {
+  args: {
+    required: true,
+  },
+};

--- a/src/slider.stories.ts
+++ b/src/slider.stories.ts
@@ -1,4 +1,6 @@
 import './icons/storybook.js';
+import { UPDATE_STORY_ARGS } from '@storybook/core-events';
+import { addons } from '@storybook/preview-api';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { withActions } from '@storybook/addon-actions/decorator';
@@ -58,7 +60,7 @@ const meta: Meta = {
       // Slider is a bit unique in that it always
       // has a `value` set. To force an error state,
       // we have to use `setCustomValidity`.
-      slider.setCustomValidity('error');
+      slider.setCustomValidity('Error');
       slider.reportValidity();
 
       // `reportValidity` scrolls the element into view, which means the "autodocs"
@@ -70,6 +72,17 @@ const meta: Meta = {
         // on `document.body` on page load.
         document.activeElement.blur();
       }
+    }
+
+    if (slider instanceof SliderComponent) {
+      slider.addEventListener('change', () => {
+        addons.getChannel().emit(UPDATE_STORY_ARGS, {
+          storyId: context.id,
+          updatedArgs: {
+            value: slider.value,
+          },
+        });
+      });
     }
   },
   render(arguments_) {
@@ -161,11 +174,12 @@ const meta: Meta = {
       },
     },
     orientation: {
-      control: false,
+      control: { type: 'radio' },
+      options: ['horizontal', 'vertical'],
       defaultValue: 'horizontal',
       table: {
         defaultValue: { summary: '"horizontal"' },
-        type: { summary: '"horizontal"' },
+        type: { summary: '"horizontal" | "vertical"' },
       },
     },
     required: {
@@ -240,7 +254,7 @@ const meta: Meta = {
       table: {
         defaultValue: { summary: '[]' },
         type: {
-          summary: 'string[]',
+          summary: 'number[]',
         },
       },
     },

--- a/src/slider.styles.ts
+++ b/src/slider.styles.ts
@@ -71,18 +71,6 @@ export default [
       }
     }
 
-    .open-track {
-      background-color: var(--glide-core-color-static-stroke-primary);
-      block-size: 0.375rem;
-      border-radius: var(--glide-core-rounding-base-radius-round);
-      inline-size: 100%;
-      position: relative;
-
-      &.disabled {
-        background-color: var(--glide-core-color-static-stroke-secondary);
-      }
-    }
-
     .filled-track {
       background-color: var(
         --glide-core-color-interactive-surface-container-active
@@ -91,9 +79,8 @@ export default [
       border-radius: var(--glide-core-rounding-base-radius-round);
 
       /*
-        Absolute positioning is required here, as we use JavaScript
-        to fill the track based on how the user interacts with the
-        component.
+        Absolute positioning is required here, as JavaScript is
+        used to fill it as the user interacts with the component.
       */
       position: absolute;
 
@@ -101,6 +88,18 @@ export default [
         background-color: var(
           --glide-core-color-interactive-surface-container-inactive
         );
+      }
+    }
+
+    .unfilled-track {
+      background-color: var(--glide-core-color-static-stroke-primary);
+      block-size: 0.375rem;
+      border-radius: var(--glide-core-rounding-base-radius-round);
+      inline-size: 100%;
+      position: relative;
+
+      &.disabled {
+        background-color: var(--glide-core-color-static-stroke-secondary);
       }
     }
 

--- a/src/slider.styles.ts
+++ b/src/slider.styles.ts
@@ -12,6 +12,8 @@ export default [
     }
 
     .slider-container {
+      --private-track-size: 0.375rem;
+
       align-items: center;
       display: flex;
       gap: var(--glide-core-spacing-base-md);
@@ -72,6 +74,13 @@ export default [
       min-inline-size: 0;
 
       &.single {
+        /*
+            Without this suggestion from design, when the handle
+            is at the min, it would overflow the container and
+            not align with label. This isn't needed in multiple
+            mode because we have an input to help prevent this
+            from happening.
+         */
         padding-inline-start: var(--glide-core-spacing-base-sm);
       }
     }
@@ -80,7 +89,7 @@ export default [
       background-color: var(
         --glide-core-color-interactive-surface-container-active
       );
-      block-size: 0.375rem;
+      block-size: var(--private-track-size);
       border-radius: var(--glide-core-rounding-base-radius-round);
 
       /*
@@ -98,7 +107,7 @@ export default [
 
     .unfilled-track {
       background-color: var(--glide-core-color-static-stroke-primary);
-      block-size: 0.375rem;
+      block-size: var(--private-track-size);
       border-radius: var(--glide-core-rounding-base-radius-round);
       inline-size: 100%;
       position: relative;

--- a/src/slider.styles.ts
+++ b/src/slider.styles.ts
@@ -59,8 +59,9 @@ export default [
       }
 
       /*
-        We had to resort to a class selector because there may be a bug in Chrome and Safari
-        with ":read-only": https://bugs.chromium.org/p/chromium/issues/detail?id=1519649
+        We had to resort to a class selector because there may be a
+        bug in Chrome and Safari with ":read-only":
+        https://bugs.chromium.org/p/chromium/issues/detail?id=1519649
       */
       &.readonly {
         background-color: transparent;
@@ -70,16 +71,16 @@ export default [
     }
 
     .track-container {
-      flex: 1;
+      flex-grow: 1;
       min-inline-size: 0;
 
       &.single {
         /*
-            Without this suggestion from design, when the handle
-            is at the min, it would overflow the container and
-            not align with label. This isn't needed in multiple
-            mode because we have an input to help prevent this
-            from happening.
+            Without this suggestion from design, when the handle is
+            at the min, it would overflow the container and not
+            align with label. This isn't needed in multiple mode
+            because we have an input to help prevent this from
+            happening.
          */
         padding-inline-start: var(--glide-core-spacing-base-sm);
       }
@@ -134,8 +135,7 @@ export default [
         border 150ms ease-in-out,
         box-shadow 150ms ease-in-out;
 
-      &:not(.disabled, .readonly):active,
-      &:not(.disabled, .readonly):hover {
+      &:not(.disabled, .readonly):is(:active, :hover) {
         border: 4px solid var(--glide-core-color-interactive-stroke-active);
         box-shadow: var(--glide-core-effect-hovered);
       }

--- a/src/slider.styles.ts
+++ b/src/slider.styles.ts
@@ -1,0 +1,161 @@
+import { css } from 'lit';
+import focusOutline from './styles/focus-outline.js';
+
+export default [
+  css`
+    ${focusOutline('.handle:focus-visible')}
+  `,
+  css`
+    .slider-container {
+      align-items: center;
+      display: flex;
+      gap: var(--glide-core-spacing-base-md);
+      inline-size: 100%;
+      justify-content: space-between;
+    }
+
+    .input {
+      /* stylelint-disable-next-line property-no-vendor-prefix */
+      -moz-appearance: textfield;
+      background-color: var(--glide-core-color-interactive-surface-container);
+      border: 1px solid var(--glide-core-color-interactive-stroke-primary);
+      border-radius: var(--glide-core-rounding-base-radius-sm);
+      inline-size: 1.5rem;
+      padding-block: 0.4688rem;
+      padding-inline: var(--glide-core-spacing-base-sm);
+      text-align: center;
+
+      &::-webkit-outer-spin-button,
+      &::-webkit-inner-spin-button {
+        appearance: none;
+      }
+
+      &:focus,
+      &:hover {
+        border-color: var(--glide-core-color-interactive-stroke-primary--hover);
+        outline: none;
+        transition: border-color 200ms ease-in-out;
+      }
+
+      &.disabled {
+        background-color: var(
+          --glide-core-color-interactive-surface-container--disabled
+        );
+        border-color: var(
+          --glide-core-color-interactive-stroke-primary--disabled
+        );
+        color: var(--glide-core-color-interactive-text-default--disabled);
+      }
+
+      &.error {
+        border-color: var(--glide-core-color-advisory-stroke-error-primary);
+      }
+
+      /*
+        We had to resort to a class selector because there may be a bug in Chrome and Safari
+        with ":read-only": https://bugs.chromium.org/p/chromium/issues/detail?id=1519649
+      */
+      &.readonly {
+        background-color: transparent;
+        border: 1px solid transparent;
+        padding-inline-start: 0;
+      }
+    }
+
+    .slider-wrapper {
+      flex: 1;
+      min-inline-size: 0;
+
+      &.single {
+        padding-inline-start: var(--glide-core-spacing-base-sm);
+      }
+    }
+
+    .open-track {
+      background-color: var(--glide-core-color-static-stroke-primary);
+      block-size: 0.375rem;
+      border-radius: var(--glide-core-rounding-base-radius-round);
+      inline-size: 100%;
+      position: relative;
+
+      &.disabled {
+        background-color: var(--glide-core-color-static-stroke-secondary);
+      }
+    }
+
+    .filled-track {
+      background-color: var(
+        --glide-core-color-interactive-surface-container-active
+      );
+      block-size: 0.375rem;
+      border-radius: var(--glide-core-rounding-base-radius-round);
+
+      /*
+        Absolute positioning is required here, as we use JavaScript
+        to fill the track based on how the user interacts with the
+        component.
+      */
+      position: absolute;
+
+      &.disabled {
+        background-color: var(
+          --glide-core-color-interactive-surface-container-inactive
+        );
+      }
+    }
+
+    .handle {
+      background-color: var(
+        --glide-core-private-color-slider-and-scrollbar-surface-handle
+      );
+      block-size: 1.5rem;
+      border: 2px solid var(--glide-core-color-interactive-stroke-active);
+      border-radius: var(--glide-core-rounding-base-radius-round);
+      box-sizing: border-box;
+      cursor: pointer;
+      inline-size: 1.5rem;
+      inset-block-start: 50%;
+      position: absolute;
+      transform: translate(-50%, -50%);
+      transition:
+        border 150ms ease-in-out,
+        box-shadow 150ms ease-in-out;
+
+      &:not(.disabled, .readonly):active,
+      &:not(.disabled, .readonly):hover {
+        border: 4px solid var(--glide-core-color-interactive-stroke-active);
+        box-shadow: var(--glide-core-effect-hovered);
+      }
+
+      &.disabled {
+        border-color: var(--glide-core-color-interactive-stroke-primary);
+        cursor: not-allowed;
+        transition: none;
+      }
+
+      &.readonly {
+        transition: none;
+      }
+    }
+
+    .meta {
+      column-gap: var(--glide-core-spacing-base-xs);
+      display: flex;
+      font-size: var(--glide-core-typography-size-body-small);
+      grid-column: 2;
+      justify-content: space-between;
+    }
+
+    .description {
+      display: block;
+
+      &.hidden {
+        display: none;
+      }
+    }
+
+    .validity-message {
+      display: block;
+    }
+  `,
+];

--- a/src/slider.styles.ts
+++ b/src/slider.styles.ts
@@ -6,6 +6,11 @@ export default [
     ${focusOutline('.handle:focus-visible')}
   `,
   css`
+    /* The designs call for a bit more spacing than the default when vertical. */
+    glide-core-private-label[orientation='vertical']::part(private-tooltips) {
+      margin-block-end: var(--glide-core-spacing-base-xxs);
+    }
+
     .slider-container {
       align-items: center;
       display: flex;
@@ -62,7 +67,7 @@ export default [
       }
     }
 
-    .slider-wrapper {
+    .track-container {
       flex: 1;
       min-inline-size: 0;
 

--- a/src/slider.styles.ts
+++ b/src/slider.styles.ts
@@ -18,11 +18,11 @@ export default [
       /* stylelint-disable-next-line property-no-vendor-prefix */
       -moz-appearance: textfield;
       background-color: var(--glide-core-color-interactive-surface-container);
+      block-size: 2.125rem;
       border: 1px solid var(--glide-core-color-interactive-stroke-primary);
       border-radius: var(--glide-core-rounding-base-radius-sm);
-      inline-size: 1.5rem;
-      padding-block: 0.4688rem;
-      padding-inline: var(--glide-core-spacing-base-sm);
+      box-sizing: border-box;
+      inline-size: 2.125rem;
       text-align: center;
 
       &::-webkit-outer-spin-button,

--- a/src/slider.test.aria.ts
+++ b/src/slider.test.aria.ts
@@ -1,6 +1,45 @@
 import { expect, test } from '@playwright/test';
 import type Slider from './slider.js';
 
+test.describe('disabled', () => {
+  test('multiple=${true}', async ({ page }) => {
+    await page.goto('?id=slider--slider');
+
+    await page
+      .locator('glide-core-slider')
+      .evaluate<void, Slider>((element) => {
+        element.disabled = true;
+        element.multiple = true;
+      });
+
+    await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
+      - text: Label
+      - spinbutton "Set minimum Label" [disabled]
+      - group:
+        - slider "Minimum Label" [disabled]
+        - slider "Maximum Label" [disabled]
+      - spinbutton "Set maximum Label" [disabled]
+    `);
+  });
+
+  test('multiple=${false}', async ({ page }) => {
+    await page.goto('?id=slider--slider');
+
+    await page
+      .locator('glide-core-slider')
+      .evaluate<void, Slider>((element) => {
+        element.disabled = true;
+      });
+
+    await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
+      - text: Label
+      - group:
+        - slider "Label" [disabled]
+      - spinbutton "Label" [disabled]
+    `);
+  });
+});
+
 test('hide-label', async ({ page }) => {
   await page.goto('?id=slider--slider');
 
@@ -33,35 +72,15 @@ test('multiple', async ({ page }) => {
   `);
 });
 
-test.describe('multiple=${true}', () => {
-  test('disabled', async ({ page }) => {
+test.describe('readonly', () => {
+  test('multiple=${true}', async ({ page }) => {
     await page.goto('?id=slider--slider');
 
     await page
       .locator('glide-core-slider')
       .evaluate<void, Slider>((element) => {
-        element.multiple = true;
-        element.disabled = true;
-      });
-
-    await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
-      - text: Label
-      - spinbutton "Set minimum Label" [disabled]
-      - group:
-        - slider "Minimum Label" [disabled]
-        - slider "Maximum Label" [disabled]
-      - spinbutton "Set maximum Label" [disabled]
-    `);
-  });
-
-  test('readonly', async ({ page }) => {
-    await page.goto('?id=slider--slider');
-
-    await page
-      .locator('glide-core-slider')
-      .evaluate<void, Slider>((element) => {
-        element.multiple = true;
         element.readonly = true;
+        element.multiple = true;
       });
 
     await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
@@ -73,27 +92,8 @@ test.describe('multiple=${true}', () => {
       - spinbutton "Set maximum Label"
     `);
   });
-});
 
-test.describe('multiple=${false}', () => {
-  test('disabled', async ({ page }) => {
-    await page.goto('?id=slider--slider');
-
-    await page
-      .locator('glide-core-slider')
-      .evaluate<void, Slider>((element) => {
-        element.disabled = true;
-      });
-
-    await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
-      - text: Label
-      - group:
-        - slider "Label" [disabled]
-      - spinbutton "Label" [disabled]
-    `);
-  });
-
-  test('readonly', async ({ page }) => {
+  test('multiple=${false}', async ({ page }) => {
     await page.goto('?id=slider--slider');
 
     await page

--- a/src/slider.test.aria.ts
+++ b/src/slider.test.aria.ts
@@ -1,0 +1,152 @@
+import { expect, test } from '@playwright/test';
+import type Slider from './slider.js';
+
+test('hide-label', async ({ page }) => {
+  await page.goto('?id=slider--slider');
+
+  await page.locator('glide-core-slider').evaluate<void, Slider>((element) => {
+    element.hideLabel = true;
+  });
+
+  await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
+    - text: Label
+    - group:
+      - slider "Label"
+    - spinbutton "Label"
+  `);
+});
+
+test('multiple', async ({ page }) => {
+  await page.goto('?id=slider--slider');
+
+  await page.locator('glide-core-slider').evaluate<void, Slider>((element) => {
+    element.multiple = true;
+  });
+
+  await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
+    - text: Label
+    - spinbutton "Set minimum Label"
+    - group:
+      - slider "Minimum Label"
+      - slider "Maximum Label"
+    - spinbutton "Set maximum Label"
+  `);
+});
+
+test.describe('multiple=${true}', () => {
+  test('disabled', async ({ page }) => {
+    await page.goto('?id=slider--slider');
+
+    await page
+      .locator('glide-core-slider')
+      .evaluate<void, Slider>((element) => {
+        element.multiple = true;
+        element.disabled = true;
+      });
+
+    await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
+      - text: Label
+      - spinbutton "Set minimum Label" [disabled]
+      - group:
+        - slider "Minimum Label" [disabled]
+        - slider "Maximum Label" [disabled]
+      - spinbutton "Set maximum Label" [disabled]
+    `);
+  });
+
+  test('readonly', async ({ page }) => {
+    await page.goto('?id=slider--slider');
+
+    await page
+      .locator('glide-core-slider')
+      .evaluate<void, Slider>((element) => {
+        element.multiple = true;
+        element.readonly = true;
+      });
+
+    await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
+      - text: Label
+      - spinbutton "Set minimum Label"
+      - group:
+        - slider "Minimum Label"
+        - slider "Maximum Label"
+      - spinbutton "Set maximum Label"
+    `);
+  });
+});
+
+test.describe('multiple=${false}', () => {
+  test('disabled', async ({ page }) => {
+    await page.goto('?id=slider--slider');
+
+    await page
+      .locator('glide-core-slider')
+      .evaluate<void, Slider>((element) => {
+        element.disabled = true;
+      });
+
+    await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
+      - text: Label
+      - group:
+        - slider "Label" [disabled]
+      - spinbutton "Label" [disabled]
+    `);
+  });
+
+  test('readonly', async ({ page }) => {
+    await page.goto('?id=slider--slider');
+
+    await page
+      .locator('glide-core-slider')
+      .evaluate<void, Slider>((element) => {
+        element.readonly = true;
+      });
+
+    await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
+      - text: Label
+      - group:
+        - slider "Label"
+      - spinbutton "Label"
+    `);
+  });
+});
+
+test('slot="description"', async ({ page }) => {
+  await page.goto('?id=slider--slider');
+
+  await page.locator('glide-core-slider').evaluate<void, Slider>((element) => {
+    const div = document.createElement('div');
+
+    div.textContent = 'Description';
+    div.slot = 'description';
+
+    element.append(div);
+  });
+
+  await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
+    - text: Label
+    - group:
+      - slider "Label"
+    - spinbutton "Label"
+    - text: Description
+  `);
+});
+
+test('tooltip', async ({ page }) => {
+  await page.goto('?id=slider--slider');
+
+  await page.locator('glide-core-slider').evaluate<void, Slider>((element) => {
+    element.tooltip = 'Tooltip';
+  });
+
+  await page.locator('glide-core-tooltip').getByRole('button').focus();
+
+  await expect(page.locator('glide-core-slider')).toMatchAriaSnapshot(`
+    - button "Tooltip:"
+    - tooltip "Tooltip"
+    - text: Label
+    - group:
+      - slider "Label"
+    - spinbutton "Label"
+  `);
+});

--- a/src/slider.test.basics.multiple.ts
+++ b/src/slider.test.basics.multiple.ts
@@ -43,7 +43,7 @@ it('sets the value of its <input>s from `value`', async () => {
   expect(maximumInput?.value).to.equal('99');
 });
 
-it('uses "min" to set "min" on the minimum-input', async () => {
+it('sets `min` on the minimum input', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -59,23 +59,7 @@ it('uses "min" to set "min" on the minimum-input', async () => {
   expect(minimumInput?.min).to.equal('10');
 });
 
-it('sets "min"', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      min="10"
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="minimum-input"]',
-  );
-
-  expect(minimumInput?.min).to.equal('10');
-});
-
-it('sets "max"', async () => {
+it('sets `max` on the maximum input', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -89,4 +73,283 @@ it('sets "max"', async () => {
   );
 
   expect(maximumInput?.max).to.equal('99');
+});
+
+it('sets `min` on the maximum input based on the current minimum value + `step`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="20"
+      .value=${[20, 60]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(maximumInput?.getAttribute('min')).to.equal('40');
+});
+
+it('sets `step` on the minimum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  expect(minimumInput?.getAttribute('step')).to.equal('10');
+});
+
+it('sets `step` on the maximum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(maximumInput?.getAttribute('step')).to.equal('10');
+});
+
+it('sets `max` on the maximum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="200"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(maximumInput?.getAttribute('max')).to.equal('200');
+});
+
+it('sets `max` on the minimum input based on the current maximum value - `step`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="20"
+      .value=${[20, 60]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  expect(minimumInput?.getAttribute('max')).to.equal('40');
+});
+
+it('sets `aria-valuemin` on the minimum handle as `min`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      min="20"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  expect(minimumHandle?.getAttribute('aria-valuemin')).to.equal('20');
+});
+
+it('sets `aria-valuemin` on the maximum handle as `min`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      min="20"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  expect(maximumHandle?.getAttribute('aria-valuemin')).to.equal('20');
+});
+
+it('sets `aria-valuemax` on the minimum handle as `max`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="200"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  expect(minimumHandle?.getAttribute('aria-valuemax')).to.equal('200');
+});
+
+it('sets `aria-valuemax` on the maximum handle as `max`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="200"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  expect(maximumHandle?.getAttribute('aria-valuemax')).to.equal('200');
+});
+
+it('sets `aria-valuenow` on the minimum handle as the minimum value of `value`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[7, 99]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  expect(minimumHandle?.getAttribute('aria-valuenow')).to.equal('7');
+});
+
+it('sets `aria-valuenow` on the maximum handle as the maximum value of `value`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[7, 99]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  expect(maximumHandle?.getAttribute('aria-valuenow')).to.equal('99');
+});
+
+it('sets the minimum and maximum inputs to disabled when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      disabled
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(minimumInput?.hasAttribute('disabled')).to.be.true;
+  expect(maximumInput?.hasAttribute('disabled')).to.be.true;
+});
+
+it('sets the minimum and maximum inputs to readonly when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      multiple
+      readonly
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(minimumInput?.hasAttribute('readonly')).to.be.true;
+  expect(maximumInput?.hasAttribute('readonly')).to.be.true;
+});
+
+it('sets the minimum and maximum handles to aria-disabled when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      disabled
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  expect(minimumHandle?.hasAttribute('aria-disabled')).to.be.true;
+  expect(maximumHandle?.hasAttribute('aria-disabled')).to.be.true;
+});
+
+it('sets the minimum and maximum handles to aria-readonly when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      multiple
+      readonly
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  expect(minimumHandle?.hasAttribute('aria-readonly')).to.be.true;
+  expect(maximumHandle?.hasAttribute('aria-readonly')).to.be.true;
+});
+
+it('hides the single input and handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleInput?.checkVisibility()).to.not.be.ok;
+  expect(singleHandle?.checkVisibility()).to.not.be.ok;
 });

--- a/src/slider.test.basics.multiple.ts
+++ b/src/slider.test.basics.multiple.ts
@@ -9,7 +9,7 @@ it('is accessible ', async () => {
   await expect(host).to.be.accessible();
 });
 
-it('sets `value` when one is not provided to 25/75% splits', async () => {
+it('sets `value` when one is not provided to 25/75% of the range size', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"

--- a/src/slider.test.basics.multiple.ts
+++ b/src/slider.test.basics.multiple.ts
@@ -1,0 +1,92 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import Slider from './slider.js';
+
+it('is accessible ', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  await expect(host).to.be.accessible();
+});
+
+it('sets `value` when one is not provided to 25/75% splits', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="100"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  await expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('sets the value of its <input>s from `value`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      multiple
+      .value=${[5, 99]}
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  expect(minimumInput?.value).to.equal('5');
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(maximumInput?.value).to.equal('99');
+});
+
+it('uses "min" to set "min" on the minimum-input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      min="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  expect(minimumInput?.min).to.equal('10');
+});
+
+it('sets "min"', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      min="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  expect(minimumInput?.min).to.equal('10');
+});
+
+it('sets "max"', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="99"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(maximumInput?.max).to.equal('99');
+});

--- a/src/slider.test.basics.multiple.ts
+++ b/src/slider.test.basics.multiple.ts
@@ -75,7 +75,7 @@ it('sets `max` on the maximum input', async () => {
   expect(maximumInput?.max).to.equal('99');
 });
 
-it('sets `min` on the maximum input based on the current minimum value + `step`', async () => {
+it('sets `min` on the maximum input based on the current minimum value plus `step`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -140,7 +140,7 @@ it('sets `max` on the maximum input', async () => {
   expect(maximumInput?.getAttribute('max')).to.equal('200');
 });
 
-it('sets `max` on the minimum input based on the current maximum value - `step`', async () => {
+it('sets `max` on the minimum input based on the current maximum value minus `step`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"

--- a/src/slider.test.basics.single.ts
+++ b/src/slider.test.basics.single.ts
@@ -9,7 +9,7 @@ it('is accessible ', async () => {
   await expect(host).to.be.accessible();
 });
 
-it('sets `value` when one is not provided to 25%', async () => {
+it('sets `value` to 25% when not provided', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" max="100"></glide-core-slider>`,
   );

--- a/src/slider.test.basics.single.ts
+++ b/src/slider.test.basics.single.ts
@@ -29,7 +29,7 @@ it('sets the value of its <input> from `value`', async () => {
   expect(input?.value).to.equal('99');
 });
 
-it('sets "min"', async () => {
+it('sets `min` on the input', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" min="10"></glide-core-slider>`,
   );
@@ -41,7 +41,7 @@ it('sets "min"', async () => {
   expect(input?.min).to.equal('10');
 });
 
-it('sets "max"', async () => {
+it('sets `max` on the input', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" max="90"></glide-core-slider>`,
   );
@@ -51,4 +51,152 @@ it('sets "max"', async () => {
   );
 
   expect(input?.max).to.equal('90');
+});
+
+it('sets `min` on the input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" min="10"></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.getAttribute('min')).to.equal('10');
+});
+
+it('sets `step` on the input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.getAttribute('step')).to.equal('10');
+});
+
+it('sets `max` on the input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" max="200"></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.getAttribute('max')).to.equal('200');
+});
+
+it('sets `aria-valuemin` on the handle as `min`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" min="20"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleHandle?.getAttribute('aria-valuemin')).to.equal('20');
+});
+
+it('sets `aria-valuemax` on the minimum handle as `max`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" max="200"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleHandle?.getAttribute('aria-valuemax')).to.equal('200');
+});
+
+it('sets `aria-valuenow` on the handle as `value`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" .value=${[7]}></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleHandle?.getAttribute('aria-valuenow')).to.equal('7');
+});
+
+it('sets the input to disabled when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" disabled></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.hasAttribute('disabled')).to.be.true;
+});
+
+it('sets the input to readonly when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" readonly></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.hasAttribute('readonly')).to.be.true;
+});
+
+it('sets the handle to aria-disabled when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" disabled></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleHandle?.hasAttribute('aria-disabled')).to.be.true;
+});
+
+it('sets the handle to aria-readonly when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" readonly></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleHandle?.hasAttribute('aria-readonly')).to.be.true;
+});
+
+it('hides the minimum and maximum inputs and handles', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector(
+    '[data-test="maximum-input"]',
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector(
+    '[data-test="minimum-input"]',
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  expect(maximumInput?.checkVisibility()).to.not.be.ok;
+  expect(minimumInput?.checkVisibility()).to.not.be.ok;
+
+  expect(maximumHandle?.checkVisibility()).to.not.be.ok;
+  expect(minimumHandle?.checkVisibility()).to.not.be.ok;
 });

--- a/src/slider.test.basics.single.ts
+++ b/src/slider.test.basics.single.ts
@@ -1,0 +1,54 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import Slider from './slider.js';
+
+it('is accessible ', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  await expect(host).to.be.accessible();
+});
+
+it('sets `value` when one is not provided to 25%', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" max="100"></glide-core-slider>`,
+  );
+
+  await expect(host.value).to.deep.equal([25]);
+});
+
+it('sets the value of its <input> from `value`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" .value=${[99]}></glide-core-slider>`,
+  );
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(input?.value).to.equal('99');
+});
+
+it('sets "min"', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" min="10"></glide-core-slider>`,
+  );
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(input?.min).to.equal('10');
+});
+
+it('sets "max"', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" max="90"></glide-core-slider>`,
+  );
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(input?.max).to.equal('90');
+});

--- a/src/slider.test.basics.ts
+++ b/src/slider.test.basics.ts
@@ -10,6 +10,14 @@ it('registers itself', async () => {
   expect(window.customElements.get('glide-core-slider')).to.equal(Slider);
 });
 
+it('sets a less than 1 `step` to 1', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="0"></glide-core-slider>`,
+  );
+
+  expect(host.step).to.equal(1);
+});
+
 it('throws when `label` is empty', async () => {
   const spy = sinon.spy();
 

--- a/src/slider.test.basics.ts
+++ b/src/slider.test.basics.ts
@@ -1,0 +1,35 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import sinon from 'sinon';
+import { customElement } from 'lit/decorators.js';
+import Slider from './slider.js';
+
+@customElement('glide-core-subclassed')
+class GlideCoreSubclassed extends Slider {}
+
+it('registers itself', async () => {
+  expect(window.customElements.get('glide-core-slider')).to.equal(Slider);
+});
+
+it('throws when `label` is empty', async () => {
+  const spy = sinon.spy();
+
+  try {
+    await fixture(html`<glide-core-slider></glide-core-slider>`);
+  } catch {
+    spy();
+  }
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('throws when subclassed', async () => {
+  const spy = sinon.spy();
+
+  try {
+    new GlideCoreSubclassed();
+  } catch {
+    spy();
+  }
+
+  expect(spy.callCount).to.equal(1);
+});

--- a/src/slider.test.events.multiple.ts
+++ b/src/slider.test.events.multiple.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { sendKeys } from '@web/test-runner-commands';
 import Slider from './slider.js';
 
-it('dispatches an "input" event typing in the minimum input', async () => {
+it('dispatches an "input" event when typing in the minimum input', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -22,7 +22,7 @@ it('dispatches an "input" event typing in the minimum input', async () => {
   expect(spy.callCount).to.equal(1);
 });
 
-it('dispatches an "input" event typing in the maximum input', async () => {
+it('dispatches an "input" event when typing in the maximum input', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -41,7 +41,7 @@ it('dispatches an "input" event typing in the maximum input', async () => {
   expect(spy.callCount).to.equal(1);
 });
 
-it('dispatches a "change" event blurring the minimum input', async () => {
+it('dispatches a "change" event when the minimum input is blurred', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -49,22 +49,17 @@ it('dispatches a "change" event blurring the minimum input', async () => {
   const spy = sinon.spy();
   host.addEventListener('change', spy);
 
-  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="minimum-input"]',
-  );
-
-  minimumInput?.focus();
-
+  await sendKeys({ press: 'Tab' });
   await sendKeys({ type: '1' });
 
   expect(spy.callCount).to.equal(0);
 
-  minimumInput?.blur();
+  await sendKeys({ press: 'Tab' });
 
   expect(spy.callCount).to.equal(1);
 });
 
-it('dispatches a "change" event blurring the maximum input', async () => {
+it('dispatches a "change" event when the maximum input is blurred', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -72,22 +67,20 @@ it('dispatches a "change" event blurring the maximum input', async () => {
   const spy = sinon.spy();
   host.addEventListener('change', spy);
 
-  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="maximum-input"]',
-  );
-
-  maximumInput?.focus();
-
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
   await sendKeys({ type: '1' });
 
   expect(spy.callCount).to.equal(0);
 
-  maximumInput?.blur();
+  await sendKeys({ press: 'Tab' });
 
   expect(spy.callCount).to.equal(1);
 });
 
-it('dispatches an "input" event dragging the minimum handle', async () => {
+it('dispatches an "input" event when dragging the minimum handle', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -113,8 +106,6 @@ it('dispatches an "input" event dragging the minimum handle', async () => {
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -122,8 +113,6 @@ it('dispatches an "input" event dragging the minimum handle', async () => {
       clientX: trackRect.left + trackRect.width * 0.2,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -144,7 +133,7 @@ it('dispatches an "input" event dragging the minimum handle', async () => {
   expect(spy.callCount).to.be.greaterThan(0);
 });
 
-it('dispatches an "input" event dragging the maximum handle', async () => {
+it('dispatches an "input" event when dragging the maximum handle', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -170,8 +159,6 @@ it('dispatches an "input" event dragging the maximum handle', async () => {
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -179,8 +166,6 @@ it('dispatches an "input" event dragging the maximum handle', async () => {
       clientX: trackRect.left + trackRect.width * 0.7,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -191,17 +176,15 @@ it('dispatches an "input" event dragging the maximum handle', async () => {
 
   await host.updateComplete;
 
-  // `greaterThan(0)` because each time the handle
-  // is dragged and the `value` updates, an `input`
-  // event is dispatched, just like native. Rather
-  // than asserting an exact value and having a
-  // comment explaining why, it may be less confusing
-  // to simply verify the event is dispatched at least
-  // once.
+  // `greaterThan(0)` because each time the handle is dragged and
+  // the `value` updates, an `input` event is dispatched, just like
+  // native. Rather than asserting an exact value and having a
+  // comment explaining why, it may be less confusing to simply
+  // verify the event is dispatched at least once.
   expect(spy.callCount).to.be.greaterThan(0);
 });
 
-it('dispatches a "change" event dragging and letting go of the minimum handle', async () => {
+it('dispatches a "change" event when dragging and letting go of the minimum handle', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -227,8 +210,6 @@ it('dispatches a "change" event dragging and letting go of the minimum handle', 
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -236,8 +217,6 @@ it('dispatches a "change" event dragging and letting go of the minimum handle', 
       clientX: trackRect.left + trackRect.width * 0.2,
     }),
   );
-
-  await aTimeout(0);
 
   expect(spy.callCount).to.equal(0);
 
@@ -253,7 +232,7 @@ it('dispatches a "change" event dragging and letting go of the minimum handle', 
   expect(spy.callCount).to.equal(1);
 });
 
-it('dispatches a "change" event dragging and letting go of the maximum handle', async () => {
+it('dispatches a "change" event when dragging and letting go of the maximum handle', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -279,8 +258,6 @@ it('dispatches a "change" event dragging and letting go of the maximum handle', 
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -288,8 +265,6 @@ it('dispatches a "change" event dragging and letting go of the maximum handle', 
       clientX: trackRect.left + trackRect.width * 0.7,
     }),
   );
-
-  await aTimeout(0);
 
   expect(spy.callCount).to.equal(0);
 
@@ -305,7 +280,7 @@ it('dispatches a "change" event dragging and letting go of the maximum handle', 
   expect(spy.callCount).to.equal(1);
 });
 
-it('dispatches an "input" and "change" event clicking on the minimum side of the track', async () => {
+it('dispatches an "input" and "change" event when clicking on the minimum side of the track', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -322,8 +297,8 @@ it('dispatches an "input" and "change" event clicking on the minimum side of the
   assert(trackRect);
   assert(sliderTrack);
 
-  // Click on the track at the 10% position, which is closer
-  // to the minimum handle than the maximum handle.
+  // Click on the track at the 10% position, which is closer to the
+  // minimum handle than the maximum handle.
   sliderTrack.dispatchEvent(
     new MouseEvent('click', {
       bubbles: true,
@@ -338,7 +313,7 @@ it('dispatches an "input" and "change" event clicking on the minimum side of the
   expect(changeSpy.callCount).to.equal(1);
 });
 
-it('dispatches an "input" and "change" event clicking on the maximum side of the track', async () => {
+it('dispatches an "input" and "change" event when clicking on the maximum side of the track', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -355,8 +330,8 @@ it('dispatches an "input" and "change" event clicking on the maximum side of the
   assert(trackRect);
   assert(sliderTrack);
 
-  // Click on the track at the 90% position, which is closer
-  // to the maximum handle than the minimum handle.
+  // The 90% position is closer to the maximum handle than the
+  // minimum handle.
   sliderTrack.dispatchEvent(
     new MouseEvent('click', {
       bubbles: true,
@@ -830,8 +805,6 @@ it('prevents track click events dispatching immediately after completing a drag 
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -839,8 +812,6 @@ it('prevents track click events dispatching immediately after completing a drag 
       clientX: trackRect.left + trackRect.width * 0.2,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -851,7 +822,8 @@ it('prevents track click events dispatching immediately after completing a drag 
 
   await host.updateComplete;
 
-  // At this point, the drag should have dispatched input and change events.
+  // At this point, the drag should have dispatched input and change
+  // events.
   expect(inputSpy.callCount).to.be.greaterThan(0);
   expect(changeSpy.callCount).to.equal(1);
   expect(host.value).to.deep.equal([20, 70]);
@@ -859,9 +831,10 @@ it('prevents track click events dispatching immediately after completing a drag 
   inputSpy.resetHistory();
   changeSpy.resetHistory();
 
-  // Immediately clicking on the track should be ignored because we just
-  // finished dragging. There's a comment in the source explaining why.
-  // No new events should be dispatched and the `value` shouldn't be updated.
+  // Immediately clicking on the track should be ignored because we
+  // just finished dragging. There's a comment in the source
+  // explaining why. No new events should be dispatched and the
+  // `value` shouldn't be updated.
   sliderTrack.dispatchEvent(
     new MouseEvent('click', {
       bubbles: true,
@@ -876,7 +849,7 @@ it('prevents track click events dispatching immediately after completing a drag 
   expect(changeSpy.callCount).to.equal(0);
   expect(host.value).to.deep.equal([20, 70]);
 
-  // Now wait for the drag completion timeout.
+  // Now wait a frame for the drag completion timeout.
   await aTimeout(0);
 
   // Clicking should now work again.

--- a/src/slider.test.events.multiple.ts
+++ b/src/slider.test.events.multiple.ts
@@ -57,6 +57,8 @@ it('dispatches a "change" event blurring the minimum input', async () => {
 
   await sendKeys({ type: '1' });
 
+  expect(spy.callCount).to.equal(0);
+
   minimumInput?.blur();
 
   expect(spy.callCount).to.equal(1);
@@ -77,6 +79,8 @@ it('dispatches a "change" event blurring the maximum input', async () => {
   maximumInput?.focus();
 
   await sendKeys({ type: '1' });
+
+  expect(spy.callCount).to.equal(0);
 
   maximumInput?.blur();
 
@@ -130,6 +134,13 @@ it('dispatches an "input" event dragging the minimum handle', async () => {
 
   await host.updateComplete;
 
+  // `greaterThan(0)` because each time the handle
+  // is dragged and the `value` updates, an `input`
+  // event is dispatched, just like native. Rather
+  // than asserting an exact value and having a
+  // comment explaining why, it may be less confusing
+  // to simply verify the event is dispatched at least
+  // once.
   expect(spy.callCount).to.be.greaterThan(0);
 });
 
@@ -180,10 +191,17 @@ it('dispatches an "input" event dragging the maximum handle', async () => {
 
   await host.updateComplete;
 
+  // `greaterThan(0)` because each time the handle
+  // is dragged and the `value` updates, an `input`
+  // event is dispatched, just like native. Rather
+  // than asserting an exact value and having a
+  // comment explaining why, it may be less confusing
+  // to simply verify the event is dispatched at least
+  // once.
   expect(spy.callCount).to.be.greaterThan(0);
 });
 
-it('dispatches an "change" event dragging and letting go of the minimum handle', async () => {
+it('dispatches a "change" event dragging and letting go of the minimum handle', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -221,6 +239,8 @@ it('dispatches an "change" event dragging and letting go of the minimum handle',
 
   await aTimeout(0);
 
+  expect(spy.callCount).to.equal(0);
+
   document.dispatchEvent(
     new MouseEvent('mouseup', {
       bubbles: true,
@@ -233,7 +253,7 @@ it('dispatches an "change" event dragging and letting go of the minimum handle',
   expect(spy.callCount).to.equal(1);
 });
 
-it('dispatches an "change" event dragging and letting go of the maximum handle', async () => {
+it('dispatches a "change" event dragging and letting go of the maximum handle', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -271,6 +291,8 @@ it('dispatches an "change" event dragging and letting go of the maximum handle',
 
   await aTimeout(0);
 
+  expect(spy.callCount).to.equal(0);
+
   document.dispatchEvent(
     new MouseEvent('mouseup', {
       bubbles: true,
@@ -300,7 +322,8 @@ it('dispatches an "input" and "change" event clicking on the minimum side of the
   assert(trackRect);
   assert(sliderTrack);
 
-  // Click on the track at 10% position (closer to minimum handle than maximum handle)
+  // Click on the track at the 10% position, which is closer
+  // to the minimum handle than the maximum handle.
   sliderTrack.dispatchEvent(
     new MouseEvent('click', {
       bubbles: true,
@@ -332,7 +355,8 @@ it('dispatches an "input" and "change" event clicking on the maximum side of the
   assert(trackRect);
   assert(sliderTrack);
 
-  // Click on the track at 90% position (closer to maximum handle than maximum handle)
+  // Click on the track at the 90% position, which is closer
+  // to the maximum handle than the minimum handle.
   sliderTrack.dispatchEvent(
     new MouseEvent('click', {
       bubbles: true,
@@ -771,7 +795,7 @@ it('does not dispatch events when clicking on the maximum handle', async () => {
   expect(changeSpy.callCount).to.equal(0);
 });
 
-it('prevents track click events immediately after completing a drag operation', async () => {
+it('prevents track click events dispatching immediately after completing a drag operation', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -827,7 +851,7 @@ it('prevents track click events immediately after completing a drag operation', 
 
   await host.updateComplete;
 
-  // At this point, drag should have triggered input and change events
+  // At this point, the drag should have dispatched input and change events.
   expect(inputSpy.callCount).to.be.greaterThan(0);
   expect(changeSpy.callCount).to.equal(1);
   expect(host.value).to.deep.equal([20, 70]);
@@ -835,8 +859,8 @@ it('prevents track click events immediately after completing a drag operation', 
   inputSpy.resetHistory();
   changeSpy.resetHistory();
 
-  // Immediately clicking on the track should be ignored because we just finished dragging.
-  // There's a comment explaining why.
+  // Immediately clicking on the track should be ignored because we just
+  // finished dragging. There's a comment in the source explaining why.
   // No new events should be dispatched and the `value` shouldn't be updated.
   sliderTrack.dispatchEvent(
     new MouseEvent('click', {
@@ -852,10 +876,10 @@ it('prevents track click events immediately after completing a drag operation', 
   expect(changeSpy.callCount).to.equal(0);
   expect(host.value).to.deep.equal([20, 70]);
 
-  // Wait for the drag completion timeout
+  // Now wait for the drag completion timeout.
   await aTimeout(0);
 
-  // Clicking should now work again
+  // Clicking should now work again.
   sliderTrack.dispatchEvent(
     new MouseEvent('click', {
       bubbles: true,

--- a/src/slider.test.events.multiple.ts
+++ b/src/slider.test.events.multiple.ts
@@ -1,0 +1,872 @@
+import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
+import sinon from 'sinon';
+import { sendKeys } from '@web/test-runner-commands';
+import Slider from './slider.js';
+
+it('dispatches an "input" event typing in the minimum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('input', spy);
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  minimumInput?.focus();
+
+  await sendKeys({ type: '1' });
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" event typing in the maximum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('input', spy);
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  maximumInput?.focus();
+
+  await sendKeys({ type: '1' });
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches a "change" event blurring the minimum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('change', spy);
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  minimumInput?.focus();
+
+  await sendKeys({ type: '1' });
+
+  minimumInput?.blur();
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches a "change" event blurring the maximum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('change', spy);
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  maximumInput?.focus();
+
+  await sendKeys({ type: '1' });
+
+  maximumInput?.blur();
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" event dragging the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('input', spy);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(minimumHandle);
+
+  minimumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.2,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(spy.callCount).to.be.greaterThan(0);
+});
+
+it('dispatches an "input" event dragging the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('input', spy);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(maximumHandle);
+
+  maximumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.7,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(spy.callCount).to.be.greaterThan(0);
+});
+
+it('dispatches an "change" event dragging and letting go of the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('change', spy);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(minimumHandle);
+
+  minimumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.2,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches an "change" event dragging and letting go of the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('change', spy);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(maximumHandle);
+
+  maximumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.7,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event clicking on the minimum side of the track', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(sliderTrack);
+
+  // Click on the track at 10% position (closer to minimum handle than maximum handle)
+  sliderTrack.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.1,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event clicking on the maximum side of the track', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(sliderTrack);
+
+  // Click on the track at 90% position (closer to maximum handle than maximum handle)
+  sliderTrack.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.9,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on ArrowLeft on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowLeft' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on ArrowDown on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on ArrowRight on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowRight' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on ArrowUp on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowUp' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on PageDown on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'PageDown' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on PageUp on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'PageUp' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on Home on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'Home' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on End on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'End' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on ArrowLeft on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowLeft' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on ArrowDown on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on ArrowRight on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowRight' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on ArrowUp on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowUp' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on PageDown on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'PageDown' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on PageUp on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'PageUp' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on Home on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'Home' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on End on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'End' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('does not dispatch events when clicking on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      multiple
+      .value=${[30, 70]}
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  assert(minimumHandle);
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  minimumHandle.click();
+  await host.updateComplete;
+
+  expect(inputSpy.callCount).to.equal(0);
+  expect(changeSpy.callCount).to.equal(0);
+});
+
+it('does not dispatch events when clicking on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      multiple
+      .value=${[30, 70]}
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  assert(maximumHandle);
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  maximumHandle.click();
+  await host.updateComplete;
+
+  expect(inputSpy.callCount).to.equal(0);
+  expect(changeSpy.callCount).to.equal(0);
+});
+
+it('prevents track click events immediately after completing a drag operation', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[30, 70]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const sliderTrack = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="slider"]',
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  assert(sliderTrack);
+  assert(minimumHandle);
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const trackRect = sliderTrack.getBoundingClientRect();
+
+  minimumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.2,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  // At this point, drag should have triggered input and change events
+  expect(inputSpy.callCount).to.be.greaterThan(0);
+  expect(changeSpy.callCount).to.equal(1);
+  expect(host.value).to.deep.equal([20, 70]);
+
+  inputSpy.resetHistory();
+  changeSpy.resetHistory();
+
+  // Immediately clicking on the track should be ignored because we just finished dragging.
+  // There's a comment explaining why.
+  // No new events should be dispatched and the `value` shouldn't be updated.
+  sliderTrack.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.2,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(inputSpy.callCount).to.equal(0);
+  expect(changeSpy.callCount).to.equal(0);
+  expect(host.value).to.deep.equal([20, 70]);
+
+  // Wait for the drag completion timeout
+  await aTimeout(0);
+
+  // Clicking should now work again
+  sliderTrack.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.4,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+  expect(host.value).to.deep.equal([40, 70]);
+});

--- a/src/slider.test.events.single.ts
+++ b/src/slider.test.events.single.ts
@@ -1,0 +1,385 @@
+import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
+import sinon from 'sinon';
+import { sendKeys } from '@web/test-runner-commands';
+import Slider from './slider.js';
+
+it('dispatches an "input" event typing in the input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('input', spy);
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  singleInput?.focus();
+
+  await sendKeys({ type: '1' });
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches a "change" event blurring the input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('change', spy);
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  singleInput?.focus();
+
+  await sendKeys({ type: '1' });
+
+  singleInput?.blur();
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" event dragging the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('input', spy);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(singleHandle);
+
+  singleHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.2, // 20% position = value of 20
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(spy.callCount).to.be.greaterThan(0);
+});
+
+it('dispatches an "change" event dragging and letting go of the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('change', spy);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(singleHandle);
+
+  singleHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.2, // 20% position = value of 20
+    }),
+  );
+
+  await aTimeout(0);
+
+  expect(spy.callCount).to.equal(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event clicking on the track', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(sliderTrack);
+
+  sliderTrack.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.2,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on ArrowLeft on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'ArrowLeft' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on ArrowDown on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on ArrowRight on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'ArrowRight' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on ArrowUp on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'ArrowUp' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on PageDown on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'PageDown' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on PageUp on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'PageUp' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on Home on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'Home' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" and "change" event on End on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'End' });
+
+  expect(inputSpy.callCount).to.equal(1);
+  expect(changeSpy.callCount).to.equal(1);
+});
+
+it('does not dispatch events when clicking on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" .value=${[40]}></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  assert(singleHandle);
+
+  const inputSpy = sinon.spy();
+  const changeSpy = sinon.spy();
+
+  host.addEventListener('input', inputSpy);
+  host.addEventListener('change', changeSpy);
+
+  singleHandle.click();
+  await host.updateComplete;
+
+  expect(inputSpy.callCount).to.equal(0);
+  expect(changeSpy.callCount).to.equal(0);
+});

--- a/src/slider.test.events.single.ts
+++ b/src/slider.test.events.single.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { sendKeys } from '@web/test-runner-commands';
 import Slider from './slider.js';
 
-it('dispatches an "input" event typing in the input', async () => {
+it('dispatches an "input" event when typing in the input', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label"></glide-core-slider>`,
   );
@@ -22,7 +22,7 @@ it('dispatches an "input" event typing in the input', async () => {
   expect(spy.callCount).to.equal(1);
 });
 
-it('dispatches a "change" event blurring the input', async () => {
+it('dispatches a "change" event when the input is blurred', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label"></glide-core-slider>`,
   );
@@ -30,22 +30,18 @@ it('dispatches a "change" event blurring the input', async () => {
   const spy = sinon.spy();
   host.addEventListener('change', spy);
 
-  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="single-input"]',
-  );
-
-  singleInput?.focus();
-
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
   await sendKeys({ type: '1' });
 
   expect(spy.callCount).to.equal(0);
 
-  singleInput?.blur();
+  await sendKeys({ press: 'Tab' });
 
   expect(spy.callCount).to.equal(1);
 });
 
-it('dispatches an "input" event dragging the handle', async () => {
+it('dispatches an "input" event when dragging the handle', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label"></glide-core-slider>`,
   );
@@ -71,8 +67,6 @@ it('dispatches an "input" event dragging the handle', async () => {
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -80,8 +74,6 @@ it('dispatches an "input" event dragging the handle', async () => {
       clientX: trackRect.left + trackRect.width * 0.2, // 20% position = value of 20
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -92,17 +84,15 @@ it('dispatches an "input" event dragging the handle', async () => {
 
   await host.updateComplete;
 
-  // `greaterThan(0)` because each time the handle
-  // is dragged and the `value` updates, an `input`
-  // event is dispatched, just like native. Rather
-  // than asserting an exact value and having a
-  // comment explaining why, it may be less confusing
-  // to simply verify the event is dispatched at least
-  // once.
+  // `greaterThan(0)` because each time the handle is dragged and
+  // the `value` updates, an `input` event is dispatched, just like
+  // native. Rather than asserting an exact value and having a
+  // comment explaining why, it may be less confusing to simply
+  // verify the event is dispatched at least once.
   expect(spy.callCount).to.be.greaterThan(0);
 });
 
-it('dispatches a "change" event dragging and letting go of the handle', async () => {
+it('dispatches a "change" event when dragging and letting go of the handle', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label"></glide-core-slider>`,
   );
@@ -128,8 +118,6 @@ it('dispatches a "change" event dragging and letting go of the handle', async ()
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -137,8 +125,6 @@ it('dispatches a "change" event dragging and letting go of the handle', async ()
       clientX: trackRect.left + trackRect.width * 0.2, // 20% position = value of 20
     }),
   );
-
-  await aTimeout(0);
 
   expect(spy.callCount).to.equal(0);
 
@@ -154,7 +140,7 @@ it('dispatches a "change" event dragging and letting go of the handle', async ()
   expect(spy.callCount).to.equal(1);
 });
 
-it('dispatches an "input" and "change" event clicking on the track', async () => {
+it('dispatches an "input" and "change" event when clicking on the track', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label"></glide-core-slider>`,
   );
@@ -424,8 +410,6 @@ it('prevents track click events dispatching immediately after completing a drag 
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -433,8 +417,6 @@ it('prevents track click events dispatching immediately after completing a drag 
       clientX: trackRect.left + trackRect.width * 0.2,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -445,7 +427,8 @@ it('prevents track click events dispatching immediately after completing a drag 
 
   await host.updateComplete;
 
-  // At this point, the drag should have dispatched input and change events.
+  // At this point, the drag should have dispatched input and change
+  // events.
   expect(inputSpy.callCount).to.be.greaterThan(0);
   expect(changeSpy.callCount).to.equal(1);
   expect(host.value).to.deep.equal([20]);
@@ -453,9 +436,10 @@ it('prevents track click events dispatching immediately after completing a drag 
   inputSpy.resetHistory();
   changeSpy.resetHistory();
 
-  // Immediately clicking on the track should be ignored because we just
-  // finished dragging. There's a comment in the source explaining why.
-  // No new events should be dispatched and the `value` shouldn't be updated.
+  // Immediately clicking on the track should be ignored because we
+  // just finished dragging. There's a comment in the source
+  // explaining why. No new events should be dispatched and the
+  // `value` shouldn't be updated.
   sliderTrack.dispatchEvent(
     new MouseEvent('click', {
       bubbles: true,
@@ -470,7 +454,7 @@ it('prevents track click events dispatching immediately after completing a drag 
   expect(changeSpy.callCount).to.equal(0);
   expect(host.value).to.deep.equal([20]);
 
-  // Now wait for the drag completion timeout.
+  // Now wait a frame for the drag completion timeout.
   await aTimeout(0);
 
   // Clicking should now work again.

--- a/src/slider.test.focus.multiple.ts
+++ b/src/slider.test.focus.multiple.ts
@@ -1,0 +1,49 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
+import Slider from './slider.js';
+
+it('focuses the minimum input when `focus()` is called', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  host.focus();
+
+  expect(host.shadowRoot?.activeElement).to.equal(minimumInput);
+});
+
+it('focuses the minimum input after submission when in a forced error state', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    // Slider is a bit different because it always has a `value`.
+    // So to force a focus state via the `invalid` event listener,
+    // one must put the Slider in an invalid state first. Which
+    // can only happen by setting custom validity.
+    host.setCustomValidity('validity message');
+    host.reportValidity();
+  });
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  minimumInput?.focus();
+
+  await sendKeys({ press: 'Enter' });
+
+  expect(host.shadowRoot?.activeElement).to.equal(minimumInput);
+});

--- a/src/slider.test.focus.multiple.ts
+++ b/src/slider.test.focus.multiple.ts
@@ -30,10 +30,10 @@ it('focuses the minimum input after submission when in a forced error state', as
     event.preventDefault();
 
     // Slider is a bit unique from our other form components
-    // because it always has a `value`. To force a focus state
-    // via the `invalid` event listener, one must put the Slider
-    // in an invalid state first. Which can only happen by setting
-    // custom validity.
+    // because it always has a `value`. To force a focus state via
+    // the `invalid` event listener, one must put the Slider in an
+    // invalid state first. Which can only happen by setting custom
+    // validity.
     host.setCustomValidity('validity message');
     host.reportValidity();
   });

--- a/src/slider.test.focus.multiple.ts
+++ b/src/slider.test.focus.multiple.ts
@@ -29,10 +29,11 @@ it('focuses the minimum input after submission when in a forced error state', as
   form.addEventListener('submit', (event) => {
     event.preventDefault();
 
-    // Slider is a bit different because it always has a `value`.
-    // So to force a focus state via the `invalid` event listener,
-    // one must put the Slider in an invalid state first. Which
-    // can only happen by setting custom validity.
+    // Slider is a bit unique from our other form components
+    // because it always has a `value`. To force a focus state
+    // via the `invalid` event listener, one must put the Slider
+    // in an invalid state first. Which can only happen by setting
+    // custom validity.
     host.setCustomValidity('validity message');
     host.reportValidity();
   });

--- a/src/slider.test.focus.single.ts
+++ b/src/slider.test.focus.single.ts
@@ -1,0 +1,49 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
+import Slider from './slider.js';
+
+it('focuses the handle when `focus()` is called', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  host.focus();
+
+  expect(host.shadowRoot?.activeElement).to.equal(singleHandle);
+});
+
+it('focuses the single input after submission when in a forced error state', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    // Slider is a bit different because it always has a `value`.
+    // So to force a focus state via the `invalid` event listener,
+    // one must put the Slider in an invalid state first. Which
+    // can only happen by setting custom validity.
+    host.setCustomValidity('validity message');
+    host.reportValidity();
+  });
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  singleInput?.focus();
+
+  await sendKeys({ press: 'Enter' });
+
+  expect(host.shadowRoot?.activeElement).to.equal(singleInput);
+});

--- a/src/slider.test.focus.single.ts
+++ b/src/slider.test.focus.single.ts
@@ -16,7 +16,7 @@ it('focuses the handle when `focus()` is called', async () => {
   expect(host.shadowRoot?.activeElement).to.equal(singleHandle);
 });
 
-it('focuses the single input after submission when in a forced error state', async () => {
+it('focuses the input after submission when in a forced error state', async () => {
   const form = document.createElement('form');
 
   const host = await fixture<Slider>(
@@ -29,10 +29,11 @@ it('focuses the single input after submission when in a forced error state', asy
   form.addEventListener('submit', (event) => {
     event.preventDefault();
 
-    // Slider is a bit different because it always has a `value`.
-    // So to force a focus state via the `invalid` event listener,
-    // one must put the Slider in an invalid state first. Which
-    // can only happen by setting custom validity.
+    // Slider is a bit unique from our other form components
+    // because it always has a `value`. To force a focus state
+    // via the `invalid` event listener, one must put the Slider
+    // in an invalid state first. Which can only happen by setting
+    // custom validity.
     host.setCustomValidity('validity message');
     host.reportValidity();
   });

--- a/src/slider.test.focus.single.ts
+++ b/src/slider.test.focus.single.ts
@@ -30,10 +30,10 @@ it('focuses the input after submission when in a forced error state', async () =
     event.preventDefault();
 
     // Slider is a bit unique from our other form components
-    // because it always has a `value`. To force a focus state
-    // via the `invalid` event listener, one must put the Slider
-    // in an invalid state first. Which can only happen by setting
-    // custom validity.
+    // because it always has a `value`. To force a focus state via
+    // the `invalid` event listener, one must put the Slider in an
+    // invalid state first. Which can only happen by setting custom
+    // validity.
     host.setCustomValidity('validity message');
     host.reportValidity();
   });

--- a/src/slider.test.forms.multiple.ts
+++ b/src/slider.test.forms.multiple.ts
@@ -3,7 +3,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import Slider from './slider.js';
 
-it('can be reset if there was no initial value', async () => {
+it('resets to 25/75% of the range size if there was no initial value', async () => {
   const form = document.createElement('form');
 
   const host = await fixture<Slider>(
@@ -31,7 +31,7 @@ it('sets `value` back to the default when one is not provided initially and it i
   expect(host.value).to.deep.equal([25, 75]);
 });
 
-it('updates `value` to 25/75% of the range size when programmatically emptying it', async () => {
+it('sets `value` to 25/75% of the range size when programmatically emptying it, even when given an initial value', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -158,7 +158,7 @@ it('submits its form on Enter when the maximum handle has focus', async () => {
   expect(spy.callCount).to.equal(1);
 });
 
-it('defaults `formData` to 25/75% of `max` when no value', async () => {
+it('defaults `formData` to 25/75% of the range size when no value', async () => {
   const form = document.createElement('form');
 
   await fixture<Slider>(

--- a/src/slider.test.forms.multiple.ts
+++ b/src/slider.test.forms.multiple.ts
@@ -1,0 +1,252 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
+import Slider from './slider.js';
+
+it('can be reset if there was no initial value', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  host.value = [10, 90];
+  await host.updateComplete;
+
+  form.reset();
+
+  expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('sets `value` back to the default when one is not provided initially and it is programmatically emptied', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  host.value = [];
+
+  expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('updates `value` to the initial value when programmatically emptying it', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      name="name"
+      .value=${[10, 90]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  host.value = [];
+
+  expect(host.value).to.deep.equal([10, 90]);
+});
+
+it('submits its form on Enter when the minimum input has focus', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const spy = sinon.spy();
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    spy();
+  });
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  minimumInput?.focus();
+
+  await sendKeys({ press: 'Enter' });
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('submits its form on Enter when the minimum handle has focus', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const spy = sinon.spy();
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    spy();
+  });
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'Enter' });
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('submits its form on Enter when the maximum input has focus', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const spy = sinon.spy();
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    spy();
+  });
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  maximumInput?.focus();
+
+  await sendKeys({ press: 'Enter' });
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('submits its form on Enter when the maximum handle has focus', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const spy = sinon.spy();
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    spy();
+  });
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'Enter' });
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('defaults `formData` to 25/75% of `max` when no value', async () => {
+  const form = document.createElement('form');
+
+  await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      name="name"
+      max="200"
+      multiple
+    ></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const formData = new FormData(form);
+  expect(formData.get('name')).to.equal('[50,150]');
+});
+
+it('sets the validity message with `setCustomValidity()`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  host.setCustomValidity('validity message');
+
+  expect(host.validity?.valid).to.be.false;
+  expect(host.validity?.customError).to.be.true;
+  expect(host.checkValidity()).to.be.false;
+
+  await host.updateComplete;
+
+  // Like native, the message shouldn't display until `reportValidity()` is called.
+  expect(
+    host.shadowRoot?.querySelector('[data-test="validity-message"]')
+      ?.textContent,
+  ).to.be.undefined;
+
+  expect(host.reportValidity()).to.be.false;
+
+  await host.updateComplete;
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="minimum-input"]')?.ariaInvalid,
+  ).to.equal('true');
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="maximum-input"]')?.ariaInvalid,
+  ).to.equal('true');
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="validity-message"]')
+      ?.textContent,
+  ).to.equal('validity message');
+});
+
+it('is invalid when `setValidity()` is called', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  host.setValidity({ customError: true }, 'validity message');
+
+  expect(host.validity.valid).to.be.false;
+
+  await host.updateComplete;
+
+  // Like native, the message shouldn't display until `reportValidity()` is called.
+  expect(
+    host.shadowRoot?.querySelector('[data-test="validity-message"]')
+      ?.textContent,
+  ).to.be.undefined;
+
+  expect(host.validity?.customError).to.be.true;
+
+  host.reportValidity();
+
+  await host.updateComplete;
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="minimum-input"]')?.ariaInvalid,
+  ).to.equal('true');
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="maximum-input"]')?.ariaInvalid,
+  ).to.equal('true');
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="validity-message"]')
+      ?.textContent,
+  ).to.equal('validity message');
+});

--- a/src/slider.test.forms.multiple.ts
+++ b/src/slider.test.forms.multiple.ts
@@ -31,7 +31,7 @@ it('sets `value` back to the default when one is not provided initially and it i
   expect(host.value).to.deep.equal([25, 75]);
 });
 
-it('updates `value` to the initial value when programmatically emptying it', async () => {
+it('updates `value` to 25/75% of the range size when programmatically emptying it', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -43,7 +43,7 @@ it('updates `value` to the initial value when programmatically emptying it', asy
 
   host.value = [];
 
-  expect(host.value).to.deep.equal([10, 90]);
+  expect(host.value).to.deep.equal([25, 75]);
 });
 
 it('submits its form on Enter when the minimum input has focus', async () => {

--- a/src/slider.test.forms.multiple.ts
+++ b/src/slider.test.forms.multiple.ts
@@ -190,7 +190,8 @@ it('sets the validity message with `setCustomValidity()`', async () => {
 
   await host.updateComplete;
 
-  // Like native, the message shouldn't display until `reportValidity()` is called.
+  // Like native, the message shouldn't display until
+  // `reportValidity()` is called.
   expect(
     host.shadowRoot?.querySelector('[data-test="validity-message"]')
       ?.textContent,

--- a/src/slider.test.forms.single.ts
+++ b/src/slider.test.forms.single.ts
@@ -133,7 +133,8 @@ it('sets the validity message with `setCustomValidity()`', async () => {
 
   await host.updateComplete;
 
-  // Like native, the message shouldn't display until `reportValidity()` is called.
+  // Like native, the message shouldn't display until
+  // `reportValidity()` is called.
   expect(
     host.shadowRoot?.querySelector('[data-test="validity-message"]')
       ?.textContent,

--- a/src/slider.test.forms.single.ts
+++ b/src/slider.test.forms.single.ts
@@ -1,0 +1,187 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
+import Slider from './slider.js';
+
+it('can be reset if there was no initial value', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  host.value = [90];
+  await host.updateComplete;
+
+  form.reset();
+
+  expect(host.value).to.deep.equal([25]);
+});
+
+it('sets `value` back to the default when one is not provided initially and it is programmatically emptied', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  host.value = [];
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25]);
+});
+
+it('updates `value` to the initial value when programmatically emptying it', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      name="name"
+      .value=${[10]}
+    ></glide-core-slider>`,
+  );
+
+  host.value = [];
+
+  expect(host.value).to.deep.equal([10]);
+});
+
+it('submits its form on Enter when the input has focus', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const spy = sinon.spy();
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    spy();
+  });
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  singleInput?.focus();
+
+  await sendKeys({ press: 'Enter' });
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('submits its form on Enter when the handle has focus', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const spy = sinon.spy();
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    spy();
+  });
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'Enter' });
+
+  expect(spy.callCount).to.equal(1);
+});
+
+it('defaults `formData` to 25% of `max` when no value', async () => {
+  const form = document.createElement('form');
+
+  await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      name="name"
+      max="200"
+    ></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const formData = new FormData(form);
+  expect(formData.get('name')).to.equal('[50]');
+});
+
+it('sets the validity message with `setCustomValidity()`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  host.setCustomValidity('validity message');
+
+  expect(host.validity?.valid).to.be.false;
+  expect(host.validity?.customError).to.be.true;
+  expect(host.checkValidity()).to.be.false;
+
+  await host.updateComplete;
+
+  // Like native, the message shouldn't display until `reportValidity()` is called.
+  expect(
+    host.shadowRoot?.querySelector('[data-test="validity-message"]')
+      ?.textContent,
+  ).to.be.undefined;
+
+  expect(host.reportValidity()).to.be.false;
+
+  await host.updateComplete;
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="single-input"]')?.ariaInvalid,
+  ).to.equal('true');
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="validity-message"]')
+      ?.textContent,
+  ).to.equal('validity message');
+});
+
+it('is invalid when `setValidity()` is called', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  host.setValidity({ customError: true }, 'validity message');
+
+  expect(host.validity.valid).to.be.false;
+
+  await host.updateComplete;
+
+  // Like native, the message shouldn't display until `reportValidity()` is called.
+  expect(
+    host.shadowRoot?.querySelector('[data-test="validity-message"]')
+      ?.textContent,
+  ).to.be.undefined;
+
+  expect(host.validity?.customError).to.be.true;
+
+  host.reportValidity();
+
+  await host.updateComplete;
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="single-input"]')?.ariaInvalid,
+  ).to.equal('true');
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="validity-message"]')
+      ?.textContent,
+  ).to.equal('validity message');
+});

--- a/src/slider.test.forms.single.ts
+++ b/src/slider.test.forms.single.ts
@@ -3,7 +3,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import Slider from './slider.js';
 
-it('can be reset if there was no initial value', async () => {
+it('resets to 25/75% of the range size if there was no initial value', async () => {
   const form = document.createElement('form');
 
   const host = await fixture<Slider>(
@@ -32,7 +32,7 @@ it('sets `value` back to the default when one is not provided initially and it i
   expect(host.value).to.deep.equal([25]);
 });
 
-it('updates `value` to 25% of the range size when programmatically emptying it', async () => {
+it('sets `value` to 25% of the range size when programmatically emptying it, even when given an initial value', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -102,7 +102,7 @@ it('submits its form on Enter when the handle has focus', async () => {
   expect(spy.callCount).to.equal(1);
 });
 
-it('defaults `formData` to 25% of `max` when no value', async () => {
+it('defaults `formData` to 25% of the range size when no value', async () => {
   const form = document.createElement('form');
 
   await fixture<Slider>(

--- a/src/slider.test.forms.single.ts
+++ b/src/slider.test.forms.single.ts
@@ -32,7 +32,7 @@ it('sets `value` back to the default when one is not provided initially and it i
   expect(host.value).to.deep.equal([25]);
 });
 
-it('updates `value` to the initial value when programmatically emptying it', async () => {
+it('updates `value` to 25% of the range size when programmatically emptying it', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -43,7 +43,7 @@ it('updates `value` to the initial value when programmatically emptying it', asy
 
   host.value = [];
 
-  expect(host.value).to.deep.equal([10]);
+  expect(host.value).to.deep.equal([25]);
 });
 
 it('submits its form on Enter when the input has focus', async () => {

--- a/src/slider.test.forms.ts
+++ b/src/slider.test.forms.ts
@@ -17,7 +17,7 @@ it('can be reset to its initial value', async () => {
   expect(host.value).to.deep.equal([20]);
 });
 
-it('has `formData` value when it has a value', async () => {
+it('has a `formData` value when it has a value', async () => {
   const form = document.createElement('form');
 
   await fixture<Slider>(
@@ -35,7 +35,7 @@ it('has `formData` value when it has a value', async () => {
   expect(formData.get('name')).to.equal('[20]');
 });
 
-it('has no `formData` value when it has a value but disabled', async () => {
+it('has no `formData` value when it has a value but is disabled', async () => {
   const form = document.createElement('form');
 
   await fixture<Slider>(
@@ -54,7 +54,7 @@ it('has no `formData` value when it has a value but disabled', async () => {
   expect(formData.get('name')).to.be.null;
 });
 
-it('has no `formData` value when it has a value but without a `name`', async () => {
+it('has no `formData` value when it has a value but no `name`', async () => {
   const form = document.createElement('form');
 
   await fixture<Slider>(
@@ -120,11 +120,9 @@ it('removes a validity message with an empty argument to `setCustomValidity()`',
 
   host.setCustomValidity('validity message');
   host.reportValidity();
-
   await host.updateComplete;
 
   host.setCustomValidity('');
-
   await host.updateComplete;
 
   expect(
@@ -139,16 +137,13 @@ it('is valid when `setValidity()` is called', async () => {
   );
 
   host.setValidity({ customError: true }, 'validity message');
-
   host.setValidity({});
-
   await host.updateComplete;
 
   expect(host.validity.valid).to.be.true;
   expect(host.validity.customError).to.be.false;
 
   expect(host.reportValidity()).to.be.true;
-
   await host.updateComplete;
 
   expect(

--- a/src/slider.test.forms.ts
+++ b/src/slider.test.forms.ts
@@ -17,7 +17,7 @@ it('can be reset to its initial value', async () => {
   expect(host.value).to.deep.equal([20]);
 });
 
-it('has `formData` value when it has a value', async () => {
+it('has a `formData` value when it has a value', async () => {
   const form = document.createElement('form');
 
   await fixture<Slider>(

--- a/src/slider.test.forms.ts
+++ b/src/slider.test.forms.ts
@@ -17,7 +17,7 @@ it('can be reset to its initial value', async () => {
   expect(host.value).to.deep.equal([20]);
 });
 
-it('has a `formData` value when it has a value', async () => {
+it('has `formData` value when it has a value', async () => {
   const form = document.createElement('form');
 
   await fixture<Slider>(

--- a/src/slider.test.forms.ts
+++ b/src/slider.test.forms.ts
@@ -1,0 +1,184 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import Slider from './slider.js';
+
+it('can be reset to its initial value', async () => {
+  const form = document.createElement('form');
+
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" .value=${[20]}></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  host.value = [90];
+  form.reset();
+
+  expect(host.value).to.deep.equal([20]);
+});
+
+it('has `formData` value when it has a value', async () => {
+  const form = document.createElement('form');
+
+  await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      name="name"
+      .value=${[20]}
+    ></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const formData = new FormData(form);
+  expect(formData.get('name')).to.equal('[20]');
+});
+
+it('has no `formData` value when it has a value but disabled', async () => {
+  const form = document.createElement('form');
+
+  await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      name="name"
+      .value=${[20]}
+      disabled
+    ></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const formData = new FormData(form);
+  expect(formData.get('name')).to.be.null;
+});
+
+it('has no `formData` value when it has a value but without a `name`', async () => {
+  const form = document.createElement('form');
+
+  await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[20]}
+      disabled
+    ></glide-core-slider>`,
+    {
+      parentNode: form,
+    },
+  );
+
+  const formData = new FormData(form);
+  expect(formData.get('name')).to.be.null;
+});
+
+it('is valid if not required and no `value`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  expect(host.validity.valid).to.be.true;
+  expect(host.validity?.valueMissing).to.be.false;
+  expect(host.checkValidity()).to.be.true;
+  expect(host.reportValidity()).to.be.true;
+});
+
+it('is valid if required and `value`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[20]}
+      required
+    ></glide-core-slider>`,
+  );
+
+  expect(host.validity.valid).to.be.true;
+  expect(host.validity?.valueMissing).to.be.false;
+  expect(host.checkValidity()).to.be.true;
+  expect(host.reportValidity()).to.be.true;
+});
+
+it('is valid if no value and required and disabled', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      disabled
+      required
+    ></glide-core-slider>`,
+  );
+
+  expect(host.validity?.valid).to.be.true;
+  expect(host.validity?.valueMissing).to.be.false;
+  expect(host.checkValidity()).to.be.true;
+  expect(host.reportValidity()).to.be.true;
+});
+
+it('removes a validity message with an empty argument to `setCustomValidity()`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  host.setCustomValidity('validity message');
+  host.reportValidity();
+
+  await host.updateComplete;
+
+  host.setCustomValidity('');
+
+  await host.updateComplete;
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="validity-message"]')
+      ?.textContent,
+  ).to.be.undefined;
+});
+
+it('is valid when `setValidity()` is called', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  host.setValidity({ customError: true }, 'validity message');
+
+  host.setValidity({});
+
+  await host.updateComplete;
+
+  expect(host.validity.valid).to.be.true;
+  expect(host.validity.customError).to.be.false;
+
+  expect(host.reportValidity()).to.be.true;
+
+  await host.updateComplete;
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="validity-message"]')
+      ?.textContent,
+  ).to.be.undefined;
+});
+
+it('removes its validity feedback but retains its validity state when `resetValidityFeedback()` is called', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  host.setCustomValidity('validity message');
+
+  expect(host.reportValidity()).to.be.false;
+
+  await host.updateComplete;
+
+  expect(
+    host.shadowRoot?.querySelector('[data-test="validity-message"]')
+      ?.textContent,
+  ).to.equal('validity message');
+
+  host.resetValidityFeedback();
+
+  await host.updateComplete;
+
+  expect(host.shadowRoot?.querySelector('[data-test="validity-message"]')).to.be
+    .null;
+
+  expect(host.validity?.valid).to.be.false;
+});

--- a/src/slider.test.interactions.multiple.ts
+++ b/src/slider.test.interactions.multiple.ts
@@ -1,6 +1,16 @@
 import { assert, expect, fixture, html } from '@open-wc/testing';
-import { sendKeys } from '@web/test-runner-commands';
+import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import Slider from './slider.js';
+import { hover } from './library/mouse.js';
+
+// You'd think you'd be able to call `resetMouse()` anywhere. But, for whatever
+// reason, calling it outside `afterEach()` results in sporadic bouts of the
+// following error via Playwright:
+//
+// "mouse.move: Target page, context or browser has been closed".
+afterEach(async () => {
+  await resetMouse();
+});
 
 it('updates all relevant elements when `max` is set programmatically', async () => {
   const host = await fixture<Slider>(
@@ -724,31 +734,25 @@ it('decreases by `step` when dragging the minimum handle', async () => {
   assert(trackRect);
   assert(minimumHandle);
 
-  minimumHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(minimumHandle);
+
+  await sendMouse({
+    type: 'down',
+  });
 
   // Drag the handle to a location that will force the value to be
   // rounded down to the nearest `step`.
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.2,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.2),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
-
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   expect(host.value).to.deep.equal([20, 75]);
 });
@@ -775,31 +779,25 @@ it('increases by `step` when dragging the minimum handle', async () => {
   assert(trackRect);
   assert(minimumHandle);
 
-  minimumHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(minimumHandle);
+
+  await sendMouse({
+    type: 'down',
+  });
 
   // Drag the handle to a location that will force the value to be
   // rounded up to the nearest `step`.
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.3,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.3),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
-
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   expect(host.value).to.deep.equal([30, 75]);
 });
@@ -826,31 +824,25 @@ it('decreases by `step` when dragging the maximum handle', async () => {
   assert(trackRect);
   assert(maximumHandle);
 
-  maximumHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(maximumHandle);
+
+  await sendMouse({
+    type: 'down',
+  });
 
   // Drag the handle to a location that will force the value to be
   // rounded down to the nearest `step`.
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.7,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.7),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
-
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   expect(host.value).to.deep.equal([25, 70]);
 });
@@ -877,31 +869,25 @@ it('increases by `step` when dragging the maximum handle', async () => {
   assert(trackRect);
   assert(maximumHandle);
 
-  maximumHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(maximumHandle);
+
+  await sendMouse({
+    type: 'down',
+  });
 
   // Drag the handle to a location that will force the value to be
   // rounded up to the nearest `step`.
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.8,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.8),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
-
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   expect(host.value).to.deep.equal([25, 80]);
 });
@@ -924,31 +910,25 @@ it('prevents the minimum handle from exceeding the maximum handle when dragging'
   assert(trackRect);
   assert(minimumHandle);
 
-  minimumHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(minimumHandle);
+
+  await sendMouse({
+    type: 'down',
+  });
 
   // Try to drag the minimum handle to the 90% position, which is
   // beyond the maximum handle currently at 75%.
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.9,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.9),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
-
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   // The minimum value should be clamped to maximum minus step
   expect(host.value).to.deep.equal([74, 75]);
@@ -972,31 +952,25 @@ it('prevents maximum handle from going below the minimum handle when dragging', 
   assert(trackRect);
   assert(maximumHandle);
 
-  maximumHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(maximumHandle);
+
+  await sendMouse({
+    type: 'down',
+  });
 
   // Try to drag the maximum handle to the 10% position, which is
   // below the minimum handle currently at 25%.
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.1,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.1),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
-
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   // The maximum value should be clamped to minimum plus step
   expect(host.value).to.deep.equal([25, 26]);
@@ -1025,29 +999,23 @@ it('does not update when dragging the minimum handle when `disabled`', async () 
   assert(trackRect);
   assert(minimumHandle);
 
-  minimumHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(minimumHandle);
 
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.9,
-    }),
-  );
+  await sendMouse({
+    type: 'down',
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.9),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   expect(host.value).to.deep.equal([25, 75]);
 });
@@ -1075,29 +1043,23 @@ it('does not update when dragging the minimum handle when `readonly`', async () 
   assert(trackRect);
   assert(minimumHandle);
 
-  minimumHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(minimumHandle);
 
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.9,
-    }),
-  );
+  await sendMouse({
+    type: 'down',
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.9),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   expect(host.value).to.deep.equal([25, 75]);
 });
@@ -1125,29 +1087,23 @@ it('does not update when dragging the maximum handle when `disabled`', async () 
   assert(trackRect);
   assert(maximumHandle);
 
-  maximumHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(maximumHandle);
 
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.9,
-    }),
-  );
+  await sendMouse({
+    type: 'down',
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.9),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   expect(host.value).to.deep.equal([25, 75]);
 });
@@ -1175,29 +1131,23 @@ it('does not update when dragging the maximum handle when `readonly`', async () 
   assert(trackRect);
   assert(maximumHandle);
 
-  maximumHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(maximumHandle);
 
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.9,
-    }),
-  );
+  await sendMouse({
+    type: 'down',
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.9),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   expect(host.value).to.deep.equal([25, 75]);
 });

--- a/src/slider.test.interactions.multiple.ts
+++ b/src/slider.test.interactions.multiple.ts
@@ -1,0 +1,1914 @@
+import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
+import Slider from './slider.js';
+
+it('sets `min` on the minimum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      min="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  expect(minimumInput?.getAttribute('min')).to.equal('10');
+});
+
+it('sets `min` on the maximum input based on the current minimum value + `step`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="20"
+      .value=${[20, 60]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(maximumInput?.getAttribute('min')).to.equal('40');
+});
+
+it('sets `step` on the minimum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  expect(minimumInput?.getAttribute('step')).to.equal('10');
+});
+
+it('sets `step` on the maximum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(maximumInput?.getAttribute('step')).to.equal('10');
+});
+
+it('sets `max` on the maximum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="200"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(maximumInput?.getAttribute('max')).to.equal('200');
+});
+
+it('sets `max` on the minimum input based on the current maximum value - `step`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="20"
+      .value=${[20, 60]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  expect(minimumInput?.getAttribute('max')).to.equal('40');
+});
+
+it('sets `aria-valuemin` on the minimum handle as `min`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      min="20"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  expect(minimumHandle?.getAttribute('aria-valuemin')).to.equal('20');
+});
+
+it('sets `aria-valuemin` on the maximum handle as `min`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      min="20"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  expect(maximumHandle?.getAttribute('aria-valuemin')).to.equal('20');
+});
+
+it('sets `aria-valuemax` on the minimum handle as `max`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="200"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  expect(minimumHandle?.getAttribute('aria-valuemax')).to.equal('200');
+});
+
+it('sets `aria-valuemax` on the maximum handle as `max`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="200"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  expect(maximumHandle?.getAttribute('aria-valuemax')).to.equal('200');
+});
+
+it('sets `aria-valuenow` on the minimum handle as the minimum value of `value`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[7, 99]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  expect(minimumHandle?.getAttribute('aria-valuenow')).to.equal('7');
+});
+
+it('sets `aria-valuenow` on the maximum handle as the maximum value of `value`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[7, 99]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  expect(maximumHandle?.getAttribute('aria-valuenow')).to.equal('99');
+});
+
+it('updates all relevant elements when `max` is set programmatically', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[30, 60]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  host.max = 80;
+  await host.updateComplete;
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  expect(maximumInput?.max).to.equal('80');
+  expect(maximumHandle?.getAttribute('aria-valuemax')).to.equal('80');
+  expect(minimumHandle?.getAttribute('aria-valuemax')).to.equal('80');
+});
+
+it('clamps minimum and maximum values when `max` is lowered programmatically', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      multiple
+      .value=${[30, 80]}
+    ></glide-core-slider>`,
+  );
+
+  // Set max below both current values
+  host.max = 25;
+  await host.updateComplete;
+
+  // Both values should be adjusted
+  // Maximum becomes max (25)
+  // Minimum becomes (max - step) = 24
+  expect(host.value).to.deep.equal([24, 25]);
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(minimumInput?.value).to.equal('24');
+  expect(maximumInput?.value).to.equal('25');
+});
+
+it('clamps the maximum value but keeps the minimum unchanged when `max` is set programmatically', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[30, 70]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  host.max = 40;
+  await host.updateComplete;
+
+  // Minimum stays the same
+  // Maximum gets clamped to new max
+  expect(host.value).to.deep.equal([30, 40]);
+});
+
+it('updates all relevant elements when `min` is set programmatically', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      multiple
+      .value=${[30, 60]}
+    ></glide-core-slider>`,
+  );
+
+  host.min = 20;
+  await host.updateComplete;
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  expect(minimumInput?.min).to.equal('20');
+  expect(minimumHandle?.getAttribute('aria-valuemin')).to.equal('20');
+  expect(maximumHandle?.getAttribute('aria-valuemin')).to.equal('20');
+});
+
+it('clamps minimum and maximum values when `min` is raised programmatically', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      multiple
+      .value=${[20, 40]}
+    ></glide-core-slider>`,
+  );
+
+  // Set min above both current values
+  host.min = 45;
+  await host.updateComplete;
+
+  // Both values should be adjusted
+  // Minimum becomes min (45)
+  // Maximum becomes (min + step) = 46
+  expect(host.value).to.deep.equal([45, 46]);
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(minimumInput?.value).to.equal('45');
+  expect(maximumInput?.value).to.equal('46');
+});
+
+it('clamps the minimum value but keeps the maximum unchanged when `min` is set programmatically', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      multiple
+      .value=${[30, 70]}
+    ></glide-core-slider>`,
+  );
+
+  host.min = 40;
+  await host.updateComplete;
+
+  // Minimum is clamped to new min
+  // Maximum stays the same
+  expect(host.value).to.deep.equal([40, 70]);
+});
+
+it('respects the min/max bounds', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="80"
+      min="20"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  host.value = [0, 100];
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([20, 80]);
+});
+
+it('updates the minimum value when entering text in the minimum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: '10' });
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  expect(minimumInput?.value).to.equal('10');
+  expect(host.value).to.deep.equal([10, 75]);
+});
+
+it('updates the maximum value when entering text in the maximum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+
+  await sendKeys({ type: '90' });
+
+  expect(maximumInput?.value).to.equal('90');
+  expect(host.value).to.deep.equal([25, 90]);
+});
+
+it('uses `step` to round up when an entered value falls outside of the step with minimum input on blur', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: '16' });
+
+  minimumInput?.blur();
+
+  expect(minimumInput?.value).to.equal('20');
+  expect(host.value).to.deep.equal([20, 75]);
+});
+
+it('uses `step` to round down when an entered value falls outside of the step with minimum input on blur', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: '14' });
+
+  minimumInput?.blur();
+
+  expect(minimumInput?.value).to.equal('10');
+  expect(host.value).to.deep.equal([10, 75]);
+});
+
+it('uses `step` to round up when a value falls outside of the step with maximum input on blur', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+
+  await sendKeys({ type: '86' });
+
+  maximumInput?.blur();
+
+  expect(maximumInput?.value).to.equal('90');
+  expect(host.value).to.deep.equal([25, 90]);
+});
+
+it('uses `step` to round down when a value falls outside of the step with maximum input on blur', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+
+  await sendKeys({ type: '84' });
+
+  maximumInput?.blur();
+
+  expect(maximumInput?.value).to.equal('80');
+  expect(host.value).to.deep.equal([25, 80]);
+});
+
+it('uses `step` on ArrowDown on the minimum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(minimumInput?.value).to.equal('20');
+  expect(host.value).to.deep.equal([20, 75]);
+});
+
+it('uses `step` on ArrowUp on the minimum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'ArrowUp' });
+
+  expect(minimumInput?.value).to.equal('30');
+  expect(host.value).to.deep.equal([30, 75]);
+});
+
+it('decreases by `step` on ArrowLeft on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowLeft' });
+
+  expect(host.value).to.deep.equal([15, 75]);
+});
+
+it('decreases by `step` on ArrowDown on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(host.value).to.deep.equal([15, 75]);
+});
+
+it('increases by `step` on ArrowRight on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowRight' });
+
+  expect(host.value).to.deep.equal([35, 75]);
+});
+
+it('increases by `step` on ArrowUp on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowUp' });
+
+  expect(host.value).to.deep.equal([35, 75]);
+});
+
+it('decreases by x10 `step` on PageDown on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="2"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'PageDown' });
+
+  expect(host.value).to.deep.equal([5, 75]);
+});
+
+it('increases by x10 `step` on PageDown on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="2"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'PageUp' });
+
+  expect(host.value).to.deep.equal([45, 75]);
+});
+
+it('sets the minimum value to `min` on Home on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'Home' });
+
+  expect(host.value).to.deep.equal([0, 75]);
+});
+
+it('sets the minimum value to the maximum value - step on End on the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="5"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'End' });
+
+  expect(host.value).to.deep.equal([70, 75]);
+});
+
+it('uses `step` on ArrowDown on the maximum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  maximumInput?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(maximumInput?.value).to.equal('70');
+  expect(host.value).to.deep.equal([25, 70]);
+});
+
+it('uses `step` on ArrowUp on the maximum input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  maximumInput?.focus();
+
+  await sendKeys({ press: 'ArrowUp' });
+
+  expect(maximumInput?.value).to.equal('90');
+  expect(host.value).to.deep.equal([25, 90]);
+});
+
+it('decreases by `step` on ArrowLeft on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowLeft' });
+
+  expect(host.value).to.deep.equal([25, 65]);
+});
+
+it('decreases by `step` on ArrowDown on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(host.value).to.deep.equal([25, 65]);
+});
+
+it('increases by `step` on ArrowRight on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowRight' });
+
+  expect(host.value).to.deep.equal([25, 85]);
+});
+
+it('increases by `step` on ArrowUp on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowUp' });
+
+  expect(host.value).to.deep.equal([25, 85]);
+});
+
+it('decreases by x10 `step` on PageDown on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="2"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'PageDown' });
+
+  expect(host.value).to.deep.equal([25, 55]);
+});
+
+it('increases by x10 `step` on PageDown on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="2"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'PageUp' });
+
+  expect(host.value).to.deep.equal([25, 95]);
+});
+
+it('sets the maximum value to the minimum value + step on Home on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="5"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'Home' });
+
+  expect(host.value).to.deep.equal([25, 30]);
+});
+
+it('sets the maximum value to `max` on Home on the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="5"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'End' });
+
+  expect(host.value).to.deep.equal([25, 100]);
+});
+
+it('decreases by `step` when dragging the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25, 75]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(minimumHandle);
+
+  minimumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.2, // 20% position = value of 20
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([20, 75]);
+});
+
+it('increases by `step` when dragging the minimum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25, 75]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(minimumHandle);
+
+  minimumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.3, // 30% position = value of 30
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([30, 75]);
+});
+
+it('decreases by `step` when dragging the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25, 75]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(maximumHandle);
+
+  maximumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.7, // 70% position = value of 70
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25, 70]);
+});
+
+it('increases by `step` when dragging the maximum handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="10"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25, 75]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(maximumHandle);
+
+  maximumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.8, // 80% position = value of 80
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25, 80]);
+});
+
+it('prevents the minimum handle from exceeding the maximum handle when dragging', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25, 75]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(minimumHandle);
+
+  minimumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  // Try to drag the minimum handle to 90% position, which is beyond the maximum handle (75%)
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.9, // 90% position
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  // The minimum value should be clamped to (maximum - step)
+  expect(host.value).to.deep.equal([74, 75]);
+});
+
+it('prevents maximum handle from going below minimum handle when dragging', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25, 75]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(maximumHandle);
+
+  maximumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  // Try to drag the maximum handle to 10% position, which is below the minimum handle (25%)
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.1, // 10% position
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  // The maximum value should be clamped to (minimum + step)
+  expect(host.value).to.deep.equal([25, 26]);
+});
+
+it('does not update when dragging the minimum handle when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25, 75]}
+      disabled
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25, 75]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(minimumHandle);
+
+  minimumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.9,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('does not update when dragging the minimum handle when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25, 75]}
+      multiple
+      readonly
+    ></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25, 75]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(minimumHandle);
+
+  minimumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.9,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('does not update when dragging the maximum handle when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25, 75]}
+      disabled
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25, 75]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(maximumHandle);
+
+  maximumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.9,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('does not update when dragging the maximum handle when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25, 75]}
+      multiple
+      readonly
+    ></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25, 75]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(maximumHandle);
+
+  maximumHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.9,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('clicking on the minimum side of the track updates the minimum value', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25, 75]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(sliderTrack);
+
+  // Click on the track at 10% position (closer to minimum handle than maximum handle)
+  sliderTrack.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.1, // 10% position
+    }),
+  );
+
+  await host.updateComplete;
+
+  // Full assertion
+  expect(host.value).to.deep.equal([10, 75]);
+
+  // Verify the minimum handle has moved to the clicked position
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  assert(minimumHandle);
+
+  // Get the handle's position as a percentage of the track width
+  const handleStyle = window.getComputedStyle(minimumHandle);
+  const handleLeft = Number.parseFloat(handleStyle.left);
+  const handleLeftPercent = (handleLeft / trackRect.width) * 100;
+
+  // The handle should be positioned at approximately 10% (allowing for small rounding differences)
+  expect(handleLeftPercent).to.be.closeTo(10, 2);
+});
+
+it('clicking on the maximum side of the track updates the maximum value', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25, 75]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(sliderTrack);
+
+  // Click on the track at 90% position (closer to maximum handle than minimum handle)
+  sliderTrack.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.9, // 90% position
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25, 90]);
+
+  // Verify the maximum handle has moved to the clicked position
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  assert(maximumHandle);
+
+  // Get the handle's position as a percentage of the track width
+  const handleStyle = window.getComputedStyle(maximumHandle);
+  const handleLeft = Number.parseFloat(handleStyle.left);
+  const handleLeftPercent = (handleLeft / trackRect.width) * 100;
+
+  // The handle should be positioned at approximately 90% (allowing for small rounding differences)
+  expect(handleLeftPercent).to.be.closeTo(90, 2);
+});
+
+it('snaps the minimum input value to the maximum value - step if the entered value exceeds the current maximum input value and is blurred', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="1"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  // Entered a value that is greater than the maximum input / handle
+  await sendKeys({ type: '80' });
+
+  minimumInput?.blur();
+
+  expect(minimumInput?.value).to.equal('74');
+  expect(host.value).to.deep.equal([74, 75]);
+});
+
+it('snaps the maximum input value to the minimum value + step if the entered value is less than the current minimum input value and is blurred', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      step="1"
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+
+  // Entered a value that is less than the minimum input / handle
+  await sendKeys({ type: '20' });
+
+  maximumInput?.blur();
+
+  expect(maximumInput?.value).to.equal('26');
+  expect(host.value).to.deep.equal([25, 26]);
+});
+
+it('maintains a multiple value when switching between multiple and single modes', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  host.value = [30, 70];
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([30, 70]);
+
+  host.multiple = false;
+  await host.updateComplete;
+
+  // Should preserve only the minimum value
+  expect(host.value).to.deep.equal([30]);
+
+  host.value = [50];
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([50]);
+
+  host.multiple = true;
+  await host.updateComplete;
+
+  // Should preserve the current value as the minimum and add a maximum value
+  expect(host.value).to.deep.equal([50, 75]);
+});
+
+it('sets the minimum and maximum inputs to disabled when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      disabled
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(minimumInput?.hasAttribute('disabled')).to.be.true;
+  expect(maximumInput?.hasAttribute('disabled')).to.be.true;
+});
+
+it('sets the minimum and maximum inputs to readonly when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      multiple
+      readonly
+    ></glide-core-slider>`,
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="minimum-input"]',
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  expect(minimumInput?.hasAttribute('readonly')).to.be.true;
+  expect(maximumInput?.hasAttribute('readonly')).to.be.true;
+});
+
+it('sets the minimum and maximum handles to aria-disabled when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      disabled
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  expect(minimumHandle?.hasAttribute('aria-disabled')).to.be.true;
+  expect(maximumHandle?.hasAttribute('aria-disabled')).to.be.true;
+});
+
+it('sets the minimum and maximum handles to aria-readonly when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      multiple
+      readonly
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  expect(minimumHandle?.hasAttribute('aria-readonly')).to.be.true;
+  expect(maximumHandle?.hasAttribute('aria-readonly')).to.be.true;
+});
+
+it('prevents updating the `value` when clicking on the track when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25, 75]}
+      disabled
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(sliderTrack);
+
+  sliderTrack.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.6, // 60% position
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('prevents updating the `value` when clicking on the track when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25, 75]}
+      multiple
+      readonly
+    ></glide-core-slider>`,
+  );
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(sliderTrack);
+
+  sliderTrack.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.6, // 60% position
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('prevents updating the `value` when using the arrow keys on the minimum handle when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25, 75]}
+      disabled
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('prevents updating the `value` when using the arrow keys on the maximum handle when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25, 75]}
+      disabled
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('prevents updating the `value` when using the arrow keys on the minimum handle when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25, 75]}
+      multiple
+      readonly
+    ></glide-core-slider>`,
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="minimum-handle"]',
+  );
+
+  minimumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('prevents updating the `value` when using the arrow keys on the maximum handle when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25, 75]}
+      multiple
+      readonly
+    ></glide-core-slider>`,
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="maximum-handle"]',
+  );
+
+  maximumHandle?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(host.value).to.deep.equal([25, 75]);
+});
+
+it('hides the minimum and maximum inputs and sliders', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleInput?.checkVisibility()).to.not.be.ok;
+  expect(singleHandle?.checkVisibility()).to.not.be.ok;
+});
+
+it('caps the maximum input value to `max` when the entered value exceeds it', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="100"
+      .value=${[25, 75]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="maximum-input"]',
+  );
+
+  maximumInput?.focus();
+
+  await sendKeys({ type: '400' });
+
+  expect(host.value).to.deep.equal([25, 100]);
+});
+
+it('caps the minimum input value to `min` when the entered value is below it', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      min="10"
+      .value=${[25, 75]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: '5' });
+
+  expect(host.value).to.deep.equal([10, 75]);
+});
+
+it('adjusts the maximum value when switched to `multiple` if the current value exceeds the 75% of the `max`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="100"
+      min="0"
+      step="10"
+    ></glide-core-slider>`,
+  );
+
+  // There's a comment in the multiple setter explaining
+  // why we do this, but changing to `multiple` while
+  // having the current `value` higher than the 75%
+  // default for the maximum value forces the maximum
+  // value to `max`.
+  host.value = [80];
+  host.multiple = true;
+
+  await host.updateComplete;
+  expect(host.value).to.deep.equal([80, 100]);
+});
+
+it('adjusts the minimum and maximum values when switched to `multiple` if the current value is set to the `max`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="100"
+      min="0"
+      step="10"
+    ></glide-core-slider>`,
+  );
+
+  // There's a comment in the multiple setter explaining
+  // why we do this, but changing to `multiple` while
+  // having the current `value` set to `max` forces the
+  // maximum value to `max` and the minimum value to
+  // `max` - `step` to prevent the component from being
+  // in an invalid UI state.
+  host.value = [100];
+  host.multiple = true;
+
+  await host.updateComplete;
+  expect(host.value).to.deep.equal([90, 100]);
+});

--- a/src/slider.test.interactions.multiple.ts
+++ b/src/slider.test.interactions.multiple.ts
@@ -1,5 +1,6 @@
 import { assert, expect, fixture, html } from '@open-wc/testing';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import Slider from './slider.js';
 import { hover } from './library/mouse.js';
 
@@ -1554,4 +1555,20 @@ it('normalizes `value` when provided with values that fall outside of `step`', a
   );
 
   expect(host.value).to.deep.equal([10, 100]);
+});
+
+it('throws when `value` is set programmatically to include more than two values', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+
+  try {
+    host.value = [20, 60, 80];
+  } catch {
+    spy();
+  }
+
+  expect(spy.callCount).to.equal(1);
 });

--- a/src/slider.test.interactions.multiple.ts
+++ b/src/slider.test.interactions.multiple.ts
@@ -1,4 +1,4 @@
-import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import Slider from './slider.js';
 
@@ -44,7 +44,7 @@ it('adjusts minimum and maximum values when `max` is lowered programmatically be
   await host.updateComplete;
 
   // Maximum becomes the max.
-  // Minimum becomes the max - step = 24.
+  // Minimum becomes the max minus step = 24.
   expect(host.value).to.deep.equal([24, 25]);
 
   const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
@@ -117,7 +117,7 @@ it('adjusts minimum and maximum values when `min` is raised programmatically abo
   await host.updateComplete;
 
   // Minimum becomes the min.
-  // Maximum becomes the min + step = 46
+  // Maximum becomes the min plus step = 46
   expect(host.value).to.deep.equal([45, 46]);
 
   const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
@@ -480,7 +480,7 @@ it('sets the minimum value to `min` on Home on the minimum handle', async () => 
   expect(host.value).to.deep.equal([0, 75]);
 });
 
-it('sets the minimum value to the maximum value - `step` on End on the minimum handle', async () => {
+it('sets the minimum value to the maximum value minus `step` on End on the minimum handle', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -662,7 +662,7 @@ it('increases by x10 `step` on PageDown on the maximum handle', async () => {
   expect(host.value).to.deep.equal([25, 95]);
 });
 
-it('sets the maximum value to the minimum value + `step` on Home on the maximum handle', async () => {
+it('sets the maximum value to the minimum value plus `step` on Home on the maximum handle', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -731,10 +731,8 @@ it('decreases by `step` when dragging the minimum handle', async () => {
     }),
   );
 
-  await aTimeout(0);
-
-  // Drag the handle to a location that will force
-  // the value to be rounded down to the nearest `step`.
+  // Drag the handle to a location that will force the value to be
+  // rounded down to the nearest `step`.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -742,8 +740,6 @@ it('decreases by `step` when dragging the minimum handle', async () => {
       clientX: trackRect.left + trackRect.width * 0.2,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -786,10 +782,8 @@ it('increases by `step` when dragging the minimum handle', async () => {
     }),
   );
 
-  await aTimeout(0);
-
-  // Drag the handle to a location that will force
-  // the value to be rounded up to the nearest `step`.
+  // Drag the handle to a location that will force the value to be
+  // rounded up to the nearest `step`.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -797,8 +791,6 @@ it('increases by `step` when dragging the minimum handle', async () => {
       clientX: trackRect.left + trackRect.width * 0.3,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -841,10 +833,8 @@ it('decreases by `step` when dragging the maximum handle', async () => {
     }),
   );
 
-  await aTimeout(0);
-
-  // Drag the handle to a location that will force
-  // the value to be rounded down to the nearest `step`.
+  // Drag the handle to a location that will force the value to be
+  // rounded down to the nearest `step`.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -852,8 +842,6 @@ it('decreases by `step` when dragging the maximum handle', async () => {
       clientX: trackRect.left + trackRect.width * 0.7,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -896,10 +884,8 @@ it('increases by `step` when dragging the maximum handle', async () => {
     }),
   );
 
-  await aTimeout(0);
-
-  // Drag the handle to a location that will force
-  // the value to be rounded up to the nearest `step`.
+  // Drag the handle to a location that will force the value to be
+  // rounded up to the nearest `step`.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -907,8 +893,6 @@ it('increases by `step` when dragging the maximum handle', async () => {
       clientX: trackRect.left + trackRect.width * 0.8,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -947,11 +931,8 @@ it('prevents the minimum handle from exceeding the maximum handle when dragging'
     }),
   );
 
-  await aTimeout(0);
-
-  // Try to drag the minimum handle to the 90% position,
-  // which is beyond the maximum handle currently at
-  // 75%.
+  // Try to drag the minimum handle to the 90% position, which is
+  // beyond the maximum handle currently at 75%.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -959,8 +940,6 @@ it('prevents the minimum handle from exceeding the maximum handle when dragging'
       clientX: trackRect.left + trackRect.width * 0.9,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -971,7 +950,7 @@ it('prevents the minimum handle from exceeding the maximum handle when dragging'
 
   await host.updateComplete;
 
-  // The minimum value should be clamped to maximum - step
+  // The minimum value should be clamped to maximum minus step
   expect(host.value).to.deep.equal([74, 75]);
 });
 
@@ -1000,10 +979,8 @@ it('prevents maximum handle from going below the minimum handle when dragging', 
     }),
   );
 
-  await aTimeout(0);
-
-  // Try to drag the maximum handle to the 10% position,
-  // which is below the minimum handle currently at 25%.
+  // Try to drag the maximum handle to the 10% position, which is
+  // below the minimum handle currently at 25%.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -1011,8 +988,6 @@ it('prevents maximum handle from going below the minimum handle when dragging', 
       clientX: trackRect.left + trackRect.width * 0.1,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -1023,7 +998,7 @@ it('prevents maximum handle from going below the minimum handle when dragging', 
 
   await host.updateComplete;
 
-  // The maximum value should be clamped to minimum + step
+  // The maximum value should be clamped to minimum plus step
   expect(host.value).to.deep.equal([25, 26]);
 });
 
@@ -1057,8 +1032,6 @@ it('does not update when dragging the minimum handle when `disabled`', async () 
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -1066,8 +1039,6 @@ it('does not update when dragging the minimum handle when `disabled`', async () 
       clientX: trackRect.left + trackRect.width * 0.9,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -1111,8 +1082,6 @@ it('does not update when dragging the minimum handle when `readonly`', async () 
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -1120,8 +1089,6 @@ it('does not update when dragging the minimum handle when `readonly`', async () 
       clientX: trackRect.left + trackRect.width * 0.9,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -1165,8 +1132,6 @@ it('does not update when dragging the maximum handle when `disabled`', async () 
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -1174,8 +1139,6 @@ it('does not update when dragging the maximum handle when `disabled`', async () 
       clientX: trackRect.left + trackRect.width * 0.9,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -1219,8 +1182,6 @@ it('does not update when dragging the maximum handle when `readonly`', async () 
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -1228,8 +1189,6 @@ it('does not update when dragging the maximum handle when `readonly`', async () 
       clientX: trackRect.left + trackRect.width * 0.9,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -1256,9 +1215,8 @@ it('clicking on the minimum side of the track updates the minimum value', async 
   assert(trackRect);
   assert(sliderTrack);
 
-  // Click on the track at the 10% position, which
-  // is closer to the minimum handle than the
-  // maximum handle.
+  // Click on the track at the 10% position, which is closer to the
+  // minimum handle than the maximum handle.
   sliderTrack.dispatchEvent(
     new MouseEvent('click', {
       bubbles: true,
@@ -1281,8 +1239,8 @@ it('clicking on the minimum side of the track updates the minimum value', async 
   const handleLeft = Number.parseFloat(handleStyle.left);
   const handleLeftPercent = (handleLeft / trackRect.width) * 100;
 
-  // The handle should be positioned at ~10%, allowing
-  // for small rounding differences.
+  // The handle should be positioned at ~10%, allowing for small
+  // rounding differences.
   expect(handleLeftPercent).to.be.closeTo(10, 2);
 });
 
@@ -1299,9 +1257,8 @@ it('clicking on the maximum side of the track updates the maximum value', async 
   assert(trackRect);
   assert(sliderTrack);
 
-  // Click on the track at the 90% position, which
-  // is closer to the maximum handle than the minimum
-  // handle.
+  // Click on the track at the 90% position, which is closer to the
+  // maximum handle than the minimum handle.
   sliderTrack.dispatchEvent(
     new MouseEvent('click', {
       bubbles: true,
@@ -1324,12 +1281,12 @@ it('clicking on the maximum side of the track updates the maximum value', async 
   const handleLeft = Number.parseFloat(handleStyle.left);
   const handleLeftPercent = (handleLeft / trackRect.width) * 100;
 
-  // The handle should be positioned at ~90%, allowing
-  // for small rounding differences.
+  // The handle should be positioned at ~90%, allowing for small
+  // rounding differences.
   expect(handleLeftPercent).to.be.closeTo(90, 2);
 });
 
-it('snaps the minimum input value to the maximum value - `step` if the entered value exceeds the current maximum input value and is blurred', async () => {
+it('snaps the minimum input value to the maximum value minus `step` if the entered value exceeds the current maximum input value and is blurred', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -1343,8 +1300,7 @@ it('snaps the minimum input value to the maximum value - `step` if the entered v
   );
 
   await sendKeys({ press: 'Tab' });
-  // Enter a value that is greater than the
-  // maximum input.
+  // Enter a value that is greater than the maximum input.
   await sendKeys({ type: '80' });
 
   minimumInput?.blur();
@@ -1355,7 +1311,7 @@ it('snaps the minimum input value to the maximum value - `step` if the entered v
   expect(host.value).to.deep.equal([74, 75]);
 });
 
-it('snaps the maximum input value to the minimum value + `step` if the entered value is less than the current minimum input value and is blurred', async () => {
+it('snaps the maximum input value to the minimum value plus `step` if the entered value is less than the current minimum input value and is blurred', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -1373,8 +1329,7 @@ it('snaps the maximum input value to the minimum value + `step` if the entered v
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Tab' });
 
-  // Entered a value that is less than the
-  // minimum input.
+  // Entered a value that is less than the minimum input.
   await sendKeys({ type: '20' });
 
   maximumInput?.blur();
@@ -1398,8 +1353,7 @@ it('maintains a multiple value when switching between multiple and single modes'
   host.multiple = false;
   await host.updateComplete;
 
-  // Should preserve only the minimum value
-  // after the switch.
+  // Should preserve only the minimum value after the switch.
   expect(host.value).to.deep.equal([30]);
 
   host.value = [50];
@@ -1410,8 +1364,8 @@ it('maintains a multiple value when switching between multiple and single modes'
   host.multiple = true;
   await host.updateComplete;
 
-  // Should preserve the current value as
-  // the minimum and add a maximum value.
+  // Should preserve the current value as the minimum and add a
+  // maximum value.
   expect(host.value).to.deep.equal([50, 75]);
 });
 
@@ -1604,11 +1558,10 @@ it('adjusts the maximum value when switched to `multiple` if the current value e
     ></glide-core-slider>`,
   );
 
-  // There's a comment in the multiple setter explaining
-  // why we do this, but changing to `multiple` while
-  // having the current `value` higher than the 75%
-  // default for the maximum value forces the maximum
-  // value to `max`.
+  // There's a comment in the multiple setter explaining why we do
+  // this, but changing to `multiple` while having the current
+  // `value` higher than the 75% default for the maximum value
+  // forces the maximum value to `max`.
   host.value = [80];
   host.multiple = true;
 
@@ -1626,12 +1579,11 @@ it('adjusts the minimum and maximum values when switched to `multiple` if the cu
     ></glide-core-slider>`,
   );
 
-  // There's a comment in the multiple setter explaining
-  // why we do this, but changing to `multiple` while
-  // having the current `value` set to `max` forces the
-  // maximum value to `max` and the minimum value to
-  // `max` - `step` to prevent the component from being
-  // in an invalid UI state.
+  // There's a comment in the multiple setter explaining why we do
+  // this, but changing to `multiple` while having the current
+  // `value` set to `max` forces the maximum value to `max` and the
+  // minimum value to `max` minus `step` to prevent the component
+  // from being in an invalid UI state.
   host.value = [100];
   host.multiple = true;
 

--- a/src/slider.test.interactions.multiple.ts
+++ b/src/slider.test.interactions.multiple.ts
@@ -2,200 +2,6 @@ import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import Slider from './slider.js';
 
-it('sets `min` on the minimum input', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      min="10"
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="minimum-input"]',
-  );
-
-  expect(minimumInput?.getAttribute('min')).to.equal('10');
-});
-
-it('sets `min` on the maximum input based on the current minimum value + `step`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      step="20"
-      .value=${[20, 60]}
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="maximum-input"]',
-  );
-
-  expect(maximumInput?.getAttribute('min')).to.equal('40');
-});
-
-it('sets `step` on the minimum input', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      step="10"
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="minimum-input"]',
-  );
-
-  expect(minimumInput?.getAttribute('step')).to.equal('10');
-});
-
-it('sets `step` on the maximum input', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      step="10"
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="maximum-input"]',
-  );
-
-  expect(maximumInput?.getAttribute('step')).to.equal('10');
-});
-
-it('sets `max` on the maximum input', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      max="200"
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="maximum-input"]',
-  );
-
-  expect(maximumInput?.getAttribute('max')).to.equal('200');
-});
-
-it('sets `max` on the minimum input based on the current maximum value - `step`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      step="20"
-      .value=${[20, 60]}
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="minimum-input"]',
-  );
-
-  expect(minimumInput?.getAttribute('max')).to.equal('40');
-});
-
-it('sets `aria-valuemin` on the minimum handle as `min`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      min="20"
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const minimumHandle = host.shadowRoot?.querySelector(
-    '[data-test="minimum-handle"]',
-  );
-
-  expect(minimumHandle?.getAttribute('aria-valuemin')).to.equal('20');
-});
-
-it('sets `aria-valuemin` on the maximum handle as `min`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      min="20"
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const maximumHandle = host.shadowRoot?.querySelector(
-    '[data-test="maximum-handle"]',
-  );
-
-  expect(maximumHandle?.getAttribute('aria-valuemin')).to.equal('20');
-});
-
-it('sets `aria-valuemax` on the minimum handle as `max`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      max="200"
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const minimumHandle = host.shadowRoot?.querySelector(
-    '[data-test="minimum-handle"]',
-  );
-
-  expect(minimumHandle?.getAttribute('aria-valuemax')).to.equal('200');
-});
-
-it('sets `aria-valuemax` on the maximum handle as `max`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      max="200"
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const maximumHandle = host.shadowRoot?.querySelector(
-    '[data-test="maximum-handle"]',
-  );
-
-  expect(maximumHandle?.getAttribute('aria-valuemax')).to.equal('200');
-});
-
-it('sets `aria-valuenow` on the minimum handle as the minimum value of `value`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      .value=${[7, 99]}
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const minimumHandle = host.shadowRoot?.querySelector(
-    '[data-test="minimum-handle"]',
-  );
-
-  expect(minimumHandle?.getAttribute('aria-valuenow')).to.equal('7');
-});
-
-it('sets `aria-valuenow` on the maximum handle as the maximum value of `value`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      .value=${[7, 99]}
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const maximumHandle = host.shadowRoot?.querySelector(
-    '[data-test="maximum-handle"]',
-  );
-
-  expect(maximumHandle?.getAttribute('aria-valuenow')).to.equal('99');
-});
-
 it('updates all relevant elements when `max` is set programmatically', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
@@ -225,22 +31,20 @@ it('updates all relevant elements when `max` is set programmatically', async () 
   expect(minimumHandle?.getAttribute('aria-valuemax')).to.equal('80');
 });
 
-it('clamps minimum and maximum values when `max` is lowered programmatically', async () => {
+it('adjusts minimum and maximum values when `max` is lowered programmatically below `min`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
-      multiple
       .value=${[30, 80]}
+      multiple
     ></glide-core-slider>`,
   );
 
-  // Set max below both current values
   host.max = 25;
   await host.updateComplete;
 
-  // Both values should be adjusted
-  // Maximum becomes max (25)
-  // Minimum becomes (max - step) = 24
+  // Maximum becomes the max.
+  // Minimum becomes the max - step = 24.
   expect(host.value).to.deep.equal([24, 25]);
 
   const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
@@ -255,7 +59,7 @@ it('clamps minimum and maximum values when `max` is lowered programmatically', a
   expect(maximumInput?.value).to.equal('25');
 });
 
-it('clamps the maximum value but keeps the minimum unchanged when `max` is set programmatically', async () => {
+it('clamps the maximum value to `max` but keeps the minimum unchanged when `max` is set programmatically', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -267,8 +71,6 @@ it('clamps the maximum value but keeps the minimum unchanged when `max` is set p
   host.max = 40;
   await host.updateComplete;
 
-  // Minimum stays the same
-  // Maximum gets clamped to new max
   expect(host.value).to.deep.equal([30, 40]);
 });
 
@@ -301,7 +103,7 @@ it('updates all relevant elements when `min` is set programmatically', async () 
   expect(maximumHandle?.getAttribute('aria-valuemin')).to.equal('20');
 });
 
-it('clamps minimum and maximum values when `min` is raised programmatically', async () => {
+it('adjusts minimum and maximum values when `min` is raised programmatically above `max`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -310,13 +112,12 @@ it('clamps minimum and maximum values when `min` is raised programmatically', as
     ></glide-core-slider>`,
   );
 
-  // Set min above both current values
+  // Set min above both current values.
   host.min = 45;
   await host.updateComplete;
 
-  // Both values should be adjusted
-  // Minimum becomes min (45)
-  // Maximum becomes (min + step) = 46
+  // Minimum becomes the min.
+  // Maximum becomes the min + step = 46
   expect(host.value).to.deep.equal([45, 46]);
 
   const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
@@ -343,12 +144,10 @@ it('clamps the minimum value but keeps the maximum unchanged when `min` is set p
   host.min = 40;
   await host.updateComplete;
 
-  // Minimum is clamped to new min
-  // Maximum stays the same
   expect(host.value).to.deep.equal([40, 70]);
 });
 
-it('respects the min/max bounds', async () => {
+it('respects the min/max bounds by ensuring the values do not exceed them', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -401,7 +200,7 @@ it('updates the maximum value when entering text in the maximum input', async ()
   expect(host.value).to.deep.equal([25, 90]);
 });
 
-it('uses `step` to round up when an entered value falls outside of the step with minimum input on blur', async () => {
+it('uses `step` to round up when an entered minimum value falls outside of the step on blur', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -449,7 +248,7 @@ it('uses `step` to round down when an entered value falls outside of the step wi
   expect(host.value).to.deep.equal([10, 75]);
 });
 
-it('uses `step` to round up when a value falls outside of the step with maximum input on blur', async () => {
+it('uses `step` to round up when a maximum value falls outside of the step on blur', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -477,7 +276,7 @@ it('uses `step` to round up when a value falls outside of the step with maximum 
   expect(host.value).to.deep.equal([25, 90]);
 });
 
-it('uses `step` to round down when a value falls outside of the step with maximum input on blur', async () => {
+it('uses `step` to round down when a maximum value falls outside of the step on blur', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -681,7 +480,7 @@ it('sets the minimum value to `min` on Home on the minimum handle', async () => 
   expect(host.value).to.deep.equal([0, 75]);
 });
 
-it('sets the minimum value to the maximum value - step on End on the minimum handle', async () => {
+it('sets the minimum value to the maximum value - `step` on End on the minimum handle', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -863,7 +662,7 @@ it('increases by x10 `step` on PageDown on the maximum handle', async () => {
   expect(host.value).to.deep.equal([25, 95]);
 });
 
-it('sets the maximum value to the minimum value + step on Home on the maximum handle', async () => {
+it('sets the maximum value to the minimum value + `step` on Home on the maximum handle', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -934,11 +733,13 @@ it('decreases by `step` when dragging the minimum handle', async () => {
 
   await aTimeout(0);
 
+  // Drag the handle to a location that will force
+  // the value to be rounded down to the nearest `step`.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.2, // 20% position = value of 20
+      clientX: trackRect.left + trackRect.width * 0.2,
     }),
   );
 
@@ -987,11 +788,13 @@ it('increases by `step` when dragging the minimum handle', async () => {
 
   await aTimeout(0);
 
+  // Drag the handle to a location that will force
+  // the value to be rounded up to the nearest `step`.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.3, // 30% position = value of 30
+      clientX: trackRect.left + trackRect.width * 0.3,
     }),
   );
 
@@ -1040,11 +843,13 @@ it('decreases by `step` when dragging the maximum handle', async () => {
 
   await aTimeout(0);
 
+  // Drag the handle to a location that will force
+  // the value to be rounded down to the nearest `step`.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.7, // 70% position = value of 70
+      clientX: trackRect.left + trackRect.width * 0.7,
     }),
   );
 
@@ -1093,11 +898,13 @@ it('increases by `step` when dragging the maximum handle', async () => {
 
   await aTimeout(0);
 
+  // Drag the handle to a location that will force
+  // the value to be rounded up to the nearest `step`.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.8, // 80% position = value of 80
+      clientX: trackRect.left + trackRect.width * 0.8,
     }),
   );
 
@@ -1142,12 +949,14 @@ it('prevents the minimum handle from exceeding the maximum handle when dragging'
 
   await aTimeout(0);
 
-  // Try to drag the minimum handle to 90% position, which is beyond the maximum handle (75%)
+  // Try to drag the minimum handle to the 90% position,
+  // which is beyond the maximum handle currently at
+  // 75%.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.9, // 90% position
+      clientX: trackRect.left + trackRect.width * 0.9,
     }),
   );
 
@@ -1162,11 +971,11 @@ it('prevents the minimum handle from exceeding the maximum handle when dragging'
 
   await host.updateComplete;
 
-  // The minimum value should be clamped to (maximum - step)
+  // The minimum value should be clamped to maximum - step
   expect(host.value).to.deep.equal([74, 75]);
 });
 
-it('prevents maximum handle from going below minimum handle when dragging', async () => {
+it('prevents maximum handle from going below the minimum handle when dragging', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
   );
@@ -1193,12 +1002,13 @@ it('prevents maximum handle from going below minimum handle when dragging', asyn
 
   await aTimeout(0);
 
-  // Try to drag the maximum handle to 10% position, which is below the minimum handle (25%)
+  // Try to drag the maximum handle to the 10% position,
+  // which is below the minimum handle currently at 25%.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.1, // 10% position
+      clientX: trackRect.left + trackRect.width * 0.1,
     }),
   );
 
@@ -1213,7 +1023,7 @@ it('prevents maximum handle from going below minimum handle when dragging', asyn
 
   await host.updateComplete;
 
-  // The maximum value should be clamped to (minimum + step)
+  // The maximum value should be clamped to minimum + step
   expect(host.value).to.deep.equal([25, 26]);
 });
 
@@ -1446,33 +1256,33 @@ it('clicking on the minimum side of the track updates the minimum value', async 
   assert(trackRect);
   assert(sliderTrack);
 
-  // Click on the track at 10% position (closer to minimum handle than maximum handle)
+  // Click on the track at the 10% position, which
+  // is closer to the minimum handle than the
+  // maximum handle.
   sliderTrack.dispatchEvent(
     new MouseEvent('click', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.1, // 10% position
+      clientX: trackRect.left + trackRect.width * 0.1,
     }),
   );
 
   await host.updateComplete;
 
-  // Full assertion
   expect(host.value).to.deep.equal([10, 75]);
 
-  // Verify the minimum handle has moved to the clicked position
   const minimumHandle = host.shadowRoot?.querySelector(
     '[data-test="minimum-handle"]',
   );
 
   assert(minimumHandle);
 
-  // Get the handle's position as a percentage of the track width
   const handleStyle = window.getComputedStyle(minimumHandle);
   const handleLeft = Number.parseFloat(handleStyle.left);
   const handleLeftPercent = (handleLeft / trackRect.width) * 100;
 
-  // The handle should be positioned at approximately 10% (allowing for small rounding differences)
+  // The handle should be positioned at ~10%, allowing
+  // for small rounding differences.
   expect(handleLeftPercent).to.be.closeTo(10, 2);
 });
 
@@ -1489,7 +1299,9 @@ it('clicking on the maximum side of the track updates the maximum value', async 
   assert(trackRect);
   assert(sliderTrack);
 
-  // Click on the track at 90% position (closer to maximum handle than minimum handle)
+  // Click on the track at the 90% position, which
+  // is closer to the maximum handle than the minimum
+  // handle.
   sliderTrack.dispatchEvent(
     new MouseEvent('click', {
       bubbles: true,
@@ -1502,23 +1314,22 @@ it('clicking on the maximum side of the track updates the maximum value', async 
 
   expect(host.value).to.deep.equal([25, 90]);
 
-  // Verify the maximum handle has moved to the clicked position
   const maximumHandle = host.shadowRoot?.querySelector(
     '[data-test="maximum-handle"]',
   );
 
   assert(maximumHandle);
 
-  // Get the handle's position as a percentage of the track width
   const handleStyle = window.getComputedStyle(maximumHandle);
   const handleLeft = Number.parseFloat(handleStyle.left);
   const handleLeftPercent = (handleLeft / trackRect.width) * 100;
 
-  // The handle should be positioned at approximately 90% (allowing for small rounding differences)
+  // The handle should be positioned at ~90%, allowing
+  // for small rounding differences.
   expect(handleLeftPercent).to.be.closeTo(90, 2);
 });
 
-it('snaps the minimum input value to the maximum value - step if the entered value exceeds the current maximum input value and is blurred', async () => {
+it('snaps the minimum input value to the maximum value - `step` if the entered value exceeds the current maximum input value and is blurred', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -1532,7 +1343,8 @@ it('snaps the minimum input value to the maximum value - step if the entered val
   );
 
   await sendKeys({ press: 'Tab' });
-  // Entered a value that is greater than the maximum input / handle
+  // Enter a value that is greater than the
+  // maximum input.
   await sendKeys({ type: '80' });
 
   minimumInput?.blur();
@@ -1543,7 +1355,7 @@ it('snaps the minimum input value to the maximum value - step if the entered val
   expect(host.value).to.deep.equal([74, 75]);
 });
 
-it('snaps the maximum input value to the minimum value + step if the entered value is less than the current minimum input value and is blurred', async () => {
+it('snaps the maximum input value to the minimum value + `step` if the entered value is less than the current minimum input value and is blurred', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -1561,7 +1373,8 @@ it('snaps the maximum input value to the minimum value + step if the entered val
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Tab' });
 
-  // Entered a value that is less than the minimum input / handle
+  // Entered a value that is less than the
+  // minimum input.
   await sendKeys({ type: '20' });
 
   maximumInput?.blur();
@@ -1586,6 +1399,7 @@ it('maintains a multiple value when switching between multiple and single modes'
   await host.updateComplete;
 
   // Should preserve only the minimum value
+  // after the switch.
   expect(host.value).to.deep.equal([30]);
 
   host.value = [50];
@@ -1596,95 +1410,12 @@ it('maintains a multiple value when switching between multiple and single modes'
   host.multiple = true;
   await host.updateComplete;
 
-  // Should preserve the current value as the minimum and add a maximum value
+  // Should preserve the current value as
+  // the minimum and add a maximum value.
   expect(host.value).to.deep.equal([50, 75]);
 });
 
-it('sets the minimum and maximum inputs to disabled when `disabled`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      disabled
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="minimum-input"]',
-  );
-
-  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="maximum-input"]',
-  );
-
-  expect(minimumInput?.hasAttribute('disabled')).to.be.true;
-  expect(maximumInput?.hasAttribute('disabled')).to.be.true;
-});
-
-it('sets the minimum and maximum inputs to readonly when `readonly`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      multiple
-      readonly
-    ></glide-core-slider>`,
-  );
-
-  const minimumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="minimum-input"]',
-  );
-
-  const maximumInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="maximum-input"]',
-  );
-
-  expect(minimumInput?.hasAttribute('readonly')).to.be.true;
-  expect(maximumInput?.hasAttribute('readonly')).to.be.true;
-});
-
-it('sets the minimum and maximum handles to aria-disabled when `disabled`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      disabled
-      multiple
-    ></glide-core-slider>`,
-  );
-
-  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="minimum-handle"]',
-  );
-
-  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="maximum-handle"]',
-  );
-
-  expect(minimumHandle?.hasAttribute('aria-disabled')).to.be.true;
-  expect(maximumHandle?.hasAttribute('aria-disabled')).to.be.true;
-});
-
-it('sets the minimum and maximum handles to aria-readonly when `readonly`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider
-      label="Label"
-      multiple
-      readonly
-    ></glide-core-slider>`,
-  );
-
-  const minimumHandle = host.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="minimum-handle"]',
-  );
-
-  const maximumHandle = host.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="maximum-handle"]',
-  );
-
-  expect(minimumHandle?.hasAttribute('aria-readonly')).to.be.true;
-  expect(maximumHandle?.hasAttribute('aria-readonly')).to.be.true;
-});
-
-it('prevents updating the `value` when clicking on the track when `disabled`', async () => {
+it('prevents updating the value when clicking on the track when `disabled`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -1704,7 +1435,7 @@ it('prevents updating the `value` when clicking on the track when `disabled`', a
     new MouseEvent('click', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.6, // 60% position
+      clientX: trackRect.left + trackRect.width * 0.6,
     }),
   );
 
@@ -1713,7 +1444,7 @@ it('prevents updating the `value` when clicking on the track when `disabled`', a
   expect(host.value).to.deep.equal([25, 75]);
 });
 
-it('prevents updating the `value` when clicking on the track when `readonly`', async () => {
+it('prevents updating the value when clicking on the track when `readonly`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -1733,7 +1464,7 @@ it('prevents updating the `value` when clicking on the track when `readonly`', a
     new MouseEvent('click', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.6, // 60% position
+      clientX: trackRect.left + trackRect.width * 0.6,
     }),
   );
 
@@ -1742,7 +1473,7 @@ it('prevents updating the `value` when clicking on the track when `readonly`', a
   expect(host.value).to.deep.equal([25, 75]);
 });
 
-it('prevents updating the `value` when using the arrow keys on the minimum handle when `disabled`', async () => {
+it('prevents updating the value when using the arrow keys on the minimum handle when `disabled`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -1763,7 +1494,7 @@ it('prevents updating the `value` when using the arrow keys on the minimum handl
   expect(host.value).to.deep.equal([25, 75]);
 });
 
-it('prevents updating the `value` when using the arrow keys on the maximum handle when `disabled`', async () => {
+it('prevents updating the value when using the arrow keys on the maximum handle when `disabled`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -1784,7 +1515,7 @@ it('prevents updating the `value` when using the arrow keys on the maximum handl
   expect(host.value).to.deep.equal([25, 75]);
 });
 
-it('prevents updating the `value` when using the arrow keys on the minimum handle when `readonly`', async () => {
+it('prevents updating the value when using the arrow keys on the minimum handle when `readonly`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -1805,7 +1536,7 @@ it('prevents updating the `value` when using the arrow keys on the minimum handl
   expect(host.value).to.deep.equal([25, 75]);
 });
 
-it('prevents updating the `value` when using the arrow keys on the maximum handle when `readonly`', async () => {
+it('prevents updating the value when using the arrow keys on the maximum handle when `readonly`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -1824,23 +1555,6 @@ it('prevents updating the `value` when using the arrow keys on the maximum handl
   await sendKeys({ press: 'ArrowDown' });
 
   expect(host.value).to.deep.equal([25, 75]);
-});
-
-it('hides the minimum and maximum inputs and sliders', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
-  );
-
-  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="single-input"]',
-  );
-
-  const singleHandle = host.shadowRoot?.querySelector(
-    '[data-test="single-handle"]',
-  );
-
-  expect(singleInput?.checkVisibility()).to.not.be.ok;
-  expect(singleHandle?.checkVisibility()).to.not.be.ok;
 });
 
 it('caps the maximum input value to `max` when the entered value exceeds it', async () => {

--- a/src/slider.test.interactions.multiple.ts
+++ b/src/slider.test.interactions.multiple.ts
@@ -1572,3 +1572,19 @@ it('throws when `value` is set programmatically to include more than two values'
 
   expect(spy.callCount).to.equal(1);
 });
+
+it('throws when `value` is set programmatically with a larger number as the first element', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" multiple></glide-core-slider>`,
+  );
+
+  const spy = sinon.spy();
+
+  try {
+    host.value = [99, 1];
+  } catch {
+    spy();
+  }
+
+  expect(spy.callCount).to.equal(1);
+});

--- a/src/slider.test.interactions.multiple.ts
+++ b/src/slider.test.interactions.multiple.ts
@@ -419,6 +419,8 @@ it('uses `step` to round up when an entered value falls outside of the step with
 
   minimumInput?.blur();
 
+  await host.updateComplete;
+
   expect(minimumInput?.value).to.equal('20');
   expect(host.value).to.deep.equal([20, 75]);
 });
@@ -440,6 +442,8 @@ it('uses `step` to round down when an entered value falls outside of the step wi
   await sendKeys({ type: '14' });
 
   minimumInput?.blur();
+
+  await host.updateComplete;
 
   expect(minimumInput?.value).to.equal('10');
   expect(host.value).to.deep.equal([10, 75]);
@@ -467,6 +471,8 @@ it('uses `step` to round up when a value falls outside of the step with maximum 
 
   maximumInput?.blur();
 
+  await host.updateComplete;
+
   expect(maximumInput?.value).to.equal('90');
   expect(host.value).to.deep.equal([25, 90]);
 });
@@ -492,6 +498,8 @@ it('uses `step` to round down when a value falls outside of the step with maximu
   await sendKeys({ type: '84' });
 
   maximumInput?.blur();
+
+  await host.updateComplete;
 
   expect(maximumInput?.value).to.equal('80');
   expect(host.value).to.deep.equal([25, 80]);
@@ -1529,6 +1537,8 @@ it('snaps the minimum input value to the maximum value - step if the entered val
 
   minimumInput?.blur();
 
+  await host.updateComplete;
+
   expect(minimumInput?.value).to.equal('74');
   expect(host.value).to.deep.equal([74, 75]);
 });
@@ -1555,6 +1565,8 @@ it('snaps the maximum input value to the minimum value + step if the entered val
   await sendKeys({ type: '20' });
 
   maximumInput?.blur();
+
+  await host.updateComplete;
 
   expect(maximumInput?.value).to.equal('26');
   expect(host.value).to.deep.equal([25, 26]);
@@ -1911,4 +1923,19 @@ it('adjusts the minimum and maximum values when switched to `multiple` if the cu
 
   await host.updateComplete;
   expect(host.value).to.deep.equal([90, 100]);
+});
+
+it('normalizes `value` when provided with values that fall outside of `step`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="100"
+      min="0"
+      step="10"
+      .value=${[5, 95]}
+      multiple
+    ></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([10, 100]);
 });

--- a/src/slider.test.interactions.single.ts
+++ b/src/slider.test.interactions.single.ts
@@ -212,6 +212,8 @@ it('uses `step` to round up when an entered value falls outside of the step on b
 
   singleInput?.blur();
 
+  await host.updateComplete;
+
   expect(singleInput?.value).to.equal('20');
   expect(host.value).to.deep.equal([20]);
 });
@@ -230,6 +232,8 @@ it('uses `step` to round down when an entered value falls outside of the step on
   await sendKeys({ type: '14' });
 
   singleInput?.blur();
+
+  await host.updateComplete;
 
   expect(singleInput?.value).to.equal('10');
   expect(host.value).to.deep.equal([10]);
@@ -846,4 +850,18 @@ it('caps the input value to `max` when the entered value exceeds it', async () =
   await sendKeys({ type: '400' });
 
   expect(host.value).to.deep.equal([100]);
+});
+
+it('normalizes `value` when provided with a value that fall outside of `step`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="100"
+      min="0"
+      step="10"
+      .value=${[15]}
+    ></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([20]);
 });

--- a/src/slider.test.interactions.single.ts
+++ b/src/slider.test.interactions.single.ts
@@ -1,6 +1,16 @@
 import { assert, expect, fixture, html } from '@open-wc/testing';
-import { sendKeys } from '@web/test-runner-commands';
+import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import Slider from './slider.js';
+import { hover } from './library/mouse.js';
+
+// You'd think you'd be able to call `resetMouse()` anywhere. But, for whatever
+// reason, calling it outside `afterEach()` results in sporadic bouts of the
+// following error via Playwright:
+//
+// "mouse.move: Target page, context or browser has been closed".
+afterEach(async () => {
+  await resetMouse();
+});
 
 it('updates all relevant elements when `max` is set programmatically', async () => {
   const host = await fixture<Slider>(
@@ -344,31 +354,25 @@ it('decreases by `step` when dragging the handle', async () => {
   assert(trackRect);
   assert(singleHandle);
 
-  singleHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(singleHandle);
+
+  await sendMouse({
+    type: 'down',
+  });
 
   // Drag the handle to a location that will force
   // the value to be rounded down to the nearest `step`.
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.2,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.2),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
-
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   expect(host.value).to.deep.equal([20]);
 });
@@ -391,31 +395,25 @@ it('increases by `step` when dragging the handle', async () => {
   assert(trackRect);
   assert(singleHandle);
 
-  singleHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(singleHandle);
+
+  await sendMouse({
+    type: 'down',
+  });
 
   // Drag the handle to a location that will force the value to be
   // rounded up to the nearest `step`.
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.3,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.3),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
-
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   expect(host.value).to.deep.equal([30]);
 });
@@ -503,29 +501,23 @@ it('does not update when dragging the handle when `disabled`', async () => {
   assert(trackRect);
   assert(singleHandle);
 
-  singleHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(singleHandle);
 
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.2,
-    }),
-  );
+  await sendMouse({
+    type: 'down',
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.2),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   expect(host.value).to.deep.equal([25]);
 });
@@ -549,29 +541,23 @@ it('does not update when dragging the handle when `readonly`', async () => {
   assert(trackRect);
   assert(singleHandle);
 
-  singleHandle.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await hover(singleHandle);
 
-  document.dispatchEvent(
-    new MouseEvent('mousemove', {
-      bubbles: true,
-      cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.2,
-    }),
-  );
+  await sendMouse({
+    type: 'down',
+  });
 
-  document.dispatchEvent(
-    new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  await sendMouse({
+    type: 'move',
+    position: [
+      Math.ceil(trackRect.x + trackRect.width * 0.2),
+      Math.ceil(trackRect.y),
+    ],
+  });
 
-  await host.updateComplete;
+  await sendMouse({
+    type: 'up',
+  });
 
   expect(host.value).to.deep.equal([25]);
 });

--- a/src/slider.test.interactions.single.ts
+++ b/src/slider.test.interactions.single.ts
@@ -687,3 +687,13 @@ it('normalizes `value` when provided with a value that fall outside of `step`', 
 
   expect(host.value).to.deep.equal([20]);
 });
+
+it('retains only the first `value` array item when multiple are set programmatically', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  host.value = [20, 80];
+
+  expect(host.value).to.deep.equal([20]);
+});

--- a/src/slider.test.interactions.single.ts
+++ b/src/slider.test.interactions.single.ts
@@ -1,4 +1,4 @@
-import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import Slider from './slider.js';
 
@@ -351,8 +351,6 @@ it('decreases by `step` when dragging the handle', async () => {
     }),
   );
 
-  await aTimeout(0);
-
   // Drag the handle to a location that will force
   // the value to be rounded down to the nearest `step`.
   document.dispatchEvent(
@@ -362,8 +360,6 @@ it('decreases by `step` when dragging the handle', async () => {
       clientX: trackRect.left + trackRect.width * 0.2,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -402,10 +398,8 @@ it('increases by `step` when dragging the handle', async () => {
     }),
   );
 
-  await aTimeout(0);
-
-  // Drag the handle to a location that will force
-  // the value to be rounded up to the nearest `step`.
+  // Drag the handle to a location that will force the value to be
+  // rounded up to the nearest `step`.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -413,8 +407,6 @@ it('increases by `step` when dragging the handle', async () => {
       clientX: trackRect.left + trackRect.width * 0.3,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -463,8 +455,8 @@ it('clicking on the track updates the value', async () => {
   const handleLeft = Number.parseFloat(handleStyle.left);
   const handleLeftPercent = (handleLeft / trackRect.width) * 100;
 
-  // The handle should be positioned at ~60%, allowing
-  // for small rounding differences.
+  // The handle should be positioned at ~60%, allowing for small
+  // rounding differences.
   expect(handleLeftPercent).to.be.closeTo(60, 2);
 });
 
@@ -480,8 +472,7 @@ it('maintains a single value when switching between multiple and single modes', 
   host.multiple = true;
   await host.updateComplete;
 
-  // Should preserve the first value and
-  // add a maximum value.
+  // Should preserve the first value and add a maximum value.
   expect(host.value.length).to.equal(2);
   expect(host.value).to.deep.equal([40, 75]);
 
@@ -519,8 +510,6 @@ it('does not update when dragging the handle when `disabled`', async () => {
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -528,8 +517,6 @@ it('does not update when dragging the handle when `disabled`', async () => {
       clientX: trackRect.left + trackRect.width * 0.2,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {
@@ -569,8 +556,6 @@ it('does not update when dragging the handle when `readonly`', async () => {
     }),
   );
 
-  await aTimeout(0);
-
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
@@ -578,8 +563,6 @@ it('does not update when dragging the handle when `readonly`', async () => {
       clientX: trackRect.left + trackRect.width * 0.2,
     }),
   );
-
-  await aTimeout(0);
 
   document.dispatchEvent(
     new MouseEvent('mouseup', {

--- a/src/slider.test.interactions.single.ts
+++ b/src/slider.test.interactions.single.ts
@@ -1,0 +1,849 @@
+import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
+import Slider from './slider.js';
+
+it('sets `min` on the input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" min="10"></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.getAttribute('min')).to.equal('10');
+});
+
+it('sets `step` on the input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.getAttribute('step')).to.equal('10');
+});
+
+it('sets `max` on the input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" max="200"></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.getAttribute('max')).to.equal('200');
+});
+
+it('sets `aria-valuemin` on the handle as `min`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" min="20"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleHandle?.getAttribute('aria-valuemin')).to.equal('20');
+});
+
+it('sets `aria-valuemax` on the minimum handle as `max`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" max="200"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleHandle?.getAttribute('aria-valuemax')).to.equal('200');
+});
+
+it('sets `aria-valuenow` on the handle as `value`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" .value=${[7]}></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleHandle?.getAttribute('aria-valuenow')).to.equal('7');
+});
+
+it('updates all relevant elements when `max` is set programmatically', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" .value=${[50]}></glide-core-slider>`,
+  );
+
+  host.max = 75;
+  await host.updateComplete;
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleInput?.max).to.equal('75');
+  expect(singleHandle?.getAttribute('aria-valuemax')).to.equal('75');
+});
+
+it('clamps the current value when `max` is set lower than the current value programmatically', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" .value=${[50]}></glide-core-slider>`,
+  );
+
+  host.max = 30;
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([30]);
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.value).to.equal('30');
+});
+
+it('updates all relevant elements when `min` is set programmatically', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" .value=${[50]}></glide-core-slider>`,
+  );
+
+  host.min = 25;
+  await host.updateComplete;
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleInput?.min).to.equal('25');
+  expect(singleHandle?.getAttribute('aria-valuemin')).to.equal('25');
+});
+
+it('clamps the current value when `min` is set higher than the current value programmatically', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" .value=${[20]}></glide-core-slider>`,
+  );
+
+  host.min = 30;
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([30]);
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.value).to.equal('30');
+});
+
+it('maintains `value` when `min` is set below the current value', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" .value=${[50]}></glide-core-slider>`,
+  );
+
+  host.min = 10;
+  await host.updateComplete;
+
+  // Value should remain unchanged
+  expect(host.value).to.deep.equal([50]);
+});
+
+it('respects the min/max bounds', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      max="80"
+      min="20"
+    ></glide-core-slider>`,
+  );
+
+  host.value = [0];
+  await host.updateComplete;
+
+  expect(host.value[0]).to.equal(20);
+
+  host.value = [100];
+  await host.updateComplete;
+
+  expect(host.value[0]).to.equal(80);
+});
+
+it('updates the value when entering text in the input', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: '40' });
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.value).to.equal('40');
+  expect(host.value).to.deep.equal([40]);
+});
+
+it('uses `step` to round up when an entered value falls outside of the step on blur', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: '16' });
+
+  singleInput?.blur();
+
+  expect(singleInput?.value).to.equal('20');
+  expect(host.value).to.deep.equal([20]);
+});
+
+it('uses `step` to round down when an entered value falls outside of the step on blur', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: '14' });
+
+  singleInput?.blur();
+
+  expect(singleInput?.value).to.equal('10');
+  expect(host.value).to.deep.equal([10]);
+});
+
+it('uses `step` on ArrowDown', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(singleInput?.value).to.equal('15');
+  expect(host.value).to.deep.equal([15]);
+});
+
+it('uses `step` on ArrowUp', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'ArrowUp' });
+
+  expect(singleInput?.value).to.equal('35');
+  expect(host.value).to.deep.equal([35]);
+});
+
+it('decreases by `step` on ArrowLeft on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'ArrowLeft' });
+
+  expect(host.value).to.deep.equal([15]);
+});
+
+it('decreases by `step` on ArrowDown on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(host.value).to.deep.equal([15]);
+});
+
+it('increases by `step` on ArrowRight on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'ArrowRight' });
+
+  expect(host.value).to.deep.equal([35]);
+});
+
+it('increases by `step` on ArrowUp on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'ArrowUp' });
+
+  expect(host.value).to.deep.equal([35]);
+});
+
+it('decreases by x10 `step` on PageDown on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="2"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'PageDown' });
+
+  expect(host.value).to.deep.equal([5]);
+});
+
+it('increases by x10 `step` on PageUp on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="2"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'PageUp' });
+
+  expect(host.value).to.deep.equal([45]);
+});
+
+it('sets the value to `min` on Home on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'Home' });
+
+  expect(host.value).to.deep.equal([0]);
+});
+
+it('sets the value to `max` on End on the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'End' });
+
+  expect(host.value).to.deep.equal([100]);
+});
+
+it('decreases by `step` when dragging the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(singleHandle);
+
+  singleHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.2, // 20% position = value of 20
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([20]);
+});
+
+it('increases by `step` when dragging the handle', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(singleHandle);
+
+  singleHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.3, // 30% position = value of 30
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([30]);
+});
+
+it('clicking on the track updates the value', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  expect(host.value).to.deep.equal([25]);
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(sliderTrack);
+
+  sliderTrack.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.6, // 60% position
+    }),
+  );
+
+  await host.updateComplete;
+
+  // The value should update to the clicked position (60)
+  expect(host.value).to.deep.equal([60]);
+
+  // Verify the handle has moved to the clicked position
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  assert(singleHandle);
+
+  // Get the handle's position as a percentage of the track width
+  const handleStyle = window.getComputedStyle(singleHandle);
+  const handleLeft = Number.parseFloat(handleStyle.left);
+  const handleLeftPercent = (handleLeft / trackRect.width) * 100;
+
+  // The handle should be positioned at approximately 60% (allowing for small rounding differences)
+  expect(handleLeftPercent).to.be.closeTo(60, 2);
+});
+
+it('maintains a single value when switching between multiple and single modes', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  host.value = [40];
+  await host.updateComplete;
+  expect(host.value).to.deep.equal([40]);
+
+  host.multiple = true;
+  await host.updateComplete;
+
+  // Should preserve the first value and add a maximum value
+  expect(host.value.length).to.equal(2);
+  expect(host.value).to.deep.equal([40, 75]);
+
+  // Switch back to single mode
+  host.multiple = false;
+  await host.updateComplete;
+
+  // Should preserve the first value
+  expect(host.value.length).to.equal(1);
+  expect(host.value[0]).to.equal(40);
+});
+
+it('sets the input to disabled when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" disabled></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.hasAttribute('disabled')).to.be.true;
+});
+
+it('sets the input to readonly when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" readonly></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  expect(singleInput?.hasAttribute('readonly')).to.be.true;
+});
+
+it('sets the handle to aria-disabled when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" disabled></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleHandle?.hasAttribute('aria-disabled')).to.be.true;
+});
+
+it('sets the handle to aria-readonly when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" readonly></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  expect(singleHandle?.hasAttribute('aria-readonly')).to.be.true;
+});
+
+it('does not update when dragging the handle when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25]}
+      disabled
+    ></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(singleHandle);
+
+  singleHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.2, // 20% position = value of 20
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25]);
+});
+
+it('does not update when dragging the handle when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25]}
+      readonly
+    ></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector(
+    '[data-test="single-handle"]',
+  );
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(singleHandle);
+
+  singleHandle.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.2, // 20% position = value of 20
+    }),
+  );
+
+  await aTimeout(0);
+
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25]);
+});
+
+it('prevents updating the `value` when clicking on the track when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25]}
+      disabled
+    ></glide-core-slider>`,
+  );
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(sliderTrack);
+
+  sliderTrack.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.6, // 60% position
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25]);
+});
+
+it('prevents updating the `value` when clicking on the track when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25]}
+      readonly
+    ></glide-core-slider>`,
+  );
+
+  const sliderTrack = host.shadowRoot?.querySelector('[data-test="slider"]');
+  const trackRect = sliderTrack?.getBoundingClientRect();
+
+  assert(trackRect);
+  assert(sliderTrack);
+
+  sliderTrack.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: trackRect.left + trackRect.width * 0.6, // 60% position
+    }),
+  );
+
+  await host.updateComplete;
+
+  expect(host.value).to.deep.equal([25]);
+});
+
+it('prevents updating the `value` when using the arrow keys on the handle when `disabled`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25]}
+      disabled
+    ></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(host.value).to.deep.equal([25]);
+});
+
+it('prevents updating the `value` when using the arrow keys on the handle when `readonly`', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider
+      label="Label"
+      .value=${[25]}
+      readonly
+    ></glide-core-slider>`,
+  );
+
+  const singleHandle = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="single-handle"]',
+  );
+
+  singleHandle?.focus();
+
+  await sendKeys({ press: 'ArrowDown' });
+
+  expect(host.value).to.deep.equal([25]);
+});
+
+it('hides the minimum and maximum inputs and sliders', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label"></glide-core-slider>`,
+  );
+
+  const maximumInput = host.shadowRoot?.querySelector(
+    '[data-test="maximum-input"]',
+  );
+
+  const minimumInput = host.shadowRoot?.querySelector(
+    '[data-test="minimum-input"]',
+  );
+
+  const maximumHandle = host.shadowRoot?.querySelector(
+    '[data-test="maximum-handle"]',
+  );
+
+  const minimumHandle = host.shadowRoot?.querySelector(
+    '[data-test="minimum-handle"]',
+  );
+
+  expect(maximumInput?.checkVisibility()).to.not.be.ok;
+  expect(minimumInput?.checkVisibility()).to.not.be.ok;
+
+  expect(maximumHandle?.checkVisibility()).to.not.be.ok;
+  expect(minimumHandle?.checkVisibility()).to.not.be.ok;
+});
+
+it('caps the input value to `max` when the entered value exceeds it', async () => {
+  const host = await fixture<Slider>(
+    html`<glide-core-slider label="Label" max="100"></glide-core-slider>`,
+  );
+
+  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="single-input"]',
+  );
+
+  singleInput?.focus();
+
+  await sendKeys({ type: '400' });
+
+  expect(host.value).to.deep.equal([100]);
+});

--- a/src/slider.test.interactions.single.ts
+++ b/src/slider.test.interactions.single.ts
@@ -2,78 +2,6 @@ import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import Slider from './slider.js';
 
-it('sets `min` on the input', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider label="Label" min="10"></glide-core-slider>`,
-  );
-
-  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="single-input"]',
-  );
-
-  expect(singleInput?.getAttribute('min')).to.equal('10');
-});
-
-it('sets `step` on the input', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider label="Label" step="10"></glide-core-slider>`,
-  );
-
-  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="single-input"]',
-  );
-
-  expect(singleInput?.getAttribute('step')).to.equal('10');
-});
-
-it('sets `max` on the input', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider label="Label" max="200"></glide-core-slider>`,
-  );
-
-  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="single-input"]',
-  );
-
-  expect(singleInput?.getAttribute('max')).to.equal('200');
-});
-
-it('sets `aria-valuemin` on the handle as `min`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider label="Label" min="20"></glide-core-slider>`,
-  );
-
-  const singleHandle = host.shadowRoot?.querySelector(
-    '[data-test="single-handle"]',
-  );
-
-  expect(singleHandle?.getAttribute('aria-valuemin')).to.equal('20');
-});
-
-it('sets `aria-valuemax` on the minimum handle as `max`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider label="Label" max="200"></glide-core-slider>`,
-  );
-
-  const singleHandle = host.shadowRoot?.querySelector(
-    '[data-test="single-handle"]',
-  );
-
-  expect(singleHandle?.getAttribute('aria-valuemax')).to.equal('200');
-});
-
-it('sets `aria-valuenow` on the handle as `value`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider label="Label" .value=${[7]}></glide-core-slider>`,
-  );
-
-  const singleHandle = host.shadowRoot?.querySelector(
-    '[data-test="single-handle"]',
-  );
-
-  expect(singleHandle?.getAttribute('aria-valuenow')).to.equal('7');
-});
-
 it('updates all relevant elements when `max` is set programmatically', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider label="Label" .value=${[50]}></glide-core-slider>`,
@@ -156,11 +84,10 @@ it('maintains `value` when `min` is set below the current value', async () => {
   host.min = 10;
   await host.updateComplete;
 
-  // Value should remain unchanged
   expect(host.value).to.deep.equal([50]);
 });
 
-it('respects the min/max bounds', async () => {
+it('respects the min/max bounds by ensuring the values do not exceed them', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -426,11 +353,13 @@ it('decreases by `step` when dragging the handle', async () => {
 
   await aTimeout(0);
 
+  // Drag the handle to a location that will force
+  // the value to be rounded down to the nearest `step`.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.2, // 20% position = value of 20
+      clientX: trackRect.left + trackRect.width * 0.2,
     }),
   );
 
@@ -475,11 +404,13 @@ it('increases by `step` when dragging the handle', async () => {
 
   await aTimeout(0);
 
+  // Drag the handle to a location that will force
+  // the value to be rounded up to the nearest `step`.
   document.dispatchEvent(
     new MouseEvent('mousemove', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.3, // 30% position = value of 30
+      clientX: trackRect.left + trackRect.width * 0.3,
     }),
   );
 
@@ -514,28 +445,26 @@ it('clicking on the track updates the value', async () => {
     new MouseEvent('click', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.6, // 60% position
+      clientX: trackRect.left + trackRect.width * 0.6,
     }),
   );
 
   await host.updateComplete;
 
-  // The value should update to the clicked position (60)
   expect(host.value).to.deep.equal([60]);
 
-  // Verify the handle has moved to the clicked position
   const singleHandle = host.shadowRoot?.querySelector(
     '[data-test="single-handle"]',
   );
 
   assert(singleHandle);
 
-  // Get the handle's position as a percentage of the track width
   const handleStyle = window.getComputedStyle(singleHandle);
   const handleLeft = Number.parseFloat(handleStyle.left);
   const handleLeftPercent = (handleLeft / trackRect.width) * 100;
 
-  // The handle should be positioned at approximately 60% (allowing for small rounding differences)
+  // The handle should be positioned at ~60%, allowing
+  // for small rounding differences.
   expect(handleLeftPercent).to.be.closeTo(60, 2);
 });
 
@@ -551,65 +480,17 @@ it('maintains a single value when switching between multiple and single modes', 
   host.multiple = true;
   await host.updateComplete;
 
-  // Should preserve the first value and add a maximum value
+  // Should preserve the first value and
+  // add a maximum value.
   expect(host.value.length).to.equal(2);
   expect(host.value).to.deep.equal([40, 75]);
 
-  // Switch back to single mode
   host.multiple = false;
   await host.updateComplete;
 
-  // Should preserve the first value
+  // Should preserve the first value.
   expect(host.value.length).to.equal(1);
   expect(host.value[0]).to.equal(40);
-});
-
-it('sets the input to disabled when `disabled`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider label="Label" disabled></glide-core-slider>`,
-  );
-
-  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="single-input"]',
-  );
-
-  expect(singleInput?.hasAttribute('disabled')).to.be.true;
-});
-
-it('sets the input to readonly when `readonly`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider label="Label" readonly></glide-core-slider>`,
-  );
-
-  const singleInput = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="single-input"]',
-  );
-
-  expect(singleInput?.hasAttribute('readonly')).to.be.true;
-});
-
-it('sets the handle to aria-disabled when `disabled`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider label="Label" disabled></glide-core-slider>`,
-  );
-
-  const singleHandle = host.shadowRoot?.querySelector(
-    '[data-test="single-handle"]',
-  );
-
-  expect(singleHandle?.hasAttribute('aria-disabled')).to.be.true;
-});
-
-it('sets the handle to aria-readonly when `readonly`', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider label="Label" readonly></glide-core-slider>`,
-  );
-
-  const singleHandle = host.shadowRoot?.querySelector(
-    '[data-test="single-handle"]',
-  );
-
-  expect(singleHandle?.hasAttribute('aria-readonly')).to.be.true;
 });
 
 it('does not update when dragging the handle when `disabled`', async () => {
@@ -644,7 +525,7 @@ it('does not update when dragging the handle when `disabled`', async () => {
     new MouseEvent('mousemove', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.2, // 20% position = value of 20
+      clientX: trackRect.left + trackRect.width * 0.2,
     }),
   );
 
@@ -694,7 +575,7 @@ it('does not update when dragging the handle when `readonly`', async () => {
     new MouseEvent('mousemove', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.2, // 20% position = value of 20
+      clientX: trackRect.left + trackRect.width * 0.2,
     }),
   );
 
@@ -712,7 +593,7 @@ it('does not update when dragging the handle when `readonly`', async () => {
   expect(host.value).to.deep.equal([25]);
 });
 
-it('prevents updating the `value` when clicking on the track when `disabled`', async () => {
+it('prevents updating the value when clicking on the track when `disabled`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -731,7 +612,7 @@ it('prevents updating the `value` when clicking on the track when `disabled`', a
     new MouseEvent('click', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.6, // 60% position
+      clientX: trackRect.left + trackRect.width * 0.6,
     }),
   );
 
@@ -740,7 +621,7 @@ it('prevents updating the `value` when clicking on the track when `disabled`', a
   expect(host.value).to.deep.equal([25]);
 });
 
-it('prevents updating the `value` when clicking on the track when `readonly`', async () => {
+it('prevents updating the value when clicking on the track when `readonly`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -759,7 +640,7 @@ it('prevents updating the `value` when clicking on the track when `readonly`', a
     new MouseEvent('click', {
       bubbles: true,
       cancelable: true,
-      clientX: trackRect.left + trackRect.width * 0.6, // 60% position
+      clientX: trackRect.left + trackRect.width * 0.6,
     }),
   );
 
@@ -768,7 +649,7 @@ it('prevents updating the `value` when clicking on the track when `readonly`', a
   expect(host.value).to.deep.equal([25]);
 });
 
-it('prevents updating the `value` when using the arrow keys on the handle when `disabled`', async () => {
+it('prevents updating the value when using the arrow keys on the handle when `disabled`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -788,7 +669,7 @@ it('prevents updating the `value` when using the arrow keys on the handle when `
   expect(host.value).to.deep.equal([25]);
 });
 
-it('prevents updating the `value` when using the arrow keys on the handle when `readonly`', async () => {
+it('prevents updating the value when using the arrow keys on the handle when `readonly`', async () => {
   const host = await fixture<Slider>(
     html`<glide-core-slider
       label="Label"
@@ -806,34 +687,6 @@ it('prevents updating the `value` when using the arrow keys on the handle when `
   await sendKeys({ press: 'ArrowDown' });
 
   expect(host.value).to.deep.equal([25]);
-});
-
-it('hides the minimum and maximum inputs and sliders', async () => {
-  const host = await fixture<Slider>(
-    html`<glide-core-slider label="Label"></glide-core-slider>`,
-  );
-
-  const maximumInput = host.shadowRoot?.querySelector(
-    '[data-test="maximum-input"]',
-  );
-
-  const minimumInput = host.shadowRoot?.querySelector(
-    '[data-test="minimum-input"]',
-  );
-
-  const maximumHandle = host.shadowRoot?.querySelector(
-    '[data-test="maximum-handle"]',
-  );
-
-  const minimumHandle = host.shadowRoot?.querySelector(
-    '[data-test="minimum-handle"]',
-  );
-
-  expect(maximumInput?.checkVisibility()).to.not.be.ok;
-  expect(minimumInput?.checkVisibility()).to.not.be.ok;
-
-  expect(maximumHandle?.checkVisibility()).to.not.be.ok;
-  expect(minimumHandle?.checkVisibility()).to.not.be.ok;
 });
 
 it('caps the input value to `max` when the entered value exceeds it', async () => {

--- a/src/slider.test.visuals.ts
+++ b/src/slider.test.visuals.ts
@@ -103,6 +103,68 @@ for (const story of stories.Slider) {
           });
         });
 
+        test.describe('orientation="horizontal"', () => {
+          test('tooltip="Tooltip"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-slider')
+              .evaluate<void, Slider>((element) => {
+                element.orientation = 'horizontal';
+                element.tooltip = 'Tooltip';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('tooltip=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-slider')
+              .evaluate<void, Slider>((element) => {
+                element.orientation = 'horizontal';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+        });
+
+        test.describe('orientation="vertical"', () => {
+          test('tooltip="Tooltip"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-slider')
+              .evaluate<void, Slider>((element) => {
+                element.orientation = 'vertical';
+                element.tooltip = 'Tooltip';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('tooltip=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-slider')
+              .evaluate<void, Slider>((element) => {
+                element.orientation = 'vertical';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+        });
+
         test('required', async ({ page }, test) => {
           await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 

--- a/src/slider.test.visuals.ts
+++ b/src/slider.test.visuals.ts
@@ -1,0 +1,186 @@
+import { expect, test } from '@playwright/test';
+import type Slider from './slider.js';
+
+const stories = JSON.parse(process.env.STORIES ?? '');
+
+for (const story of stories.Slider) {
+  test.describe(story.id, () => {
+    for (const theme of story.themes) {
+      test.describe(theme, () => {
+        test(':focus', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page.locator('glide-core-slider').getByRole('slider').focus();
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('hide-label', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-slider')
+            .evaluate<void, Slider>((element) => {
+              element.hideLabel = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test(':hover', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page.locator('glide-core-slider').getByRole('slider').hover();
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test.describe('multiple=${false}', () => {
+          test('disabled', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-slider')
+              .evaluate<void, Slider>((element) => {
+                element.disabled = true;
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('readonly', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-slider')
+              .evaluate<void, Slider>((element) => {
+                element.readonly = true;
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+        });
+
+        test.describe('multiple=${true}', () => {
+          test('disabled', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-slider')
+              .evaluate<void, Slider>((element) => {
+                element.multiple = true;
+                element.disabled = true;
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('readonly', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-slider')
+              .evaluate<void, Slider>((element) => {
+                element.multiple = true;
+                element.readonly = true;
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+        });
+
+        test('required', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-slider')
+            .evaluate<void, Slider>((element) => {
+              element.required = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('slot="description"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-slider')
+            .evaluate<void, Slider>((element) => {
+              const div = document.createElement('div');
+
+              div.textContent = 'Description';
+              div.slot = 'description';
+
+              element.append(div);
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('tooltip', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-slider')
+            .evaluate<void, Slider>((element) => {
+              element.tooltip = 'Tooltip';
+            });
+
+          await page.locator('glide-core-tooltip').getByRole('button').focus();
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test(`value="['80']"`, async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-slider')
+            .evaluate<void, Slider>((element) => {
+              element.value = [80];
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test(`value="['10, 90']"`, async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-slider')
+            .evaluate<void, Slider>((element) => {
+              element.multiple = true;
+              element.value = [10, 90];
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+      });
+    }
+  });
+}

--- a/src/slider.test.visuals.ts
+++ b/src/slider.test.visuals.ts
@@ -69,6 +69,20 @@ for (const story of stories.Slider) {
               `${test.titlePath.join('.')}.png`,
             );
           });
+
+          test(`value="['80']"`, async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-slider')
+              .evaluate<void, Slider>((element) => {
+                element.value = [80];
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
         });
 
         test.describe('multiple=${true}', () => {
@@ -95,6 +109,21 @@ for (const story of stories.Slider) {
               .evaluate<void, Slider>((element) => {
                 element.multiple = true;
                 element.readonly = true;
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test(`value="['10, 90']"`, async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-slider')
+              .evaluate<void, Slider>((element) => {
+                element.multiple = true;
+                element.value = [10, 90];
               });
 
             await expect(page).toHaveScreenshot(
@@ -191,35 +220,6 @@ for (const story of stories.Slider) {
               div.slot = 'description';
 
               element.append(div);
-            });
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
-
-        test(`value="['80']"`, async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-          await page
-            .locator('glide-core-slider')
-            .evaluate<void, Slider>((element) => {
-              element.value = [80];
-            });
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
-
-        test(`value="['10, 90']"`, async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-          await page
-            .locator('glide-core-slider')
-            .evaluate<void, Slider>((element) => {
-              element.multiple = true;
-              element.value = [10, 90];
             });
 
           await expect(page).toHaveScreenshot(

--- a/src/slider.test.visuals.ts
+++ b/src/slider.test.visuals.ts
@@ -198,22 +198,6 @@ for (const story of stories.Slider) {
           );
         });
 
-        test('tooltip', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-          await page
-            .locator('glide-core-slider')
-            .evaluate<void, Slider>((element) => {
-              element.tooltip = 'Tooltip';
-            });
-
-          await page.locator('glide-core-tooltip').getByRole('button').focus();
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
-
         test(`value="['80']"`, async ({ page }, test) => {
           await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -484,7 +484,14 @@ export default class Slider extends LitElement implements FormControl {
             () =>
               html`<input
                   aria-describedby="meta"
-                  aria-label=${this.#localize.term('setMinimum', this.label!)}
+                  aria-label=${this.#localize.term(
+                    'setMinimum',
+                    // `this.label` is always defined because it's a
+                    // required attribute.
+                    //
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    this.label!,
+                  )}
                   aria-invalid=${this.#isShowValidationFeedback}
                   class=${classMap({
                     input: true,
@@ -531,7 +538,14 @@ export default class Slider extends LitElement implements FormControl {
 
                     <div
                       aria-disabled=${this.disabled}
-                      aria-label=${this.#localize.term('minimum', this.label!)}
+                      aria-label=${this.#localize.term(
+                        'minimum',
+                        // `this.label` is always defined because
+                        // it's a required attribute.
+                        //
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        this.label!,
+                      )}
                       aria-readonly=${this.readonly}
                       aria-valuemin=${this.min}
                       aria-valuemax=${this.max}
@@ -551,7 +565,14 @@ export default class Slider extends LitElement implements FormControl {
 
                     <div
                       aria-disabled=${this.disabled}
-                      aria-label=${this.#localize.term('maximum', this.label!)}
+                      aria-label=${this.#localize.term(
+                        'maximum',
+                        // `this.label` is always defined because
+                        // it's a required attribute.
+                        //
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        this.label!,
+                      )}
                       aria-readonly=${this.readonly}
                       aria-valuemin=${this.min}
                       aria-valuemax=${this.max}
@@ -572,7 +593,13 @@ export default class Slider extends LitElement implements FormControl {
                 </div>
 
                 <input
-                  aria-label=${this.#localize.term('setMaximum', this.label!)}
+                  aria-label=${this.#localize.term(
+                    'setMaximum',
+                    // `this.label` is always defined because it's a required attribute.
+                    //
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    this.label!,
+                  )}
                   aria-invalid=${this.#isShowValidationFeedback}
                   class=${classMap({
                     input: true,
@@ -964,11 +991,15 @@ export default class Slider extends LitElement implements FormControl {
   }
 
   #onMaximumHandleKeydown(event: KeyboardEvent) {
-    this.#onMultipleHandleKeydown(event, this.#maximumHandleElementRef.value!);
+    if (this.#maximumHandleElementRef.value) {
+      this.#onMultipleHandleKeydown(event, this.#maximumHandleElementRef.value);
+    }
   }
 
   #onMaximumHandleMousedown(event: MouseEvent) {
-    this.#startDragging(event, this.#maximumHandleElementRef.value!);
+    if (this.#maximumHandleElementRef.value) {
+      this.#startDragging(event, this.#maximumHandleElementRef.value);
+    }
   }
 
   #onMaximumInputChange() {
@@ -1003,11 +1034,15 @@ export default class Slider extends LitElement implements FormControl {
   }
 
   #onMinimumHandleKeydown(event: KeyboardEvent) {
-    this.#onMultipleHandleKeydown(event, this.#minimumHandleElementRef.value!);
+    if (this.#minimumHandleElementRef.value) {
+      this.#onMultipleHandleKeydown(event, this.#minimumHandleElementRef.value);
+    }
   }
 
   #onMinimumHandleMousedown(event: MouseEvent) {
-    this.#startDragging(event, this.#minimumHandleElementRef.value!);
+    if (this.#minimumHandleElementRef.value) {
+      this.#startDragging(event, this.#minimumHandleElementRef.value);
+    }
   }
 
   #onMinimumInputChange() {
@@ -1185,7 +1220,9 @@ export default class Slider extends LitElement implements FormControl {
   }
 
   #onSingleHandleMousedown(event: MouseEvent) {
-    this.#startDragging(event, this.#singleHandleElementRef.value!);
+    if (this.#singleHandleElementRef.value) {
+      this.#startDragging(event, this.#singleHandleElementRef.value);
+    }
   }
 
   #onSingleInputChange() {

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -455,7 +455,7 @@ export default class Slider extends LitElement implements FormControl {
                 <div class="slider-wrapper">
                   <div
                     class=${classMap({
-                      'open-track': true,
+                      'unfilled-track': true,
                       disabled: this.disabled,
                     })}
                     data-test="slider"
@@ -543,7 +543,7 @@ export default class Slider extends LitElement implements FormControl {
               html`<div class="slider-wrapper single">
                   <div
                     class=${classMap({
-                      'open-track': true,
+                      'unfilled-track': true,
                       disabled: this.disabled,
                     })}
                     data-test="slider"

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -129,6 +129,10 @@ export default class Slider extends LitElement implements FormControl {
       value[0] !== undefined &&
       value[1] !== undefined
     ) {
+      if (value[0] > value[1]) {
+        throw new Error('The first value must be less than the second.');
+      }
+
       // Normalize values to snap to the closest valid step
       // increment, even if a developer sets a value between
       // steps.

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -28,7 +28,7 @@ declare global {
  * @attr {number} [min=0]
  * @attr {boolean} [multiple=false]
  * @attr {string} [name='']
- * @attr {'vertical'} [orientation='vertical']
+ * @attr {'horizontal'|'vertical'} [orientation='horizontal']
  * @attr {boolean} [readonly=false]
  * @attr {boolean} [required=false]
  * @attr {number} [step=1]
@@ -165,8 +165,8 @@ export default class Slider extends LitElement implements FormControl {
   @required
   label?: string;
 
-  @property({ reflect: true })
-  orientation = 'vertical' as const;
+  @property({ reflect: true, useDefault: true })
+  orientation: 'horizontal' | 'vertical' = 'horizontal';
 
   @property({ attribute: 'hide-label', type: Boolean })
   hideLabel = false;
@@ -294,8 +294,17 @@ export default class Slider extends LitElement implements FormControl {
     }
   }
 
+  /**
+   * @default 1
+   */
   @property({ reflect: true, type: Number, useDefault: true })
-  step = 1;
+  get step(): number {
+    return this.#step;
+  }
+
+  set step(step: number) {
+    this.#step = step > 0 ? step : 1;
+  }
 
   // Private because it's only meant to be used by Form Controls Layout.
   @property()
@@ -409,7 +418,7 @@ export default class Slider extends LitElement implements FormControl {
           middle: this.privateSplit === 'middle',
         })}
         label=${ifDefined(this.label)}
-        orientation="vertical"
+        orientation=${this.orientation}
         split=${ifDefined(this.privateSplit ?? undefined)}
         tooltip=${ifDefined(this.tooltip)}
         ?disabled=${this.disabled}
@@ -459,7 +468,7 @@ export default class Slider extends LitElement implements FormControl {
                   ${ref(this.#minimumInputElementRef)}
                 />
 
-                <div class="slider-wrapper">
+                <div class="track-container">
                   <div
                     class=${classMap({
                       'unfilled-track': true,
@@ -547,7 +556,7 @@ export default class Slider extends LitElement implements FormControl {
                   ${ref(this.#maximumInputElementRef)}
                 />`,
             () =>
-              html`<div class="slider-wrapper single">
+              html`<div class="track-container single">
                   <div
                     class=${classMap({
                       'unfilled-track': true,
@@ -768,6 +777,8 @@ export default class Slider extends LitElement implements FormControl {
   #sliderElementRef = createRef<HTMLDivElement>();
 
   #sliderFillElementRef = createRef<HTMLDivElement>();
+
+  #step = 1;
 
   get #isShowValidationFeedback() {
     return (

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -173,7 +173,11 @@ export default class Slider extends LitElement implements FormControl {
         this.min,
       );
 
-      // Clear maximumValue to ensure consistency in single handle mode.
+      // When not in multiple mode, we clear the maximumValue to
+      // ensure the Slider won't get in an odd state as the minimumValue
+      // is adjusted. If a consumers add the multiple attribute, we
+      // recalculate what the maximumValue should be based on the current
+      // position of the minimum handle with respect to max and step.
       this.maximumValue = undefined;
 
       this.#updateHandlesAndTrack();
@@ -298,7 +302,7 @@ export default class Slider extends LitElement implements FormControl {
       const rangeSize = this.max - this.min;
 
       // Design calls for positioning the maximum handle at 75% of
-      // the available range.
+      // the range size.
       const desiredMaximumValue = this.min + Math.ceil(rangeSize * 0.75);
 
       // There may be cases where the current minimum value now
@@ -307,10 +311,10 @@ export default class Slider extends LitElement implements FormControl {
       if (this.minimumValue >= desiredMaximumValue) {
         this.maximumValue = this.max;
 
-        // If the minimum value is still (somehow) larger,
-        // we lower it to help prevent the component from
-        // getting into an invalid state. This is hopefully
-        // an edge case, but one we should account for.
+        // If the minimum value is still larger, we lower it to help
+        // prevent the component from getting into an invalid state.
+        // This is hopefully an edge case, but one we should account
+        // for.
         if (this.minimumValue >= this.maximumValue) {
           this.minimumValue = this.maximumValue - this.step;
         }
@@ -384,7 +388,6 @@ export default class Slider extends LitElement implements FormControl {
       this.minimumValue = this.value.at(0);
       this.maximumValue = this.value.at(1);
 
-      // Have to add this check to satisfy TypeScript
       if (this.minimumValue !== undefined && this.maximumValue !== undefined) {
         this.#initialValue = [this.minimumValue, this.maximumValue];
       }
@@ -397,11 +400,11 @@ export default class Slider extends LitElement implements FormControl {
       const rangeSize = this.max - this.min;
 
       // When the native range input is not provided a value,
-      // it defaults it to 50% of the max. Our design requirements
-      // are a little bit different, in that they want the single
-      // slider and minimum handle in multiple mode to be at
-      // 25% of the range size, and the maximum handle in multiple
-      // mode to be at 75% of the range size.
+      // it defaults value to 50% of the max. Our design requirements
+      // are different, in that they want the single slider or minimum
+      // handle in multiple mode to be at 25% of the range size, and
+      // the maximum handle in multiple mode to be at 75% of the range
+      // size.
       this.minimumValue = this.min + Math.floor(rangeSize * 0.25);
 
       this.maximumValue = this.multiple

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -1,0 +1,1258 @@
+import './label.js';
+import { html, LitElement } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { createRef, ref } from 'lit/directives/ref.js';
+import { customElement, property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { when } from 'lit/directives/when.js';
+import packageJson from '../package.json' with { type: 'json' };
+import { LocalizeController } from './library/localize.js';
+import styles from './slider.styles.js';
+import type FormControl from './library/form-control.js';
+import shadowRootMode from './library/shadow-root-mode.js';
+import final from './library/final.js';
+import required from './library/required.js';
+
+// TONY TODO:
+// - Move the firstUpdated default setting when no value
+//   changes into the value setter instead.
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'glide-core-slider': Slider;
+  }
+}
+
+/**
+ * @attr {string} label
+ * @attr {boolean} [disabled=false]
+ * @attr {boolean} [hide-label=false]
+ * @attr {number} [max=100]
+ * @attr {number} [min=0]
+ * @attr {boolean} [multiple=false]
+ * @attr {string} [name='']
+ * @attr {'vertical'} [orientation='vertical']
+ * @attr {boolean} [readonly=false]
+ * @attr {boolean} [required=false]
+ * @attr {number} [step=1]
+ * @attr {string} [tooltip]
+ * @attr {number[]} [value=[]]
+ *
+ * @readonly
+ * @attr {string} [version]
+ *
+ * @slot {Element | string} [description] - Additional information or context
+ *
+ * @fires {Event} change
+ * @fires {Event} input
+ * @fires {Event} invalid
+ *
+ * @readonly
+ * @prop {HTMLFormElement | null} form
+ *
+ * @readonly
+ * @prop {ValidityState} validity
+ *
+ * @method checkValidity
+ * @returns boolean
+ *
+ * @method formAssociatedCallback
+ * @method formResetCallback
+ *
+ * @method reportValidity
+ * @returns boolean
+ *
+ * @method resetValidityFeedback
+ *
+ * @method setCustomValidity
+ * @param {string} message
+ *
+ * @method setValidity
+ * @param {ValidityStateFlags} [flags]
+ * @param {string} [message]
+ */
+@customElement('glide-core-slider')
+@final
+export default class Slider extends LitElement implements FormControl {
+  static formAssociated = true;
+
+  static override shadowRootOptions: ShadowRootInit = {
+    ...LitElement.shadowRootOptions,
+    mode: shadowRootMode,
+    delegatesFocus: true,
+  };
+
+  static override styles = styles;
+
+  @property({ reflect: true, useDefault: true })
+  name = '';
+
+  // Intentionally not reflected to match native.
+  /**
+   * @default []
+   */
+  @property({ type: Array })
+  get value(): number[] {
+    if (
+      this.multiple &&
+      this.minimumValue !== undefined &&
+      this.maximumValue !== undefined
+    ) {
+      return [this.minimumValue, this.maximumValue];
+    }
+
+    if (this.minimumValue !== undefined) {
+      return [this.minimumValue];
+    }
+
+    return [];
+  }
+
+  set value(value: number[]) {
+    // TONY TODO:
+    // Update firstUpdated to this instead:
+    //
+    // if !value
+    //   set defaults
+    //
+    // Comment:
+    // Can expect a warning in the console, don't worry
+
+    if (
+      this.multiple &&
+      value.length === 2 &&
+      value[0] !== undefined &&
+      value[1] !== undefined
+    ) {
+      const normalizedMinimum = Math.round(value[0] / this.step) * this.step;
+      const normalizedMaximum = Math.round(value[1] / this.step) * this.step;
+
+      this.minimumValue = Math.max(normalizedMinimum, this.min);
+      this.maximumValue = Math.min(normalizedMaximum, this.max);
+
+      this.#updateHandlesAndTrack();
+      return;
+    }
+
+    if (!this.multiple && value.length > 0 && value[0] !== undefined) {
+      const normalizedValue = Math.round(value[0] / this.step) * this.step;
+
+      this.minimumValue = Math.max(
+        Math.min(normalizedValue, this.max),
+        this.min,
+      );
+
+      // Clear maximumValue to ensure consistency in single handle mode
+      this.maximumValue = undefined;
+
+      this.#updateHandlesAndTrack();
+      return;
+    }
+  }
+
+  @property({ reflect: true })
+  @required
+  label?: string;
+
+  @property({ reflect: true })
+  orientation = 'vertical' as const;
+
+  @property({ attribute: 'hide-label', type: Boolean })
+  hideLabel = false;
+
+  @property({ reflect: true, type: Boolean })
+  required = false;
+
+  @property({ type: Boolean })
+  readonly = false;
+
+  @property({ reflect: true, type: Boolean })
+  disabled = false;
+
+  /**
+   * @default 100
+   */
+  @property({ reflect: true, type: Number })
+  get max(): number {
+    return this.#max;
+  }
+
+  set max(max: number) {
+    this.#max = max;
+
+    this.maximumValue = Math.min(this.maximumValue ?? this.#max, max);
+
+    // Help the user out by clamping the minimum value if it is now
+    // greater than the `max` to prevent the UI from being in a position
+    // where a user can't interact with the handles.
+    //
+    // In multiple mode, we can decide which value to set it to by
+    // looking at `max` and the current value and `step`.
+    // But in single mode, it's easier, because we can simply
+    // set the current value to the provided `max`.
+    if (this.minimumValue !== undefined && this.minimumValue > max) {
+      this.minimumValue =
+        this.multiple && this.maximumValue !== undefined
+          ? Math.min(max, this.maximumValue - this.step)
+          : max;
+    }
+
+    this.#updateHandlesAndTrack();
+  }
+
+  /**
+   * @default 0
+   */
+  @property({ reflect: true, type: Number })
+  get min(): number {
+    return this.#min;
+  }
+
+  set min(min: number) {
+    this.#min = min;
+
+    this.minimumValue = Math.max(this.minimumValue ?? this.#min, min);
+
+    if (this.multiple) {
+      // Help the user out by clamping the maximum value if it is now
+      // less than the `min` to prevent the sliders from being in a
+      // position where a user can't easily interact with the handles.
+      //
+      // We'll leverage the minimumValue and `step` for our maximumValue
+      // in this case.
+      if (this.maximumValue !== undefined && this.maximumValue < min) {
+        this.maximumValue = Math.max(min, this.minimumValue + this.step);
+      }
+    } else {
+      // In single mode, it's safer to always reset the
+      // maximumValue to undefined when `min` changes
+      // to prevent getting into states where the maximumValue
+      // persists.
+      this.maximumValue = undefined;
+    }
+
+    this.#updateHandlesAndTrack();
+  }
+
+  /**
+   * @default false
+   */
+  @property({ type: Boolean })
+  get multiple(): boolean {
+    return this.#multiple;
+  }
+
+  set multiple(multiple: boolean) {
+    const oldValue = this.#multiple;
+    this.#multiple = multiple;
+
+    if (oldValue && !multiple) {
+      this.maximumValue = undefined;
+
+      this.requestUpdate();
+
+      this.updateComplete.then(() => {
+        this.#updateHandlesAndTrack();
+      });
+    } else if (!oldValue && multiple && this.minimumValue !== undefined) {
+      const rangeSize = this.max - this.min;
+
+      // As per the designs, we always try to default the
+      // maximum value to ~75% of the range size available.
+      const desiredMaximumValue = this.min + Math.ceil(rangeSize * 0.75);
+
+      // However, there may be cases where the current
+      // minimum value now exceeds that 75% threshold.
+      // We attempt to account for this case by updating
+      // the maximum value to `max`.
+      if (this.minimumValue >= desiredMaximumValue) {
+        this.maximumValue = this.max;
+
+        // If the minimum value is still (somehow) larger,
+        // we lower it to help prevent the component from
+        // getting into an invalid state. This is hopefully
+        // an edge case, but one we should account for.
+        if (this.minimumValue >= this.maximumValue) {
+          this.minimumValue = this.maximumValue - this.step;
+        }
+      } else {
+        this.maximumValue = desiredMaximumValue;
+      }
+
+      this.requestUpdate();
+
+      this.updateComplete.then(() => {
+        this.#updateHandlesAndTrack();
+      });
+    }
+  }
+
+  @property({ reflect: true, type: Number, useDefault: true })
+  step = 1;
+
+  // Private because it's only meant to be used by Form Controls Layout.
+  @property()
+  privateSplit?: 'left' | 'middle';
+
+  @property({ reflect: true })
+  readonly version: string = packageJson.version;
+
+  @property({ reflect: true })
+  tooltip?: string;
+
+  get form(): HTMLFormElement | null {
+    return this.#internals.form;
+  }
+
+  get validity(): ValidityState {
+    return this.#internals.validity;
+  }
+
+  checkValidity(): boolean {
+    this.isCheckingValidity = true;
+    const isValid = this.#internals.checkValidity();
+    this.isCheckingValidity = false;
+
+    return isValid;
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.form?.removeEventListener('formdata', this.#onFormdata);
+
+    document.removeEventListener('mousemove', this.#onDraggingMousemove);
+    document.removeEventListener('mouseup', this.#onDraggingMouseup);
+  }
+
+  override firstUpdated() {
+    if (!this.multiple && this.value.length === 1) {
+      this.minimumValue = this.value.at(0);
+
+      this.#initialValue = this.value;
+
+      this.#updateHandlesAndTrack();
+      return;
+    }
+
+    if (this.multiple && this.value.length === 2) {
+      this.minimumValue = this.value.at(0);
+      this.maximumValue = this.value.at(1);
+
+      // Have to add this check to satisfy TypeScript
+      if (this.minimumValue !== undefined && this.maximumValue !== undefined) {
+        this.#initialValue = [this.minimumValue, this.maximumValue];
+      }
+
+      this.#updateHandlesAndTrack();
+      return;
+    }
+
+    if (!this.value || this.value.length === 0) {
+      const rangeSize = this.max - this.min;
+
+      // We have a design requirement that when a Slider isn't
+      // provided a default value, to set it 25% for the
+      // single slider and 25% and 75% for the multiple slider.
+      // This roughly aligns with native, at least by setting
+      // a default value.
+      this.minimumValue = this.min + Math.floor(rangeSize * 0.25);
+
+      this.maximumValue = this.multiple
+        ? this.min + Math.ceil(rangeSize * 0.75)
+        : undefined;
+
+      this.#initialValue =
+        this.multiple && this.maximumValue !== undefined
+          ? [this.minimumValue, this.maximumValue]
+          : [this.minimumValue];
+
+      this.#updateHandlesAndTrack();
+    }
+  }
+
+  formAssociatedCallback(): void {
+    this.form?.addEventListener('formdata', this.#onFormdata.bind(this));
+  }
+
+  formResetCallback(): void {
+    this.value = this.#initialValue;
+  }
+
+  override render() {
+    // The #slider element has a click handler for convenience
+    // to allow for users to click anywhere on the track and have
+    // a handle move to that position. This is a situation where the
+    // linter is being overzealous without considering the full context
+    // of the component.
+    //
+    // This behavior is an ehancement rather than essential functionality.
+    //
+    // A keyboard user can already update this component
+    // via the inputs directly or via the handles. Exposing the track via
+    // keyboard wouldn't bring any real value in this instance.
+    //
+    // So... we disable it.
+
+    /*  eslint-disable lit-a11y/click-events-have-key-events */
+    return html`
+      <glide-core-private-label
+        class=${classMap({
+          left: this.privateSplit === 'left',
+          middle: this.privateSplit === 'middle',
+        })}
+        label=${ifDefined(this.label)}
+        orientation="vertical"
+        split=${ifDefined(this.privateSplit ?? undefined)}
+        tooltip=${ifDefined(this.tooltip)}
+        ?disabled=${this.disabled}
+        ?error=${this.#isShowValidationFeedback}
+        ?hide=${this.hideLabel}
+        ?required=${this.required}
+      >
+        <label>${this.label}</label>
+
+        <div
+          class=${classMap({
+            'slider-container': true,
+            disabled: this.disabled,
+            readonly: this.readonly && !this.disabled,
+            error: this.#isShowValidationFeedback,
+          })}
+          slot="control"
+        >
+          ${when(
+            this.multiple,
+            () =>
+              html`<input
+                  aria-describedby="meta"
+                  aria-label=${this.#localize.term('setMinimum', this.label!)}
+                  aria-invalid=${this.#isShowValidationFeedback}
+                  class=${classMap({
+                    input: true,
+                    disabled: this.disabled,
+                    error: this.#isShowValidationFeedback,
+                    readonly: this.readonly && !this.disabled,
+                  })}
+                  data-test="minimum-input"
+                  max=${ifDefined(
+                    this.maximumValue
+                      ? this.maximumValue - this.step
+                      : undefined,
+                  )}
+                  min=${this.min}
+                  step=${this.step}
+                  type="number"
+                  .value=${this.minimumValue?.toString() ?? ''}
+                  ?disabled=${this.disabled}
+                  ?readonly=${this.readonly}
+                  @change=${this.#onMinimumInputChange.bind(this)}
+                  @input=${this.#onMinimumInputInput}
+                  @keydown=${this.#onInputKeydown}
+                  ${ref(this.#minimumInputElementRef)}
+                />
+
+                <div class="slider-wrapper">
+                  <div
+                    class=${classMap({
+                      'open-track': true,
+                      disabled: this.disabled,
+                    })}
+                    data-test="slider"
+                    role="group"
+                    @click=${this.#onTrackClick.bind(this)}
+                    ${ref(this.#sliderElementRef)}
+                  >
+                    <div
+                      class=${classMap({
+                        'filled-track': true,
+                        disabled: this.disabled,
+                      })}
+                      ${ref(this.#sliderFillElementRef)}
+                    ></div>
+
+                    <div
+                      aria-disabled=${this.disabled}
+                      aria-label=${this.#localize.term('minimum', this.label!)}
+                      aria-readonly=${this.readonly}
+                      aria-valuemin=${this.min}
+                      aria-valuemax=${this.max}
+                      aria-valuenow=${ifDefined(this.minimumValue)}
+                      class=${classMap({
+                        handle: true,
+                        disabled: this.disabled,
+                        readonly: this.readonly && !this.disabled,
+                      })}
+                      data-test="minimum-handle"
+                      role="slider"
+                      tabindex="0"
+                      @mousedown=${this.#onMinimumHandleMousedown.bind(this)}
+                      @keydown=${this.#onMinimumHandleKeydown.bind(this)}
+                      ${ref(this.#minimumHandleElementRef)}
+                    ></div>
+
+                    <div
+                      aria-disabled=${this.disabled}
+                      aria-label=${this.#localize.term('maximum', this.label!)}
+                      aria-readonly=${this.readonly}
+                      aria-valuemin=${this.min}
+                      aria-valuemax=${this.max}
+                      aria-valuenow=${ifDefined(this.maximumValue)}
+                      class=${classMap({
+                        handle: true,
+                        disabled: this.disabled,
+                        readonly: this.readonly && !this.disabled,
+                      })}
+                      data-test="maximum-handle"
+                      role="slider"
+                      tabindex="0"
+                      @mousedown=${this.#onMaximumHandleMousedown.bind(this)}
+                      @keydown=${this.#onMaximumHandleKeydown.bind(this)}
+                      ${ref(this.#maximumHandleElementRef)}
+                    ></div>
+                  </div>
+                </div>
+
+                <input
+                  aria-label=${this.#localize.term('setMaximum', this.label!)}
+                  aria-invalid=${this.#isShowValidationFeedback}
+                  class=${classMap({
+                    input: true,
+                    disabled: this.disabled,
+                    error: this.#isShowValidationFeedback,
+                    readonly: this.readonly && !this.disabled,
+                  })}
+                  data-test="maximum-input"
+                  max=${this.max}
+                  min=${ifDefined(
+                    this.minimumValue
+                      ? this.minimumValue + this.step
+                      : undefined,
+                  )}
+                  step=${this.step}
+                  type="number"
+                  .value=${this.maximumValue?.toString() ?? ''}
+                  ?disabled=${this.disabled}
+                  ?readonly=${this.readonly}
+                  @change=${this.#onMaximumInputChange.bind(this)}
+                  @input=${this.#onMaximumInputInput}
+                  @keydown=${this.#onInputKeydown}
+                  ${ref(this.#maximumInputElementRef)}
+                />`,
+            () =>
+              html`<div class="slider-wrapper single">
+                  <div
+                    class=${classMap({
+                      'open-track': true,
+                      disabled: this.disabled,
+                    })}
+                    data-test="slider"
+                    role="group"
+                    @click=${this.#onTrackClick.bind(this)}
+                    ${ref(this.#sliderElementRef)}
+                  >
+                    <div
+                      class=${classMap({
+                        'filled-track': true,
+                        disabled: this.disabled,
+                      })}
+                      ${ref(this.#sliderFillElementRef)}
+                    ></div>
+
+                    <div
+                      aria-describedby="meta"
+                      aria-disabled=${this.disabled}
+                      aria-label=${ifDefined(this.label)}
+                      aria-readonly=${this.readonly}
+                      aria-valuemin=${this.min}
+                      aria-valuemax=${this.max}
+                      aria-valuenow=${ifDefined(this.minimumValue)}
+                      class=${classMap({
+                        handle: true,
+                        disabled: this.disabled,
+                        readonly: this.readonly && !this.disabled,
+                      })}
+                      data-test="single-handle"
+                      role="slider"
+                      tabindex="0"
+                      @mousedown=${this.#onSingleHandleMousedown.bind(this)}
+                      @keydown=${this.#onSingleHandleKeyDown.bind(this)}
+                      ${ref(this.#singleHandleElementRef)}
+                    ></div>
+                  </div>
+                </div>
+
+                <input
+                  aria-label=${ifDefined(this.label)}
+                  aria-invalid=${this.#isShowValidationFeedback}
+                  class=${classMap({
+                    input: true,
+                    disabled: this.disabled,
+                    error: this.#isShowValidationFeedback,
+                    readonly: this.readonly && !this.disabled,
+                  })}
+                  data-test="single-input"
+                  max=${this.max}
+                  min=${this.min}
+                  step=${this.step}
+                  type="number"
+                  .value=${this.minimumValue?.toString() ?? ''}
+                  ?disabled=${this.disabled}
+                  ?readonly=${this.readonly}
+                  @change=${this.#onSingleInputChange.bind(this)}
+                  @input=${this.#onSingleInputInput.bind(this)}
+                  @keydown=${this.#onInputKeydown}
+                  ${ref(this.#singleInputElementRef)}
+                />`,
+          )}
+        </div>
+
+        <div class="meta" id="meta" slot="description">
+          <slot
+            class=${classMap({
+              description: true,
+              hidden: Boolean(
+                this.#isShowValidationFeedback && this.validityMessage,
+              ),
+            })}
+            name="description"
+          >
+            <!--
+              Additional information or context
+              @type {Element | string}
+            -->
+          </slot>
+
+          ${when(
+            this.#isShowValidationFeedback && this.validityMessage,
+            () =>
+              html`<span class="validity-message" data-test="validity-message"
+                >${unsafeHTML(this.validityMessage)}</span
+              >`,
+          )}
+        </div>
+      </glide-core-private-label>
+    `;
+  }
+
+  reportValidity(): boolean {
+    this.isReportValidityOrSubmit = true;
+
+    const isValid = this.#internals.reportValidity();
+
+    // Ensures that getters referencing this.validity?.valid update (i.e. #isShowValidationFeedback)
+    this.requestUpdate();
+
+    return isValid;
+  }
+
+  resetValidityFeedback(): void {
+    this.isReportValidityOrSubmit = false;
+  }
+
+  setCustomValidity(message: string): void {
+    this.validityMessage = message;
+
+    if (message === '') {
+      this.#internals.setValidity(
+        { customError: false },
+        '',
+        this.#inputElementRef.value,
+      );
+    } else {
+      // A validation message is required but unused because we disable native validation feedback.
+      // And an empty string isn't allowed. Thus a single space.
+      this.#internals.setValidity(
+        {
+          customError: true,
+          patternMismatch: this.#internals.validity.patternMismatch,
+          valueMissing: this.#internals.validity.valueMissing,
+        },
+        ' ',
+        this.#inputElementRef.value,
+      );
+    }
+  }
+
+  setValidity(flags?: ValidityStateFlags, message?: string): void {
+    this.validityMessage = message;
+
+    // A validation message is required but unused because we disable native validation feedback.
+    // And an empty string isn't allowed. Thus a single space.
+    this.#internals.setValidity(flags, ' ', this.#inputElementRef.value);
+  }
+
+  constructor() {
+    super();
+    this.#internals = this.attachInternals();
+
+    // Event handlers on the host aren't great because consumers can remove them.
+    // Unfortunately, the host is the only thing on which this event is dispatched
+    // because it's the host that is form-associated.
+    this.addEventListener('invalid', (event) => {
+      event?.preventDefault(); // Canceled so a native validation message isn't shown.
+
+      // We only want to focus the slider if the invalid event resulted from either:
+      // 1. Form submission
+      // 2. a call to reportValidity that did NOT result from the slider blur event
+      if (this.isCheckingValidity || this.isBlurring) {
+        return;
+      }
+
+      this.isReportValidityOrSubmit = true;
+
+      const isFirstInvalidFormElement =
+        this.form?.querySelector(':invalid') === this;
+
+      if (isFirstInvalidFormElement) {
+        this.focus();
+      }
+    });
+  }
+
+  @state()
+  private isBlurring = false;
+
+  @state()
+  private isCheckingValidity = false;
+
+  @state()
+  private isReportValidityOrSubmit = false;
+
+  @state()
+  private maximumValue?: number;
+
+  @state()
+  private minimumValue?: number;
+
+  @state()
+  private validityMessage?: string;
+
+  #draggingHandleElement?: HTMLElement;
+
+  #initialValue: number[] = [];
+
+  #inputElementRef = createRef<HTMLInputElement>();
+
+  #internals: ElementInternals;
+
+  #isCompletingDrag = false;
+
+  #localize = new LocalizeController(this);
+
+  #max = 100;
+
+  #maximumHandleElementRef = createRef<HTMLDivElement>();
+
+  #maximumInputElementRef = createRef<HTMLInputElement>();
+
+  #min = 0;
+
+  #minimumHandleElementRef = createRef<HTMLDivElement>();
+
+  #minimumInputElementRef = createRef<HTMLInputElement>();
+
+  #multiple = false;
+
+  #singleHandleElementRef = createRef<HTMLDivElement>();
+
+  #singleInputElementRef = createRef<HTMLInputElement>();
+
+  #sliderElementRef = createRef<HTMLDivElement>();
+
+  #sliderFillElementRef = createRef<HTMLDivElement>();
+
+  get #isShowValidationFeedback() {
+    return (
+      !this.disabled && !this.validity?.valid && this.isReportValidityOrSubmit
+    );
+  }
+
+  // An arrow function field instead of a method so `this` is closed over and set
+  // to the component instead of `document`.
+  #onDraggingMousemove = (mouseEvent: MouseEvent) => {
+    mouseEvent.preventDefault();
+
+    const slider = this.#sliderElementRef.value;
+
+    if (slider && this.#draggingHandleElement) {
+      const { clientX } = mouseEvent;
+
+      if (clientX !== undefined) {
+        const sliderRect = slider.getBoundingClientRect();
+        this.#onDrag(clientX, this.#draggingHandleElement, sliderRect);
+      }
+    }
+  };
+
+  // An arrow function field instead of a method so `this` is closed over and set
+  // to the component instead of `document`.
+  #onDraggingMouseup = () => {
+    if (this.#draggingHandleElement) {
+      document.removeEventListener('mousemove', this.#onDraggingMousemove);
+      document.removeEventListener('mouseup', this.#onDraggingMouseup);
+
+      this.dispatchEvent(
+        new Event('change', { bubbles: true, composed: true }),
+      );
+
+      this.#isCompletingDrag = true;
+
+      this.#draggingHandleElement = undefined;
+
+      // Dragging involves interacting with the handles on a track.
+      // Track clicks can inadvertently occur when letting go of
+      // a handle. To help combat that, we use this variable to
+      // keep track of when we are still processing a drag event.
+      //
+      // Resetting the state in the next frame allows the drag
+      // to fully complete before accept tracking click events
+      // again.
+      setTimeout(() => {
+        this.#isCompletingDrag = false;
+      });
+    }
+  };
+
+  #onDrag(clientX: number, handle: HTMLElement, sliderRect: DOMRect) {
+    const position = (clientX - sliderRect.left) / sliderRect.width;
+    const clampedPosition = position * (this.max - this.min) + this.min;
+    const valueUsingStep = Math.round(clampedPosition / this.step) * this.step;
+
+    // Track if any value actually changed to match native
+    let hasValueChanged = false;
+
+    if (this.multiple) {
+      const isMinimumHandle = handle === this.#minimumHandleElementRef.value;
+
+      if (isMinimumHandle && this.maximumValue) {
+        const newValue = Math.min(
+          Math.max(valueUsingStep, this.min),
+          this.maximumValue - this.step,
+        );
+
+        if (newValue !== this.minimumValue) {
+          this.minimumValue = newValue;
+          hasValueChanged = true;
+        }
+      } else if (this.minimumValue !== undefined) {
+        const newValue = Math.min(
+          Math.max(valueUsingStep, this.minimumValue + this.step),
+          this.max,
+        );
+
+        if (newValue !== this.maximumValue) {
+          this.maximumValue = newValue;
+          hasValueChanged = true;
+        }
+      }
+
+      this.#updateHandlesAndTrack();
+
+      if (hasValueChanged) {
+        this.dispatchEvent(
+          new Event('input', { bubbles: true, composed: true }),
+        );
+      }
+
+      return;
+    }
+
+    const newValue = Math.min(Math.max(valueUsingStep, this.min), this.max);
+
+    if (newValue !== this.minimumValue) {
+      this.minimumValue = newValue;
+      hasValueChanged = true;
+    }
+
+    this.#updateHandlesAndTrack();
+
+    if (hasValueChanged) {
+      this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    }
+  }
+
+  #onFormdata(event: FormDataEvent) {
+    if (this.name && this.value && !this.disabled) {
+      event.formData.append(this.name, JSON.stringify(this.value));
+    }
+  }
+
+  #onInputKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      this.form?.requestSubmit();
+    }
+  }
+
+  #onMaximumHandleKeydown(event: KeyboardEvent) {
+    this.#onMultipleHandleKeydown(event, this.#maximumHandleElementRef.value!);
+  }
+
+  #onMaximumHandleMousedown(event: MouseEvent) {
+    this.#startDragging(event, this.#maximumHandleElementRef.value!);
+  }
+
+  #onMaximumInputChange() {
+    if (this.#maximumInputElementRef.value && this.minimumValue !== undefined) {
+      const maximumInput = this.#maximumInputElementRef.value;
+
+      let valueUsingStep = Number(maximumInput.value);
+      valueUsingStep = Math.round(valueUsingStep / this.step) * this.step;
+
+      this.maximumValue = Math.min(
+        Math.max(valueUsingStep, this.minimumValue + this.step),
+        this.max,
+      );
+
+      maximumInput.value = this.maximumValue.toString(); // Update if clamped
+
+      this.#updateHandlesAndTrack();
+
+      // Unlike "input" events, "change" events aren't composed. So we have to
+      // manually dispatch them.
+      this.dispatchEvent(
+        new Event('change', { bubbles: true, composed: true }),
+      );
+    }
+  }
+
+  #onMaximumInputInput() {
+    if (this.#maximumInputElementRef.value) {
+      const inputValue = Number(this.#maximumInputElementRef.value.value);
+
+      if (this.minimumValue !== undefined && inputValue >= this.minimumValue) {
+        this.maximumValue = Math.min(inputValue, this.max);
+        this.#updateHandlesAndTrack();
+      }
+    }
+  }
+
+  #onMinimumHandleKeydown(event: KeyboardEvent) {
+    this.#onMultipleHandleKeydown(event, this.#minimumHandleElementRef.value!);
+  }
+
+  #onMinimumHandleMousedown(event: MouseEvent) {
+    this.#startDragging(event, this.#minimumHandleElementRef.value!);
+  }
+
+  #onMinimumInputChange() {
+    if (this.#minimumInputElementRef.value && this.maximumValue !== undefined) {
+      const minimumInput = this.#minimumInputElementRef.value;
+
+      let valueUsingStep = Number(minimumInput.value);
+      valueUsingStep = Math.round(valueUsingStep / this.step) * this.step;
+
+      this.minimumValue = Math.min(
+        Math.max(valueUsingStep, this.min),
+        this.maximumValue - this.step,
+      );
+
+      minimumInput.value = this.minimumValue.toString(); // Update if clamped
+
+      this.#updateHandlesAndTrack();
+
+      // Unlike "input" events, "change" events aren't composed. So we have to
+      // manually dispatch them.
+      this.dispatchEvent(
+        new Event('change', { bubbles: true, composed: true }),
+      );
+    }
+  }
+
+  #onMinimumInputInput() {
+    if (this.#minimumInputElementRef.value) {
+      const inputValue = Number(this.#minimumInputElementRef.value.value);
+
+      if (this.maximumValue !== undefined && inputValue <= this.maximumValue) {
+        this.minimumValue = Math.max(inputValue, this.min);
+        this.#updateHandlesAndTrack();
+      }
+    }
+  }
+
+  #onMultipleHandleKeydown(event: KeyboardEvent, handle: HTMLElement) {
+    if (this.disabled || this.readonly) {
+      return;
+    }
+
+    if (this.minimumValue !== undefined && this.maximumValue !== undefined) {
+      const isMinimumHandle = handle === this.#minimumHandleElementRef.value;
+
+      let newValue = isMinimumHandle ? this.minimumValue : this.maximumValue;
+
+      switch (event.key) {
+        case 'ArrowLeft':
+        case 'ArrowDown': {
+          newValue = newValue - this.step;
+          break;
+        }
+        case 'ArrowRight':
+        case 'ArrowUp': {
+          newValue = newValue + this.step;
+          break;
+        }
+        case 'PageDown': {
+          newValue = newValue - this.step * 10;
+          break;
+        }
+        case 'PageUp': {
+          newValue = newValue + this.step * 10;
+          break;
+        }
+        case 'Home': {
+          newValue = isMinimumHandle ? this.min : this.minimumValue + this.step;
+          break;
+        }
+        case 'End': {
+          newValue = isMinimumHandle ? this.maximumValue - this.step : this.max;
+          break;
+        }
+        case 'Enter': {
+          this.form?.requestSubmit();
+          return;
+        }
+
+        default: {
+          return;
+        }
+      }
+
+      event.preventDefault();
+
+      if (isMinimumHandle) {
+        this.minimumValue = Math.min(
+          Math.max(newValue, this.min),
+          this.maximumValue - this.step,
+        );
+      } else {
+        this.maximumValue = Math.min(
+          Math.max(newValue, this.minimumValue + this.step),
+          this.max,
+        );
+      }
+
+      this.#updateHandlesAndTrack();
+
+      this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+
+      this.dispatchEvent(
+        new Event('change', { bubbles: true, composed: true }),
+      );
+    }
+  }
+
+  #onSingleHandleKeyDown(event: KeyboardEvent) {
+    if (this.disabled || this.readonly) {
+      return;
+    }
+
+    const handle = this.#singleHandleElementRef.value;
+
+    if (handle && this.minimumValue !== undefined) {
+      let newValue = this.minimumValue;
+
+      switch (event.key) {
+        case 'ArrowLeft':
+        case 'ArrowDown': {
+          newValue -= this.step;
+          break;
+        }
+        case 'ArrowRight':
+        case 'ArrowUp': {
+          newValue += this.step;
+          break;
+        }
+        case 'PageDown': {
+          newValue -= this.step * 10;
+          break;
+        }
+        case 'PageUp': {
+          newValue += this.step * 10;
+          break;
+        }
+        case 'Home': {
+          newValue = this.min;
+          break;
+        }
+        case 'End': {
+          newValue = this.max;
+          break;
+        }
+        case 'Enter': {
+          this.form?.requestSubmit();
+          return;
+        }
+
+        default: {
+          return;
+        }
+      }
+
+      event.preventDefault();
+
+      this.minimumValue = Math.min(Math.max(newValue, this.min), this.max);
+
+      this.#updateHandlesAndTrack();
+
+      this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+
+      this.dispatchEvent(
+        new Event('change', { bubbles: true, composed: true }),
+      );
+    }
+  }
+
+  #onSingleHandleMousedown(event: MouseEvent) {
+    this.#startDragging(event, this.#singleHandleElementRef.value!);
+  }
+
+  #onSingleInputChange() {
+    const input = this.#singleInputElementRef.value;
+    const handle = this.#singleHandleElementRef.value;
+
+    if (input && handle) {
+      let newValue = Number(input.value);
+      newValue = Math.round(newValue / this.step) * this.step;
+
+      this.minimumValue = Math.min(Math.max(newValue, this.min), this.max);
+      input.value = this.minimumValue.toString();
+
+      this.#updateHandlesAndTrack();
+
+      this.dispatchEvent(
+        new Event('change', { bubbles: true, composed: true }),
+      );
+    }
+  }
+
+  #onSingleInputInput() {
+    if (this.#singleInputElementRef.value) {
+      const inputValue = Number(this.#singleInputElementRef.value.value);
+
+      if (inputValue >= 0) {
+        this.minimumValue = Math.min(inputValue, this.max);
+        this.#updateHandlesAndTrack();
+      }
+    }
+  }
+
+  #onTrackClick(event: MouseEvent) {
+    if (this.disabled || this.readonly) {
+      return;
+    }
+
+    if (
+      event.target === this.#minimumHandleElementRef.value ||
+      event.target === this.#maximumHandleElementRef.value ||
+      event.target === this.#singleHandleElementRef.value ||
+      this.#isCompletingDrag
+    ) {
+      return;
+    }
+
+    const slider = this.#sliderElementRef.value;
+
+    if (slider) {
+      const sliderRect = slider.getBoundingClientRect();
+
+      const clickPosition =
+        (event.clientX - sliderRect.left) / sliderRect.width;
+
+      const clampedPosition = clickPosition * (this.max - this.min) + this.min;
+
+      const clickValue = Math.round(clampedPosition / this.step) * this.step;
+
+      if (
+        this.multiple &&
+        this.minimumValue !== undefined &&
+        this.maximumValue !== undefined
+      ) {
+        // Calculate distance to each handle to determine which one to move
+        const minimumDistance = Math.abs(clickValue - this.minimumValue);
+        const maximumDistance = Math.abs(clickValue - this.maximumValue);
+
+        // Move the closest handle
+        if (minimumDistance <= maximumDistance) {
+          this.minimumValue = Math.min(
+            Math.max(clickValue, this.min),
+            this.maximumValue - this.step,
+          );
+        } else {
+          this.maximumValue = Math.min(
+            Math.max(clickValue, this.minimumValue + this.step),
+            this.max,
+          );
+        }
+      } else {
+        this.minimumValue = Math.min(Math.max(clickValue, this.min), this.max);
+      }
+
+      this.#updateHandlesAndTrack();
+
+      // Native fires both events in this case
+      this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+
+      this.dispatchEvent(
+        new Event('change', { bubbles: true, composed: true }),
+      );
+    }
+  }
+
+  #startDragging(event: MouseEvent, handle: HTMLElement) {
+    if (this.disabled || this.readonly) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const slider = this.#sliderElementRef.value;
+
+    if (slider) {
+      this.#draggingHandleElement = handle;
+
+      // We want document-level event listeners so that the user can
+      // drag and release the handle outside of the component and it
+      // update properly. Not all users will drag the handles though,
+      // so rather than adding event listeners in connectedCallback
+      // and having them fire any time a user moves their mouse, even
+      // if they aren't interacting directly with the Slider, we add
+      // these event listeners only when the user initiates dragging.
+      document.addEventListener('mousemove', this.#onDraggingMousemove);
+      document.addEventListener('mouseup', this.#onDraggingMouseup);
+
+      this.#onDrag(event.clientX, handle, slider.getBoundingClientRect());
+    }
+  }
+
+  #updateHandlesAndTrack() {
+    const sliderFill = this.#sliderFillElementRef.value;
+    const singleHandle = this.#singleHandleElementRef.value;
+    const minimumHandle = this.#minimumHandleElementRef.value;
+    const maximumHandle = this.#maximumHandleElementRef.value;
+
+    if (sliderFill && this.minimumValue !== undefined) {
+      if (!this.multiple && singleHandle) {
+        const range = this.max - this.min;
+
+        const calculatedPosition =
+          ((this.minimumValue - this.min) / range) * 100;
+
+        singleHandle.style.left = `${calculatedPosition}%`;
+        sliderFill.style.left = '0';
+        sliderFill.style.width = `${calculatedPosition}%`;
+        return;
+      }
+
+      if (this.maximumValue !== undefined && minimumHandle && maximumHandle) {
+        const range = this.max - this.min;
+        const minimumPosition = ((this.minimumValue - this.min) / range) * 100;
+        const maximumPosition = ((this.maximumValue - this.min) / range) * 100;
+
+        minimumHandle.style.left = `${minimumPosition}%`;
+        maximumHandle.style.left = `${maximumPosition}%`;
+        sliderFill.style.left = `${minimumPosition}%`;
+        sliderFill.style.width = `${maximumPosition - minimumPosition}%`;
+      }
+    }
+  }
+}

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -260,8 +260,6 @@ export default class Slider extends LitElement implements FormControl {
     if (oldValue && !multiple) {
       this.maximumValue = undefined;
 
-      this.requestUpdate();
-
       this.updateComplete.then(() => {
         this.#updateHandlesAndTrack();
       });
@@ -289,8 +287,6 @@ export default class Slider extends LitElement implements FormControl {
       } else {
         this.maximumValue = desiredMaximumValue;
       }
-
-      this.requestUpdate();
 
       this.updateComplete.then(() => {
         this.#updateHandlesAndTrack();

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -153,6 +153,10 @@ export default class Slider extends LitElement implements FormControl {
       return;
     }
 
+    if (this.multiple && value.length > 2) {
+      throw new Error('Only two values are allowed when `multiple`.');
+    }
+
     if (!this.multiple && value.length > 0 && value[0] !== undefined) {
       // Normalize the value to snap to the closest valid step
       // increment, even if a developer sets a value between steps.

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -861,60 +861,67 @@ export default class Slider extends LitElement implements FormControl {
     const filledPercentage = (clientX - sliderRect.left) / sliderRect.width;
     const clampedPosition = filledPercentage * (this.max - this.min) + this.min;
 
-    // Ensures the calculated value aligns with the slider's step
+    // Ensures the calculated value aligns with the Slider's step
     // configuration, rounding to the nearest valid step increment.
     const snappedValue = Math.round(clampedPosition / this.step) * this.step;
 
-    // Track if any value actually changed to match native.
-    let hasValueChanged = false;
+    if (!this.multiple) {
+      const newValue = Math.min(Math.max(snappedValue, this.min), this.max);
 
-    if (this.multiple) {
-      const isMinimumHandle = handle === this.#minimumHandleElementRef.value;
+      // To align with native, we only dispatch the input event when
+      // the value is actually changed.
+      if (newValue !== this.minimumValue) {
+        this.minimumValue = newValue;
+        this.#updateHandlesAndTrack();
 
-      if (isMinimumHandle && this.maximumValue) {
-        const newValue = Math.min(
-          Math.max(snappedValue, this.min),
-          this.maximumValue - this.step,
-        );
-
-        if (newValue !== this.minimumValue) {
-          this.minimumValue = newValue;
-          hasValueChanged = true;
-        }
-      } else if (this.minimumValue !== undefined) {
-        const newValue = Math.min(
-          Math.max(snappedValue, this.minimumValue + this.step),
-          this.max,
-        );
-
-        if (newValue !== this.maximumValue) {
-          this.maximumValue = newValue;
-          hasValueChanged = true;
-        }
-      }
-
-      this.#updateHandlesAndTrack();
-
-      if (hasValueChanged) {
         this.dispatchEvent(
           new Event('input', { bubbles: true, composed: true }),
         );
+
+        return;
       }
-
-      return;
     }
 
-    const newValue = Math.min(Math.max(snappedValue, this.min), this.max);
+    const isMinimumHandle = handle === this.#minimumHandleElementRef.value;
 
-    if (newValue !== this.minimumValue) {
-      this.minimumValue = newValue;
-      hasValueChanged = true;
+    if (isMinimumHandle && this.maximumValue !== undefined) {
+      const newValue = Math.min(
+        Math.max(snappedValue, this.min),
+        this.maximumValue - this.step,
+      );
+
+      // To align with native, we only dispatch the input event when
+      // the value is actually changed.
+      if (newValue !== this.minimumValue) {
+        this.minimumValue = newValue;
+        this.#updateHandlesAndTrack();
+
+        this.dispatchEvent(
+          new Event('input', { bubbles: true, composed: true }),
+        );
+
+        return;
+      }
     }
 
-    this.#updateHandlesAndTrack();
+    if (this.minimumValue !== undefined) {
+      const newValue = Math.min(
+        Math.max(snappedValue, this.minimumValue + this.step),
+        this.max,
+      );
 
-    if (hasValueChanged) {
-      this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+      // To align with native, we only dispatch the input event when
+      // the value is actually changed.
+      if (newValue !== this.maximumValue) {
+        this.maximumValue = newValue;
+        this.#updateHandlesAndTrack();
+
+        this.dispatchEvent(
+          new Event('input', { bubbles: true, composed: true }),
+        );
+
+        return;
+      }
     }
   }
 
@@ -1026,33 +1033,33 @@ export default class Slider extends LitElement implements FormControl {
     if (this.minimumValue !== undefined && this.maximumValue !== undefined) {
       const isMinimumHandle = handle === this.#minimumHandleElementRef.value;
 
-      let newValue = isMinimumHandle ? this.minimumValue : this.maximumValue;
+      let value = isMinimumHandle ? this.minimumValue : this.maximumValue;
 
       switch (event.key) {
         case 'ArrowLeft':
         case 'ArrowDown': {
-          newValue = newValue - this.step;
+          value = value - this.step;
           break;
         }
         case 'ArrowRight':
         case 'ArrowUp': {
-          newValue = newValue + this.step;
+          value = value + this.step;
           break;
         }
         case 'PageDown': {
-          newValue = newValue - this.step * 10;
+          value = value - this.step * 10;
           break;
         }
         case 'PageUp': {
-          newValue = newValue + this.step * 10;
+          value = value + this.step * 10;
           break;
         }
         case 'Home': {
-          newValue = isMinimumHandle ? this.min : this.minimumValue + this.step;
+          value = isMinimumHandle ? this.min : this.minimumValue + this.step;
           break;
         }
         case 'End': {
-          newValue = isMinimumHandle ? this.maximumValue - this.step : this.max;
+          value = isMinimumHandle ? this.maximumValue - this.step : this.max;
           break;
         }
         case 'Enter': {
@@ -1069,12 +1076,12 @@ export default class Slider extends LitElement implements FormControl {
 
       if (isMinimumHandle) {
         this.minimumValue = Math.min(
-          Math.max(newValue, this.min),
+          Math.max(value, this.min),
           this.maximumValue - this.step,
         );
       } else {
         this.maximumValue = Math.min(
-          Math.max(newValue, this.minimumValue + this.step),
+          Math.max(value, this.minimumValue + this.step),
           this.max,
         );
       }
@@ -1097,33 +1104,33 @@ export default class Slider extends LitElement implements FormControl {
     const handle = this.#singleHandleElementRef.value;
 
     if (handle && this.minimumValue !== undefined) {
-      let newValue = this.minimumValue;
+      let value = this.minimumValue;
 
       switch (event.key) {
         case 'ArrowLeft':
         case 'ArrowDown': {
-          newValue -= this.step;
+          value -= this.step;
           break;
         }
         case 'ArrowRight':
         case 'ArrowUp': {
-          newValue += this.step;
+          value += this.step;
           break;
         }
         case 'PageDown': {
-          newValue -= this.step * 10;
+          value -= this.step * 10;
           break;
         }
         case 'PageUp': {
-          newValue += this.step * 10;
+          value += this.step * 10;
           break;
         }
         case 'Home': {
-          newValue = this.min;
+          value = this.min;
           break;
         }
         case 'End': {
-          newValue = this.max;
+          value = this.max;
           break;
         }
         case 'Enter': {
@@ -1138,7 +1145,7 @@ export default class Slider extends LitElement implements FormControl {
 
       event.preventDefault();
 
-      this.minimumValue = Math.min(Math.max(newValue, this.min), this.max);
+      this.minimumValue = Math.min(Math.max(value, this.min), this.max);
 
       this.#updateHandlesAndTrack();
 
@@ -1207,7 +1214,10 @@ export default class Slider extends LitElement implements FormControl {
 
       const clampedPosition = clickPosition * (this.max - this.min) + this.min;
 
-      const clickValue = Math.round(clampedPosition / this.step) * this.step;
+      // Similar to when dragging, when clicking the track we need to
+      // ensure the calculated value aligns with the Slider's step
+      // configuration, rounding to the nearest valid step increment.
+      const snappedValue = Math.round(clampedPosition / this.step) * this.step;
 
       if (
         this.multiple &&
@@ -1215,24 +1225,37 @@ export default class Slider extends LitElement implements FormControl {
         this.maximumValue !== undefined
       ) {
         // Calculate the distance to each handle to determine which one to move.
-        const minimumDistance = Math.abs(clickValue - this.minimumValue);
-        const maximumDistance = Math.abs(clickValue - this.maximumValue);
+        const minimumDistance = Math.abs(snappedValue - this.minimumValue);
+        const maximumDistance = Math.abs(snappedValue - this.maximumValue);
 
         // Move the closest handle.
         if (minimumDistance <= maximumDistance) {
           this.minimumValue = Math.min(
-            Math.max(clickValue, this.min),
+            Math.max(snappedValue, this.min),
             this.maximumValue - this.step,
           );
         } else {
           this.maximumValue = Math.min(
-            Math.max(clickValue, this.minimumValue + this.step),
+            Math.max(snappedValue, this.minimumValue + this.step),
             this.max,
           );
         }
-      } else {
-        this.minimumValue = Math.min(Math.max(clickValue, this.min), this.max);
+
+        this.#updateHandlesAndTrack();
+
+        // Native fires both events in this case.
+        this.dispatchEvent(
+          new Event('input', { bubbles: true, composed: true }),
+        );
+
+        this.dispatchEvent(
+          new Event('change', { bubbles: true, composed: true }),
+        );
+
+        return;
       }
+
+      this.minimumValue = Math.min(Math.max(snappedValue, this.min), this.max);
 
       this.#updateHandlesAndTrack();
 

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -109,9 +109,9 @@ export default class Slider extends LitElement implements FormControl {
     if (value.length === 0) {
       const rangeSize = this.max - this.min;
 
-      // To match native, when the value is emptied, we create
-      // one. Native sets it to 50% of the max, but we have a
-      // design requirement for a 25/75% split of the range size.
+      // To match native, when the value is emptied, we create one.
+      // Native sets it to 50% of the max, but we have a design
+      // requirement for a 25/75% split of the range size.
       this.minimumValue = this.min + Math.floor(rangeSize * 0.25);
 
       this.maximumValue = this.multiple
@@ -129,8 +129,9 @@ export default class Slider extends LitElement implements FormControl {
       value[0] !== undefined &&
       value[1] !== undefined
     ) {
-      // Normalize values to snap to the closest valid step increment,
-      // even if a developer sets a value between steps.
+      // Normalize values to snap to the closest valid step
+      // increment, even if a developer sets a value between
+      // steps.
       //
       // Doing so creates consistent behavior between programmatic
       // updates and user interactions. Users can select values that
@@ -139,8 +140,8 @@ export default class Slider extends LitElement implements FormControl {
       // follow the same rules.
       //
       // It also prevents the Slider from ending up in a state where
-      // the position visually doesn't match where a user would expect
-      // based on the step configuration.
+      // the position visually doesn't match where a user would
+      // expect based on the step configuration.
       const normalizedMinimum = Math.round(value[0] / this.step) * this.step;
       const normalizedMaximum = Math.round(value[1] / this.step) * this.step;
 
@@ -153,8 +154,8 @@ export default class Slider extends LitElement implements FormControl {
     }
 
     if (!this.multiple && value.length > 0 && value[0] !== undefined) {
-      // Normalize the value to snap to the closest valid step increment,
-      // even if a developer sets a value between steps.
+      // Normalize the value to snap to the closest valid step
+      // increment, even if a developer sets a value between steps.
       //
       // Doing so creates consistent behavior between programmatic
       // updates and user interactions. Users can select values that
@@ -163,8 +164,8 @@ export default class Slider extends LitElement implements FormControl {
       // follow the same rules.
       //
       // It also prevents the Slider from ending up in a state where
-      // the position visually doesn't match where a user would expect
-      // based on the step configuration.
+      // the position visually doesn't match where a user would
+      // expect based on the step configuration.
       const normalizedValue = Math.round(value[0] / this.step) * this.step;
 
       // Clamp the normalized value to the allowed range.
@@ -174,10 +175,11 @@ export default class Slider extends LitElement implements FormControl {
       );
 
       // When not in multiple mode, we clear the maximumValue to
-      // ensure the Slider won't get in an odd state as the minimumValue
-      // is adjusted. If a consumers add the multiple attribute, we
-      // recalculate what the maximumValue should be based on the current
-      // position of the minimum handle with respect to max and step.
+      // ensure the Slider won't get in an odd state as the
+      // minimumValue is adjusted. If a consumers add the multiple
+      // attribute, we recalculate what the maximumValue should be
+      // based on the current position of the minimum handle with
+      // respect to max and step.
       this.maximumValue = undefined;
 
       this.#updateHandlesAndTrack();
@@ -217,12 +219,13 @@ export default class Slider extends LitElement implements FormControl {
 
     this.maximumValue = Math.min(this.maximumValue ?? this.#max, max);
 
-    // Prevents Slider from reaching an unusable state when max changes.
+    // Prevents Slider from reaching an unusable state when max
+    // changes.
     //
-    // If max decreases below minimumValue, we need to adjust the value
-    // to maintain usability. Without this adjustment, the handle could
-    // become stuck beyond the visible track, leaving users unable to
-    // interact with it.
+    // If max decreases below minimumValue, we need to adjust the
+    // value to maintain usability. Without this adjustment, the
+    // handle could become stuck beyond the visible track, leaving
+    // users unable to interact with it.
     //
     // Setting minimumValue maintains functionality to respect the
     // relationship between handles in multiple mode. In single mode,
@@ -251,22 +254,23 @@ export default class Slider extends LitElement implements FormControl {
     this.minimumValue = Math.max(this.minimumValue ?? this.#min, min);
 
     if (this.multiple) {
-      // Prevents the multi-handle Slider from becoming unusable when
-      // min increases.
+      // Prevents the multi-handle Slider from becoming unusable
+      // when min increases.
       //
       // If min increases above the maximumValue, the maximum handle
-      // would become inaccessible and be outside of the visible track.
-      // This adjustment ensures both handles remain functional within
-      // the valid range while maintaining proper step separation between
-      // them.
+      // would become inaccessible and be outside of the visible
+      // track. This adjustment ensures both handles remain
+      // functional within the valid range while maintaining proper
+      // step separation between them.
       if (this.maximumValue !== undefined && this.maximumValue < min) {
         this.maximumValue = Math.max(min, this.minimumValue + this.step);
       }
     } else {
-      // In single mode, we intentionally clear maximumValue when min
-      // changes to maintain component state consistency and prevent edge
-      // cases where maximumValue could unexpectedly influence Slider's
-      // behavior when switching between single and multiple modes.
+      // In single mode, we intentionally clear maximumValue when
+      // min changes to maintain component state consistency and
+      // prevent edge cases where maximumValue could unexpectedly
+      // influence Slider's behavior when switching between single
+      // and multiple modes.
       this.maximumValue = undefined;
     }
 
@@ -400,11 +404,11 @@ export default class Slider extends LitElement implements FormControl {
       const rangeSize = this.max - this.min;
 
       // When the native range input is not provided a value,
-      // it defaults value to 50% of the max. Our design requirements
-      // are different, in that they want the single slider or minimum
-      // handle in multiple mode to be at 25% of the range size, and
-      // the maximum handle in multiple mode to be at 75% of the range
-      // size.
+      // it defaults value to 50% of the max. Our design
+      // requirements are different, in that they want the single
+      // slider or minimum handle in multiple mode to be at 25% of
+      // the range size, and the maximum handle in multiple mode to
+      // be at 75% of the range size.
       this.minimumValue = this.min + Math.floor(rangeSize * 0.25);
 
       this.maximumValue = this.multiple
@@ -430,14 +434,16 @@ export default class Slider extends LitElement implements FormControl {
 
   override render() {
     // The Slider track has a click handler for convenience to allow
-    // users to click anywhere on the track and have a handle move to
-    // that position. This behavior is an ehancement rather than
-    // essential functionality and is a situation where the linter is being
-    // overzealous without considering the full context of the component.
+    // users to click anywhere on the track and have a handle move
+    // to that position. This behavior is an ehancement rather than
+    // essential functionality and is a situation where the linter
+    // is being overzealous without considering the full context of
+    // the component.
     //
-    // A keyboard user can already update the component via the input
-    // elements directly or via the handles. Exposing the track via keyboard
-    // wouldn't bring any real value in this instance.
+    // A keyboard user can already update the component via the
+    // input elements directly or via the handles. Exposing the
+    // track via keyboard wouldn't bring any real value in this
+    // instance.
     /*  eslint-disable lit-a11y/click-events-have-key-events */
     return html`
       <glide-core-private-label
@@ -684,7 +690,8 @@ export default class Slider extends LitElement implements FormControl {
 
     const isValid = this.#internals.reportValidity();
 
-    // Ensures that getters referencing this.validity?.valid update (i.e. #isShowValidationFeedback)
+    // Ensures that getters referencing this.validity?.valid update
+    // (i.e. #isShowValidationFeedback)
     this.requestUpdate();
 
     return isValid;
@@ -704,8 +711,9 @@ export default class Slider extends LitElement implements FormControl {
         this.#inputElementRef.value,
       );
     } else {
-      // A validation message is required but unused because we disable native validation feedback.
-      // And an empty string isn't allowed. Thus a single space.
+      // A validation message is required but unused because we
+      // disable native validation feedback. And an empty string
+      // isn't allowed. Thus a single space.
       this.#internals.setValidity(
         {
           customError: true,
@@ -721,8 +729,9 @@ export default class Slider extends LitElement implements FormControl {
   setValidity(flags?: ValidityStateFlags, message?: string): void {
     this.validityMessage = message;
 
-    // A validation message is required but unused because we disable native validation feedback.
-    // And an empty string isn't allowed. Thus a single space.
+    // A validation message is required but unused because we
+    // disable native validation feedback. And an empty string isn't
+    // allowed. Thus a single space.
     this.#internals.setValidity(flags, ' ', this.#inputElementRef.value);
   }
 
@@ -730,15 +739,18 @@ export default class Slider extends LitElement implements FormControl {
     super();
     this.#internals = this.attachInternals();
 
-    // Event handlers on the host aren't great because consumers can remove them.
-    // Unfortunately, the host is the only thing on which this event is dispatched
-    // because it's the host that is form-associated.
+    // Event handlers on the host aren't great because consumers can
+    // remove them. Unfortunately, the host is the only thing on
+    // which this event is dispatched because it's the host that is
+    // form-associated.
     this.addEventListener('invalid', (event) => {
       event?.preventDefault(); // Canceled so a native validation message isn't shown.
 
-      // We only want to focus the slider if the invalid event resulted from either:
+      // We only want to focus the slider if the invalid event
+      // resulted from either:
       // 1. Form submission
-      // 2. a call to reportValidity that did NOT result from the slider blur event
+      // 2. a call to reportValidity that did NOT result from
+      //    the slider blur event
       if (this.isCheckingValidity || this.isBlurring) {
         return;
       }
@@ -774,13 +786,13 @@ export default class Slider extends LitElement implements FormControl {
 
   #draggingHandleElement?: HTMLElement;
 
+  #hasCompletedDrag = false;
+
   #initialValue: number[] = [];
 
   #inputElementRef = createRef<HTMLInputElement>();
 
   #internals: ElementInternals;
-
-  #isCompletingDrag = false;
 
   #localize = new LocalizeController(this);
 
@@ -814,8 +826,8 @@ export default class Slider extends LitElement implements FormControl {
     );
   }
 
-  // An arrow function field instead of a method so `this` is closed over and set
-  // to the component instead of `document`.
+  // An arrow function field instead of a method so `this` is closed
+  // over and set to the component instead of `document`.
   #onDraggingMousemove = (mouseEvent: MouseEvent) => {
     mouseEvent.preventDefault();
 
@@ -831,8 +843,8 @@ export default class Slider extends LitElement implements FormControl {
     }
   };
 
-  // An arrow function field instead of a method so `this` is closed over and set
-  // to the component instead of `document`.
+  // An arrow function field instead of a method so `this` is closed
+  // over and set to the component instead of `document`.
   #onDraggingMouseup = () => {
     if (this.#draggingHandleElement) {
       document.removeEventListener('mousemove', this.#onDraggingMousemove);
@@ -842,7 +854,7 @@ export default class Slider extends LitElement implements FormControl {
         new Event('change', { bubbles: true, composed: true }),
       );
 
-      this.#isCompletingDrag = true;
+      this.#hasCompletedDrag = true;
 
       this.#draggingHandleElement = undefined;
 
@@ -851,11 +863,10 @@ export default class Slider extends LitElement implements FormControl {
       // this variable keeps track of when we are still processing
       // the drag event.
       //
-      // Resetting the state in the next frame allows the drag
-      // to fully complete before accepting track click events
-      // again.
+      // Resetting the state in the next frame allows the drag to
+      // fully complete before accepting track click events again.
       setTimeout(() => {
-        this.#isCompletingDrag = false;
+        this.#hasCompletedDrag = false;
       });
     }
   };
@@ -880,14 +891,15 @@ export default class Slider extends LitElement implements FormControl {
         this.dispatchEvent(
           new Event('input', { bubbles: true, composed: true }),
         );
-
-        return;
       }
+
+      return;
     }
 
-    const isMinimumHandle = handle === this.#minimumHandleElementRef.value;
-
-    if (isMinimumHandle && this.maximumValue !== undefined) {
+    if (
+      handle === this.#minimumHandleElementRef.value &&
+      this.maximumValue !== undefined
+    ) {
       const newValue = Math.min(
         Math.max(snappedValue, this.min),
         this.maximumValue - this.step,
@@ -907,7 +919,10 @@ export default class Slider extends LitElement implements FormControl {
       }
     }
 
-    if (this.minimumValue !== undefined) {
+    if (
+      handle === this.#maximumHandleElementRef.value &&
+      this.minimumValue !== undefined
+    ) {
       const newValue = Math.min(
         Math.max(snappedValue, this.minimumValue + this.step),
         this.max,
@@ -960,8 +975,8 @@ export default class Slider extends LitElement implements FormControl {
 
       this.#updateHandlesAndTrack();
 
-      // Unlike "input" events, "change" events aren't composed. So we have to
-      // manually dispatch them.
+      // Unlike "input" events, "change" events aren't composed. So
+      // we have to manually dispatch them.
       this.dispatchEvent(
         new Event('change', { bubbles: true, composed: true }),
       );
@@ -994,23 +1009,23 @@ export default class Slider extends LitElement implements FormControl {
 
       this.minimumValue = Math.min(
         Math.max(normalizedValue, this.min),
-        // Ensures the minimum value always stays at least one step below the
-        // maximum value, maintaining the required separation.
-        // Without this, users could set the minimum value equal to or higher
-        // than the maximum value, creating issues, both visually and
-        // operationally.
+        // Ensures the minimum value always stays at least one step
+        // below the maximum value, maintaining the required
+        // separation. Without this, users could set the minimum
+        // value equal to or higher than the maximum value, creating
+        // issues, both visually and operationally.
         //
         // Consider the case where maximumValue is 75 and step is 5.
-        // Without this, a user could set the value to 80, which would
-        // be invalid. With this constraint, the minimum value can't go higher
-        // than 70 (75-5).
+        // Without this, a user could set the value to 80, which
+        // would be invalid. With this constraint, the minimum value
+        // can't go higher than 70 (75-5).
         this.maximumValue - this.step,
       );
 
       this.#updateHandlesAndTrack();
 
-      // Unlike "input" events, "change" events aren't composed. So we have to
-      // manually dispatch them.
+      // Unlike "input" events, "change" events aren't composed. So
+      // we have to manually dispatch them.
       this.dispatchEvent(
         new Event('change', { bubbles: true, composed: true }),
       );
@@ -1075,6 +1090,7 @@ export default class Slider extends LitElement implements FormControl {
         }
       }
 
+      // Prevent page scroll.
       event.preventDefault();
 
       if (isMinimumHandle) {
@@ -1202,7 +1218,7 @@ export default class Slider extends LitElement implements FormControl {
       event.target === this.#minimumHandleElementRef.value ||
       event.target === this.#maximumHandleElementRef.value ||
       event.target === this.#singleHandleElementRef.value ||
-      this.#isCompletingDrag
+      this.#hasCompletedDrag
     ) {
       return;
     }
@@ -1217,9 +1233,10 @@ export default class Slider extends LitElement implements FormControl {
 
       const clampedPosition = clickPosition * (this.max - this.min) + this.min;
 
-      // Similar to when dragging, when clicking the track we need to
-      // ensure the calculated value aligns with the Slider's step
-      // configuration, rounding to the nearest valid step increment.
+      // Similar to when dragging, when clicking the track we need
+      // to ensure the calculated value aligns with the Slider's
+      // step configuration, rounding to the nearest valid step
+      // increment.
       const snappedValue = Math.round(clampedPosition / this.step) * this.step;
 
       if (
@@ -1227,7 +1244,8 @@ export default class Slider extends LitElement implements FormControl {
         this.minimumValue !== undefined &&
         this.maximumValue !== undefined
       ) {
-        // Calculate the distance to each handle to determine which one to move.
+        // Calculate the distance to each handle to determine which
+        // one to move.
         const minimumDistance = Math.abs(snappedValue - this.minimumValue);
         const maximumDistance = Math.abs(snappedValue - this.maximumValue);
 
@@ -1287,9 +1305,10 @@ export default class Slider extends LitElement implements FormControl {
       // drag and release the handle outside of the component and it
       // update properly. Not all users will drag the handles though,
       // so rather than adding event listeners in connectedCallback()
-      // and having them fire any time a user moves their mouse, even
-      // if they aren't interacting directly with the Slider, we add
-      // these event listeners only when the user initiates dragging.
+      // and having them fire any time a user moves their mouse,
+      // even if they aren't interacting directly with the Slider,
+      // we add these event listeners only when the user initiates
+      // dragging.
       document.addEventListener('mousemove', this.#onDraggingMousemove);
       document.addEventListener('mouseup', this.#onDraggingMouseup);
 

--- a/src/styles/variables/color-dark.css
+++ b/src/styles/variables/color-dark.css
@@ -144,6 +144,7 @@
   --glide-core-private-color-dialog-and-modal-surface-container: #2c2c2c;
   --glide-core-private-color-skeleton-loader-surface-linear-gradient-sides: #ffffff0d;
   --glide-core-private-color-skeleton-loader-surface-linear-gradient-middle: #ffffff1a;
+  --glide-core-private-color-slider-and-scrollbar-surface-handle: #202020;
   --glide-core-private-color-tabs-stroke-underline: #ffffff26;
   --glide-core-private-color-template-surface-container-detail: #2c2c2c;
   --glide-core-private-color-tooltip-surface-container: #dcdcdc;

--- a/src/styles/variables/color-light.css
+++ b/src/styles/variables/color-light.css
@@ -145,6 +145,7 @@
   --glide-core-private-color-dialog-and-modal-surface-container: #ffffff;
   --glide-core-private-color-skeleton-loader-surface-linear-gradient-sides: #0000000d;
   --glide-core-private-color-skeleton-loader-surface-linear-gradient-middle: #0000001a;
+  --glide-core-private-color-slider-and-scrollbar-surface-handle: #f0f0f0;
   --glide-core-private-color-tabs-stroke-underline: #e3e3e3;
   --glide-core-private-color-template-surface-container-detail: #ffffffe5;
   --glide-core-private-color-tooltip-surface-container: #212121;

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -33,6 +33,10 @@ const translation: Translation = {
   editTag: (label: string) => `Edit tag: ${label}`,
   removeTag: (label: string) => `Remove tag: ${label}`,
   itemCount: (count: string) => `${count} items`,
+  maximum: (label: string) => `Maximum ${label}`,
+  setMaximum: (label: string) => `Set maximum ${label}`,
+  minimum: (label: string) => `Minimum ${label}`,
+  setMinimum: (label: string) => `Set minimum ${label}`,
 };
 
 export default translation;

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -10,6 +10,10 @@ export const PENDING_STRINGS = [
   'loading',
   'noAvailableOptions',
   'noMatchingOptions',
+  'maximum',
+  'setMaximum',
+  'minimum',
+  'setMinimum',
 ] as const;
 
 type PendingTranslation = (typeof PENDING_STRINGS)[number];

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -10,6 +10,10 @@ export const PENDING_STRINGS = [
   'loading',
   'noAvailableOptions',
   'noMatchingOptions',
+  'maximum',
+  'setMaximum',
+  'minimum',
+  'setMinimum',
 ] as const;
 
 type PendingTranslation = (typeof PENDING_STRINGS)[number];


### PR DESCRIPTION
## 🚀 Description

Adds a new Slider component.

For the most part, it mimics how `<input type="range"` behaves, except:

- There is a `multiple` mode.
- Rather than defaulting to 50% of the range size, single mode does 25% and multiple mode does a 25/75% split.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

Tests should have us covered, but for some manual validations:

**Single mode**

- Go to [Storybook](https://glide-core.crowdstrike-ux.workers.dev/slider?path=/story/slider--slider).
- Press and hold the mouse on the handle, begin dragging.
- Verify you can drag the handle and the value in the input updates.

- Go to [Storybook](https://glide-core.crowdstrike-ux.workers.dev/slider?path=/story/slider--slider).
- Type a value into the input.
- Verify the drag handle position updates.

- Go to [Storybook](https://glide-core.crowdstrike-ux.workers.dev/slider?path=/story/slider--slider).
- Turn on Voice Over.
- Tab to the handle.
- Verify the `label` is read aloud.
- Press `control` + `option` + shift` + `arrowdown`.
- Verify Voice Over reads "in slider".
- Press `arrowright`.
- Verify the new value is announced.
- Tab to the input field now.
- Verify the current value and `label` is announced.

**Multiple mode**

- Go to [Storybook](https://glide-core.crowdstrike-ux.workers.dev/slider?path=/story/slider--slider&args=multiple:!true)
- Press and hold the mouse on the "minimum handle" (the one on the left), begin dragging.
- Verify you can drag the handle and the value in the minimum input (the one on the left) updates.
- Now do the same thing, but for the "maximum handle" (the one on the right).

- Go to [Storybook](https://glide-core.crowdstrike-ux.workers.dev/slider?path=/story/slider--slider&args=multiple:!true)
- Type a value into the minimum input.
- Verify the minimum drag handle position updates.
- Do the same thing for the maximum input.

- Go to [Storybook](https://glide-core.crowdstrike-ux.workers.dev/slider?path=/story/slider--slider&args=multiple:!true)
- Turn on Voice Over.
- Tab to the minimum input.
- Verify the minimum input value and "Set minimum `label`" is announced.
- Tab to the minimum handle.
- Verify the "Minimum `label`" is read aloud.
- Press `control` + `option` + shift` + `arrowdown`.
- Verify Voice Over reads "in slider".
- Press `arrowright`.
- Verify the new value is announced.
- Do the same thing for the maximum handle and input, except it should read aloud "maximum".