### PR TITLE
Disabled Dropdown Options fix

### DIFF
--- a/.changeset/stale-melons-flash.md
+++ b/.changeset/stale-melons-flash.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown when filterable and all but one Dropdown Option is disabled no longer sets the value of its input field to "Select All" when the enabled Dropdown Option is selected.

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -392,7 +392,6 @@ it('clears its filter on close when multiselect and no option is selected', asyn
   await aTimeout(0);
 
   await sendKeys({ press: 'Tab' });
-
   await sendKeys({ type: 'o' });
   await click(document.body);
 
@@ -419,7 +418,6 @@ it('clears its filter on close when multiselect and an option is selected', asyn
   await aTimeout(0);
 
   await sendKeys({ press: 'Tab' });
-
   await sendKeys({ type: 'o' });
   await click(document.body);
 
@@ -479,7 +477,6 @@ it('does not clear its filter when every tag is removed via Meta + Backspace', a
 
   await sendKeys({ press: 'Tab' }); // Focus the tag.
   await sendKeys({ press: 'Tab' }); // Focus the input.
-
   await sendKeys({ type: 'o' });
   await sendKeys({ press: 'ArrowLeft' });
   await sendKeys({ down: 'Meta' });


### PR DESCRIPTION
## 🚀 Description

> ### Patch
> Dropdown when filterable and all but one Dropdown Option is disabled no longer sets the value of its input field to "Select All" when the enabled Dropdown Option is selected.

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

I intentionally omitted a test. I suspect that'll be contentious, and I don't know if I can describe my intuition well. But something doesn't seem right to me about adding tests for edge-case bugs whose root cause is structural. 

Part of it, I think, has to do with the fact the space of possible tests—covering every situation—is nearly infinite. For example, say we got a bug report where Dropdown's has three options and only the last option couldn't be disabled—or only its last option couldn't be selected. 

It's not hard to imagine hundreds of situations like this. Yet we don't test for them because they (like this bug) would be indicative of a deeper problem—and testing for them would produce an almost unlimited number of tests.

Anyway, I'm happy to add a test if you disagree or think differently. Just let me know. Either way, if you want to test the fix manually:

1. Navigate to Dropdown in Storybook.
2. Make Dropdown filterable.
3. Use DevTools disable all but one option.
4. Select the enabled option.
5. Verify the input field's value is the `label` of the selected option.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
