### PR TITLE
Add `protected` lint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,6 +56,7 @@ export default defineConfig([
       '@crowdstrike/glide-core/public-property-expression-type': 'error',
       '@crowdstrike/glide-core/use-default-with-property-decorator': 'error',
       '@crowdstrike/glide-core/private-state-decorators': 'error',
+      '@crowdstrike/glide-core/no-protected-keyword': 'error',
 
       // Only a few hand-picked rules because much of what the plugin offers either doesn't
       // apply to us (SEO rules) or is covered by other tools (formatting and accessibility

--- a/src/eslint/plugin.ts
+++ b/src/eslint/plugin.ts
@@ -17,6 +17,7 @@ import { slotTypeComment } from './rules/slot-type-comment.js';
 import { publicPropertyExpressionType } from './rules/public-property-expression-type.js';
 import { useDefaultWithPropertyDecorator } from './rules/use-default-with-property-decorator.js';
 import { privateStateDecorators } from './rules/private-state-decorators.js';
+import { noProtectedKeyword } from './rules/no-protected-keyword.js';
 
 export default {
   rules: {
@@ -41,5 +42,6 @@ export default {
     'public-property-expression-type': publicPropertyExpressionType,
     'use-default-with-property-decorator': useDefaultWithPropertyDecorator,
     'private-state-decorators': privateStateDecorators,
+    'no-protected-keyword': noProtectedKeyword,
   },
 };

--- a/src/eslint/rules/better-test-assertions.ts
+++ b/src/eslint/rules/better-test-assertions.ts
@@ -1,8 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
-
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/consistent-reference-element-declarations.ts
+++ b/src/eslint/rules/consistent-reference-element-declarations.ts
@@ -1,7 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>(
   (name) =>

--- a/src/eslint/rules/consistent-test-fixture-variable-declarator.ts
+++ b/src/eslint/rules/consistent-test-fixture-variable-declarator.ts
@@ -1,7 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>(
   (name) =>

--- a/src/eslint/rules/event-dispatch-from-this.ts
+++ b/src/eslint/rules/event-dispatch-from-this.ts
@@ -1,7 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/no-nested-template-literals.ts
+++ b/src/eslint/rules/no-nested-template-literals.ts
@@ -1,8 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
-
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/no-only-tests.ts
+++ b/src/eslint/rules/no-only-tests.ts
@@ -1,8 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
-
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/no-protected-keyword.test.ts
+++ b/src/eslint/rules/no-protected-keyword.test.ts
@@ -1,0 +1,125 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noProtectedKeyword } from './no-protected-keyword.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-protected-keyword', noProtectedKeyword, {
+  valid: [
+    {
+      code: `
+        class Component extends LitElement {
+          method() {}
+        }
+      `,
+    },
+    {
+      code: `
+        class Component extends LitElement {
+          override method() {}
+        }
+      `,
+    },
+    {
+      code: `
+        class Component extends LitElement {
+          private method() {}
+        }
+      `,
+    },
+    {
+      code: `
+        class Component extends LitElement {
+          property = true;
+        }
+      `,
+    },
+    {
+      code: `
+        class Component extends LitElement {
+          override property = true;
+        }
+      `,
+    },
+    {
+      code: `
+        class Component extends LitElement {
+          private property = true;
+        }
+      `,
+    },
+    {
+      code: `
+        class Component extends LitElement {
+          readonly property = true;
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        class Component extends LitElement {
+          protected method() {}
+        }
+      `,
+      errors: [{ messageId: 'noProtectedKeyword' }],
+      output: `
+        class Component extends LitElement {
+          method() {}
+        }
+      `,
+    },
+    {
+      code: `
+        class Component extends LitElement {
+          protected override method() {}
+        }
+      `,
+      errors: [{ messageId: 'noProtectedKeyword' }],
+      output: `
+        class Component extends LitElement {
+          override method() {}
+        }
+      `,
+    },
+    {
+      code: `
+        class Component extends LitElement {
+          protected property = true;
+        }
+      `,
+      errors: [{ messageId: 'noProtectedKeyword' }],
+      output: `
+        class Component extends LitElement {
+          property = true;
+        }
+      `,
+    },
+    {
+      code: `
+        class Component extends LitElement {
+          protected override property = true;
+        }
+      `,
+      errors: [{ messageId: 'noProtectedKeyword' }],
+      output: `
+        class Component extends LitElement {
+          override property = true;
+        }
+      `,
+    },
+    {
+      code: `
+        class Component extends LitElement {
+          protected readonly property = true;
+        }
+      `,
+      errors: [{ messageId: 'noProtectedKeyword' }],
+      output: `
+        class Component extends LitElement {
+          readonly property = true;
+        }
+      `,
+    },
+  ],
+});

--- a/src/eslint/rules/no-protected-keyword.ts
+++ b/src/eslint/rules/no-protected-keyword.ts
@@ -1,0 +1,86 @@
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
+  recommended: boolean;
+}>((name) => {
+  return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;
+});
+
+export const noProtectedKeyword = createRule({
+  name: 'no-protected-keyword',
+  meta: {
+    docs: {
+      description:
+        "Ensures `protected` isn't used on component class fields. Most developers are unlikely to add `protected` to a method or property. But many editor plugins do, especially when autocompleting Lit lifecycle methods.",
+      recommended: true,
+    },
+    type: 'suggestion',
+    messages: {
+      noProtectedKeyword:
+        "Via the `@final` decorator our components don't allow extension. So `protected` has no use.",
+    },
+    schema: [],
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create(context) {
+    let isComponent = true;
+
+    return {
+      ClassDeclaration(node) {
+        if (
+          node.superClass?.type === AST_NODE_TYPES.Identifier &&
+          node.superClass.name !== 'LitElement'
+        ) {
+          isComponent = false;
+          return;
+        }
+      },
+      MethodDefinition(node) {
+        if (isComponent && node.accessibility === 'protected') {
+          context.report({
+            node,
+            messageId: 'noProtectedKeyword',
+            fix(fixer) {
+              const token = context.sourceCode.getFirstToken(
+                node,
+                (token) => token.value === node.accessibility,
+              );
+
+              const tokenRangeStart = token?.range.at(0);
+              const tokenRangeEnd = token?.range.at(1);
+
+              return token && tokenRangeStart && tokenRangeEnd
+                ? // `1` is added to the end of the range so whitespace trailing `protected`
+                  // is removed.
+                  fixer.removeRange([tokenRangeStart, tokenRangeEnd + 1])
+                : null;
+            },
+          });
+        }
+      },
+      PropertyDefinition(node) {
+        if (isComponent && node.accessibility === 'protected') {
+          context.report({
+            node,
+            messageId: 'noProtectedKeyword',
+            fix(fixer) {
+              const token = context.sourceCode.getFirstToken(
+                node,
+                (token) => token.value === node.accessibility,
+              );
+
+              const tokenRangeStart = token?.range.at(0);
+              const tokenRangeEnd = token?.range.at(1);
+
+              return token && tokenRangeStart && tokenRangeEnd
+                ? fixer.removeRange([tokenRangeStart, tokenRangeEnd + 1])
+                : null;
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/src/eslint/rules/no-redundant-property-attribute.ts
+++ b/src/eslint/rules/no-redundant-property-attribute.ts
@@ -1,8 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
-
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/no-redundant-property-string-type.ts
+++ b/src/eslint/rules/no-redundant-property-string-type.ts
@@ -1,8 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
-
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/no-skip-tests.ts
+++ b/src/eslint/rules/no-skip-tests.ts
@@ -1,8 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
-
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/no-space-press.ts
+++ b/src/eslint/rules/no-space-press.ts
@@ -1,8 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
-
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/no-to-have-attribute.ts
+++ b/src/eslint/rules/no-to-have-attribute.ts
@@ -1,8 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
-
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/prefer-shadow-root-mode.ts
+++ b/src/eslint/rules/prefer-shadow-root-mode.ts
@@ -1,8 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
-
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/private-state-decorators.ts
+++ b/src/eslint/rules/private-state-decorators.ts
@@ -1,8 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
-
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/public-getter-default-comment.ts
+++ b/src/eslint/rules/public-getter-default-comment.ts
@@ -5,8 +5,8 @@ import {
 } from '@typescript-eslint/utils';
 import { parse as commentParser } from 'comment-parser';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;
@@ -68,8 +68,8 @@ export const publicGetterDefaultComment = createRule({
           });
 
           if (comment) {
-            const parsed = commentParser(`/** 
-              ${comment.value} 
+            const parsed = commentParser(`/**
+              ${comment.value}
             */`);
 
             const hasDefaultTag = parsed.at(0)?.tags.some((tag) => {

--- a/src/eslint/rules/public-member-return-type.ts
+++ b/src/eslint/rules/public-member-return-type.ts
@@ -1,7 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/public-property-expression-type.ts
+++ b/src/eslint/rules/public-property-expression-type.ts
@@ -1,7 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/slot-type-comment.ts
+++ b/src/eslint/rules/slot-type-comment.ts
@@ -2,8 +2,8 @@ import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 import { parse as htmlParser, CommentNode } from 'node-html-parser';
 import { parse as commentParser } from 'comment-parser';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;
@@ -65,8 +65,8 @@ export const slotTypeComment = createRule({
               return;
             }
 
-            const tags = commentParser(`/** 
-                ${comment.rawText} 
+            const tags = commentParser(`/**
+                ${comment.rawText}
               */`).flatMap((block) => block.tags);
 
             const typeTag = tags.find((tag) => tag.tag === 'type');

--- a/src/eslint/rules/string-event-name.ts
+++ b/src/eslint/rules/string-event-name.ts
@@ -1,7 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/eslint/rules/use-default-with-property-decorator.test.ts
+++ b/src/eslint/rules/use-default-with-property-decorator.test.ts
@@ -72,6 +72,13 @@ ruleTester.run(
           }
         `,
       },
+      {
+        code: `
+          class Class {
+            readonly property = true;
+          }
+        `,
+      },
     ],
     invalid: [
       {

--- a/src/eslint/rules/use-default-with-property-decorator.ts
+++ b/src/eslint/rules/use-default-with-property-decorator.ts
@@ -1,8 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
-// https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L109
-
 const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
   recommended: boolean;
 }>((name) => {
   return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -113,7 +113,7 @@ export default class Tab extends LitElement {
     </div>`;
   }
 
-  protected override updated(changes: PropertyValues) {
+  override updated(changes: PropertyValues) {
     if (changes.has('selected')) {
       this.setAttribute('aria-selected', this.selected ? 'true' : 'false');
     }


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->


```ts
messages: {
  noProtectedKeyword:
    "Via the `@final` decorator our components don't allow extension. So `protected` has no use.",
}
```
## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

N/A

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
