### PR TITLE
Only show Link underline on hover when `href` is present

### DIFF
--- a/.changeset/lemon-knives-smile.md
+++ b/.changeset/lemon-knives-smile.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Link no longer has an underline on hover when an `href` attribute isn't provided.

--- a/src/link.styles.ts
+++ b/src/link.styles.ts
@@ -23,7 +23,7 @@ export default [
           cursor: not-allowed;
         }
 
-        &:not(.disabled) {
+        &.href:not(.disabled) {
           color: var(--glide-core-color-interactive-text-link--hover);
           text-decoration: underline;
         }

--- a/src/link.test.visuals.ts
+++ b/src/link.test.visuals.ts
@@ -49,13 +49,37 @@ for (const story of stories.Link) {
           );
         });
 
-        test(':hover', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-          await page.locator('glide-core-link').hover();
+        test.describe(':hover', () => {
+          test('href=""', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+            await page.locator('glide-core-link').hover();
 
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
+            await page
+              .locator('glide-core-link')
+              .evaluate<void, Link>((element) => {
+                element.href = '';
+              });
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
+
+          test('href="/"', async ({ page }, test) => {
+            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+            await page
+              .locator('glide-core-link')
+              .evaluate<void, Link>((element) => {
+                element.href = '/';
+              });
+
+            await page.locator('glide-core-link').hover();
+
+            await expect(page).toHaveScreenshot(
+              `${test.titlePath.join('.')}.png`,
+            );
+          });
         });
       });
     }

--- a/src/link.ts
+++ b/src/link.ts
@@ -64,7 +64,11 @@ export default class Link extends LitElement {
   override render() {
     return html`<a
       aria-disabled=${this.disabled}
-      class=${classMap({ component: true, disabled: this.disabled })}
+      class=${classMap({
+        component: true,
+        disabled: this.disabled,
+        href: Boolean(this.href),
+      })}
       data-test="component"
       download=${ifDefined(this.download)}
       href=${ifDefined(this.href)}


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->
> ### Patch
> Link no longer has an underline on hover when an `href` attribute isn't provided.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

Take a look at the visual test report.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
