### PR TITLE
Add vertical tooltip visual tests and remove margin-top from Textarea when in the horizontal orientation

### DIFF
--- a/.changeset/new-planes-serve.md
+++ b/.changeset/new-planes-serve.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Removed unnecessary top margin Textarea when `orientation="vertical"`.

--- a/src/checkbox.test.visuals.ts
+++ b/src/checkbox.test.visuals.ts
@@ -125,18 +125,66 @@ for (const story of stories.Checkbox) {
           );
         });
 
-        test('orientation="vertical"', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+        test.describe('orientation="horizontal"', () => {
+          test('tooltip="Tooltip"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
-          await page
-            .locator('glide-core-checkbox')
-            .evaluate<void, Checkbox>((element) => {
-              element.orientation = 'vertical';
-            });
+            await page
+              .locator('glide-core-checkbox')
+              .evaluate<void, Checkbox>((element) => {
+                element.orientation = 'horizontal';
+                element.tooltip = 'Tooltip';
+              });
 
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('tooltip=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-checkbox')
+              .evaluate<void, Checkbox>((element) => {
+                element.orientation = 'horizontal';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+        });
+
+        test.describe('orientation="vertical"', () => {
+          test('tooltip="Tooltip"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-checkbox')
+              .evaluate<void, Checkbox>((element) => {
+                element.orientation = 'vertical';
+                element.tooltip = 'Tooltip';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('tooltip=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-checkbox')
+              .evaluate<void, Checkbox>((element) => {
+                element.orientation = 'vertical';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
         });
 
         test('required', async ({ page }, test) => {
@@ -180,22 +228,6 @@ for (const story of stories.Checkbox) {
             .evaluate<void, Checkbox>((element) => {
               element.summary = 'Summary';
             });
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
-
-        test('tooltip', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-          await page
-            .locator('glide-core-checkbox')
-            .evaluate<void, Checkbox>((element) => {
-              element.tooltip = 'Tooltip';
-            });
-
-          await page.locator('glide-core-tooltip').getByRole('button').focus();
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,

--- a/src/dropdown.test.visuals.ts
+++ b/src/dropdown.test.visuals.ts
@@ -132,18 +132,66 @@ for (const story of stories.Dropdown) {
           );
         });
 
-        test('orientation="vertical"', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+        test.describe('orientation="horizontal"', () => {
+          test('tooltip="Tooltip"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
-          await page
-            .locator('glide-core-dropdown')
-            .evaluate<void, Dropdown>((element) => {
-              element.orientation = 'vertical';
-            });
+            await page
+              .locator('glide-core-dropdown')
+              .evaluate<void, Dropdown>((element) => {
+                element.orientation = 'horizontal';
+                element.tooltip = 'Tooltip';
+              });
 
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('tooltip=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-dropdown')
+              .evaluate<void, Dropdown>((element) => {
+                element.orientation = 'horizontal';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+        });
+
+        test.describe('orientation="vertical"', () => {
+          test('tooltip="Tooltip"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-dropdown')
+              .evaluate<void, Dropdown>((element) => {
+                element.orientation = 'vertical';
+                element.tooltip = 'Tooltip';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('tooltip=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-dropdown')
+              .evaluate<void, Dropdown>((element) => {
+                element.orientation = 'vertical';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
         });
 
         test('placeholder', async ({ page }, test) => {
@@ -218,22 +266,6 @@ for (const story of stories.Dropdown) {
 
               element.append(div);
             });
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
-
-        test('tooltip', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-          await page
-            .locator('glide-core-dropdown')
-            .evaluate<void, Dropdown>((element) => {
-              element.tooltip = 'Tooltip';
-            });
-
-          await page.locator('glide-core-tooltip').getByRole('button').focus();
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,

--- a/src/input.test.visuals.ts
+++ b/src/input.test.visuals.ts
@@ -85,18 +85,66 @@ for (const story of stories.Input) {
           );
         });
 
-        test('orientation="vertical"', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+        test.describe('orientation="horizontal"', () => {
+          test('tooltip="Tooltip"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
-          await page
-            .locator('glide-core-input')
-            .evaluate<void, Input>((element) => {
-              element.orientation = 'vertical';
-            });
+            await page
+              .locator('glide-core-input')
+              .evaluate<void, Input>((element) => {
+                element.orientation = 'horizontal';
+                element.tooltip = 'Tooltip';
+              });
 
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('tooltip=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-input')
+              .evaluate<void, Input>((element) => {
+                element.orientation = 'horizontal';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+        });
+
+        test.describe('orientation="vertical"', () => {
+          test('tooltip="Tooltip"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-input')
+              .evaluate<void, Input>((element) => {
+                element.orientation = 'vertical';
+                element.tooltip = 'Tooltip';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('tooltip=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-input')
+              .evaluate<void, Input>((element) => {
+                element.orientation = 'vertical';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
         });
 
         test('password-toggle', async ({ page }, test) => {
@@ -150,22 +198,6 @@ for (const story of stories.Input) {
             .evaluate<void, Input>((element) => {
               element.required = true;
             });
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
-
-        test('tooltip', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-          await page
-            .locator('glide-core-input')
-            .evaluate<void, Input>((element) => {
-              element.tooltip = 'Tooltip';
-            });
-
-          await page.locator('glide-core-tooltip').getByRole('button').focus();
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,

--- a/src/textarea.styles.ts
+++ b/src/textarea.styles.ts
@@ -21,7 +21,7 @@ export default [
     ${visuallyHidden('.character-count .hidden')}
   `,
   css`
-    glide-core-private-label::part(private-tooltips) {
+    glide-core-private-label[orientation='horizontal']::part(private-tooltips) {
       align-items: flex-start;
       margin-block-start: var(--glide-core-spacing-base-sm);
     }

--- a/src/textarea.test.visuals.ts
+++ b/src/textarea.test.visuals.ts
@@ -69,18 +69,66 @@ for (const story of stories.Textarea) {
           );
         });
 
-        test('orientation', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+        test.describe('orientation="horizontal"', () => {
+          test('tooltip="Tooltip"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
-          await page
-            .locator('glide-core-textarea')
-            .evaluate<void, Textarea>((element) => {
-              element.orientation = 'vertical';
-            });
+            await page
+              .locator('glide-core-textarea')
+              .evaluate<void, Textarea>((element) => {
+                element.orientation = 'horizontal';
+                element.tooltip = 'Tooltip';
+              });
 
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('tooltip=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-textarea')
+              .evaluate<void, Textarea>((element) => {
+                element.orientation = 'horizontal';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+        });
+
+        test.describe('orientation="vertical"', () => {
+          test('tooltip="Tooltip"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-textarea')
+              .evaluate<void, Textarea>((element) => {
+                element.orientation = 'vertical';
+                element.tooltip = 'Tooltip';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('tooltip=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-textarea')
+              .evaluate<void, Textarea>((element) => {
+                element.orientation = 'vertical';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
         });
 
         test('placeholder', async ({ page }, test) => {
@@ -138,22 +186,6 @@ for (const story of stories.Textarea) {
 
               element.append(div);
             });
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
-
-        test('tooltip', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-          await page
-            .locator('glide-core-textarea')
-            .evaluate<void, Textarea>((element) => {
-              element.tooltip = 'Tooltip';
-            });
-
-          await page.locator('glide-core-tooltip').getByRole('button').focus();
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,

--- a/src/toggle.test.visuals.ts
+++ b/src/toggle.test.visuals.ts
@@ -58,18 +58,66 @@ for (const story of stories.Toggle) {
           );
         });
 
-        test('orientation="vertical"', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+        test.describe('orientation="horizontal"', () => {
+          test('tooltip="Tooltip"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
-          await page
-            .locator('glide-core-toggle')
-            .evaluate<void, Toggle>((element) => {
-              element.orientation = 'vertical';
-            });
+            await page
+              .locator('glide-core-toggle')
+              .evaluate<void, Toggle>((element) => {
+                element.orientation = 'horizontal';
+                element.tooltip = 'Tooltip';
+              });
 
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('tooltip=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-toggle')
+              .evaluate<void, Toggle>((element) => {
+                element.orientation = 'horizontal';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+        });
+
+        test.describe('orientation="vertical"', () => {
+          test('tooltip="Tooltip"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-toggle')
+              .evaluate<void, Toggle>((element) => {
+                element.orientation = 'vertical';
+                element.tooltip = 'Tooltip';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('tooltip=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-toggle')
+              .evaluate<void, Toggle>((element) => {
+                element.orientation = 'vertical';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
         });
 
         test('slot="description"', async ({ page }, test) => {
@@ -99,22 +147,6 @@ for (const story of stories.Toggle) {
             .evaluate<void, Toggle>((element) => {
               element.summary = 'Summary';
             });
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
-
-        test('tooltip', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-          await page
-            .locator('glide-core-toggle')
-            .evaluate<void, Toggle>((element) => {
-              element.tooltip = 'Tooltip';
-            });
-
-          await page.locator('glide-core-tooltip').getByRole('button').focus();
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,


### PR DESCRIPTION
## 🚀 Description

I mentioned over on https://github.com/CrowdStrike/glide-core/pull/898 that we didn't catch a visual bug because we didn't have tests in place. With this PR, we do!

And an added bonus - I noticed the Textarea when `orientation="horizontal"` had some margin on the top that it shouldn't have had.  It's needed for `orientation="vertical"` to knock the label to be more in line with the text being entered. But with the horizontal orientation it added spacing, which consumers likely don't expect!

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

Visual tests should be enough. Left a comment on the Textarea change. Another case that wasn't caught by our existing visual tests, but now it will be! 🎉 
