### PR TITLE
Add `@final` lint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,6 +57,7 @@ export default defineConfig([
       '@crowdstrike/glide-core/use-default-with-property-decorator': 'error',
       '@crowdstrike/glide-core/private-state-decorators': 'error',
       '@crowdstrike/glide-core/no-protected-keyword': 'error',
+      '@crowdstrike/glide-core/use-final-decorator': 'error',
 
       // Only a few hand-picked rules because much of what the plugin offers either doesn't
       // apply to us (SEO rules) or is covered by other tools (formatting and accessibility
@@ -340,6 +341,7 @@ export default defineConfig([
       '@crowdstrike/glide-core/string-event-name': 'off',
       '@crowdstrike/glide-core/slot-type-comment': 'off',
       '@crowdstrike/glide-core/public-property-expression-type': 'off',
+      '@crowdstrike/glide-core/use-final-decorator': 'off',
     },
   },
   {

--- a/src/eslint/plugin.ts
+++ b/src/eslint/plugin.ts
@@ -18,6 +18,7 @@ import { publicPropertyExpressionType } from './rules/public-property-expression
 import { useDefaultWithPropertyDecorator } from './rules/use-default-with-property-decorator.js';
 import { privateStateDecorators } from './rules/private-state-decorators.js';
 import { noProtectedKeyword } from './rules/no-protected-keyword.js';
+import { useFinalDecorator } from './rules/use-final-decorator.js';
 
 export default {
   rules: {
@@ -43,5 +44,6 @@ export default {
     'use-default-with-property-decorator': useDefaultWithPropertyDecorator,
     'private-state-decorators': privateStateDecorators,
     'no-protected-keyword': noProtectedKeyword,
+    'use-final-decorator': useFinalDecorator,
   },
 };

--- a/src/eslint/rules/use-final-decorator.test.ts
+++ b/src/eslint/rules/use-final-decorator.test.ts
@@ -1,0 +1,42 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { useFinalDecorator } from './use-final-decorator.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('use-final-decorator', useFinalDecorator, {
+  valid: [
+    {
+      code: `
+        @customElement('glide-core-component')
+        @final
+        class Component extends LitElement {}
+      `,
+    },
+    {
+      code: `
+        @final
+        @customElement('glide-core-component')
+        class Component extends LitElement {}
+      `,
+    },
+    {
+      code: `
+        class Class {}
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        @customElement('glide-core-component')
+        class Component extends LitElement {}
+      `,
+      errors: [{ messageId: 'useFinalDecorator' }],
+      output: `
+        @customElement('glide-core-component')
+        @final
+        class Component extends LitElement {}
+      `,
+    },
+  ],
+});

--- a/src/eslint/rules/use-final-decorator.ts
+++ b/src/eslint/rules/use-final-decorator.ts
@@ -1,0 +1,70 @@
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator<{
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/developers/Custom_Rules.mdx?plain=1#L110
+  recommended: boolean;
+}>((name) => {
+  return `https://github.com/CrowdStrike/glide-core/blob/main/src/eslint/rules/${name}.ts`;
+});
+
+export const useFinalDecorator = createRule({
+  name: 'use-final-decorator',
+  meta: {
+    docs: {
+      description:
+        "Ensures components are decorated with `@final`. We want consumers to talk to us instead of extending components if one doesn't meet their needs.",
+      recommended: true,
+    },
+    type: 'suggestion',
+    messages: {
+      useFinalDecorator:
+        'Decorate your component with `@final` to prevent extension.',
+    },
+    schema: [],
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ClassDeclaration(node) {
+        const hasFinalDecorator = node.decorators.some(
+          (node) =>
+            node.expression.type === AST_NODE_TYPES.Identifier &&
+            node.expression.name === 'final',
+        );
+
+        if (
+          node.superClass?.type === AST_NODE_TYPES.Identifier &&
+          node.superClass.name === 'LitElement' &&
+          !hasFinalDecorator
+        ) {
+          context.report({
+            node,
+            messageId: 'useFinalDecorator',
+            fix(fixer) {
+              const lastDecorator = node.decorators.at(-1);
+              const classToken = context.sourceCode.getFirstToken(node);
+
+              if (
+                node.decorators &&
+                node.decorators.length > 0 &&
+                lastDecorator
+              ) {
+                const indent = ' '.repeat(lastDecorator.loc.start.column);
+
+                return fixer.insertTextAfter(
+                  lastDecorator,
+                  `\n${indent}@final`,
+                );
+              } else if (classToken) {
+                return fixer.insertTextBefore(classToken, '@final\n');
+              } else {
+                return null;
+              }
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/src/icons/storybook.ts
+++ b/src/icons/storybook.ts
@@ -5,8 +5,10 @@
 import { css, html, LitElement, svg } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import shadowRootMode from '../library/shadow-root-mode.js';
+import final from '../library/final.js';
 
 @customElement('glide-core-example-icon')
+@final
 export default class ExampleIcon extends LitElement {
   static override shadowRootOptions: ShadowRootInit = {
     ...LitElement.shadowRootOptions,


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Adds `@crowdstrike/glide-core/use-final-decorator`, which forces us to use `@final` whenever we extend `LitElement`.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

N/A

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
