### PR TITLE
Add Create button to Dropdown

### DIFF
--- a/.changeset/lucky-rules-float.md
+++ b/.changeset/lucky-rules-float.md
@@ -1,0 +1,9 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown now supports creation of a new option while filtering.
+
+When the user's filter query includes a space, a Create button will appear at the bottom of Dropdown's menu. Dropdown will remain open when the button is clicked and a "create" event will be dispatched. The event's `detail` property will be set to the user's filter query.
+
+TODO

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2474,7 +2474,7 @@
           "slots": [
             {
               "name": "icon:value",
-              "description": "Icons for the selected option or options. Slot one icon per Dropdown Option. \\`<value>\\` should be equal to the \\`value\\` of each Dropdown Option.",
+              "description": "Icons for the selected Dropdown Option(s). Slot one icon per Dropdown Option. \\`<value>\\` should be equal to the \\`value\\` of each Dropdown Option.",
               "type": {
                 "text": "Element"
               }
@@ -2492,9 +2492,9 @@
                 "source": [
                   {
                     "number": 2,
-                    "source": "                  @required",
+                    "source": "                    @required",
                     "tokens": {
-                      "start": "                  ",
+                      "start": "                    ",
                       "delimiter": "",
                       "postDelimiter": "",
                       "tag": "@required",
@@ -2853,6 +2853,12 @@
             }
           ],
           "events": [
+            {
+              "name": "create",
+              "type": {
+                "text": "CustomEvent"
+              }
+            },
             {
               "name": "input",
               "type": {

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -25,7 +25,7 @@ const meta: Meta = {
   ],
   parameters: {
     actions: {
-      handles: ['change', 'input', 'invalid', 'toggle'],
+      handles: ['change', 'create', 'input', 'invalid', 'toggle'],
     },
     docs: {
       story: {
@@ -94,7 +94,7 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail:
-            '(event: "add" | "change" | "input" | "invalid" | "toggle", handler: (event: Event) => void): void',
+            '(event: "change" | "create" | "input" | "invalid" | "toggle", handler: (event: Event) => void): void',
         },
       },
     },

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -161,8 +161,7 @@ export default [
       }
     }
 
-    .default-slot {
-      display: block;
+    .default-slot-and-create-button {
       padding: var(--glide-core-spacing-base-xxxs);
     }
 
@@ -326,6 +325,54 @@ export default [
         color: var(--glide-core-color-interactive-text-placeholder);
         font-family: var(--glide-core-typography-family-primary);
       }
+    }
+
+    .create-button-container {
+      display: none;
+
+      &.bordered {
+        border-block-start: 1px solid
+          var(--glide-core-color-static-stroke-secondary);
+        margin-block-start: var(--glide-core-spacing-base-xxxs);
+        padding-block-start: var(--glide-core-spacing-base-xxxs);
+      }
+
+      &.visible {
+        display: block;
+      }
+    }
+
+    .create-button {
+      align-items: center;
+      background-color: transparent;
+      block-size: var(--private-option-height);
+      border-radius: var(--glide-core-spacing-base-sm);
+      border-width: 0;
+      display: flex;
+      font-family: var(--glide-core-typography-family-primary);
+      font-size: var(--glide-core-typography-size-body-default);
+      inline-size: 100%;
+      max-inline-size: 21.875rem;
+      padding-inline: 0.625rem;
+      transition: background-color 100ms ease-in-out;
+      user-select: none;
+      white-space: nowrap;
+
+      &.active {
+        background-color: var(
+          --glide-core-color-interactive-surface-container--hover
+        );
+      }
+    }
+
+    .create-button-label {
+      font-weight: var(--glide-core-typography-weight-bold);
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .create-button-description {
+      color: var(--glide-core-color-interactive-text-placeholder);
     }
 
     .description {

--- a/src/dropdown.test.aria.ts
+++ b/src/dropdown.test.aria.ts
@@ -29,7 +29,7 @@ test('disabled=${false}', async ({ page }) => {
   `);
 });
 
-test.describe('filterable', () => {
+test.describe('filter("o")', () => {
   test('open=${true}', async ({ page }) => {
     await page.goto('?id=dropdown--dropdown');
 
@@ -40,13 +40,128 @@ test.describe('filterable', () => {
         element.open = true;
       });
 
+    await page.getByRole('combobox').fill('o');
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+      - text: Label
+      - combobox "Label 2 items" [expanded]
+      - listbox "o":
+        - option "One"
+        - option "Two"
+    `);
+  });
+
+  test('open=${false}', async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        element.filterable = true;
+      });
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+      - text: Label
+      - combobox "Label"
+    `);
+  });
+});
+
+test.describe('filter("noMatchingOptions")', () => {
+  test('open=${true}', async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        element.filterable = true;
+        element.open = true;
+      });
+
+    await page.getByRole('combobox').fill('noMatchingOptions');
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+      - text: Label
+      - combobox "Label 0 items" [expanded]
+      - text: No matching options
+    `);
+  });
+
+  test('open=${false}', async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        element.filterable = true;
+      });
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+      - text: Label
+      - combobox "Label"
+    `);
+  });
+});
+
+test.describe('filter("noAvailableOptions")', () => {
+  test('open=${true}', async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+
+      .evaluate<void, Dropdown>((element) => {
+        element.filterable = true;
+        element.open = true;
+
+        const options = element.querySelectorAll('glide-core-dropdown-option');
+
+        for (const option of options) {
+          option.remove();
+        }
+      });
+
     await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
       - text: Label
       - combobox "Label" [expanded]
-      - listbox:
-        - option "One"
-        - option "Two"
-        - option "Three"
+      - text: No options available
+    `);
+  });
+
+  test('open=${false}', async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        element.filterable = true;
+      });
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+      - text: Label
+      - combobox "Label"
+    `);
+  });
+});
+
+test.describe('filter("create ")', () => {
+  test('open=${true}', async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        element.filterable = true;
+        element.open = true;
+      });
+
+    await page.getByRole('combobox').fill('create ');
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+      - text: Label
+      - combobox "Label 1 items" [expanded]
+      - listbox "create":
+        - option "create (Create)"
     `);
   });
 

--- a/src/dropdown.test.events.filterable.ts
+++ b/src/dropdown.test.events.filterable.ts
@@ -1,8 +1,68 @@
 import * as sinon from 'sinon';
-import { expect, fixture, html } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
+import { click } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import './dropdown.option.js';
+
+it('dispatches a "create" event on Create button selection via click', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable open>
+      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  const spy = sinon.spy();
+  host.addEventListener('create', spy);
+
+  await click(host);
+  await sendKeys({ type: 'create ' });
+
+  const createButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="create-button"]',
+  );
+
+  click(createButton);
+
+  const event = await oneEvent(host, 'create');
+
+  expect(event instanceof CustomEvent).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
+  expect(event.detail).to.equal('create ');
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches a "create" event on Create button selection via Enter', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable open>
+      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  // Wait for Floating UI.
+  await aTimeout(0);
+
+  const spy = sinon.spy();
+  host.addEventListener('create', spy);
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'create ' });
+  sendKeys({ press: 'Enter' });
+
+  const event = await oneEvent(host, 'create');
+
+  expect(event instanceof CustomEvent).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
+  expect(event.detail).to.equal('create ');
+  expect(spy.callCount).to.equal(1);
+});
 
 it('does not dispatch "input" events on input', async () => {
   const host = await fixture<Dropdown>(

--- a/src/dropdown.test.visuals.ts
+++ b/src/dropdown.test.visuals.ts
@@ -22,16 +22,57 @@ for (const story of stories.Dropdown) {
           );
         });
 
-        test('filterable', async ({ page }, test) => {
+        test('filter("noAvailableOptions")', async ({ page }, test) => {
           await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
           await page
             .locator('glide-core-dropdown')
             .evaluate<void, Dropdown>((element) => {
               element.filterable = true;
+              element.open = true;
+
+              const options = element.querySelectorAll(
+                'glide-core-dropdown-option',
+              );
+
+              for (const option of options) {
+                option.remove();
+              }
             });
 
-          await page.getByRole('combobox').fill('test');
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('filter("noMatchingOptions")', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-dropdown')
+            .evaluate<void, Dropdown>((element) => {
+              element.filterable = true;
+              element.open = true;
+            });
+
+          await page.getByRole('combobox').fill('noMatchingOptions');
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('filter("create ")', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-dropdown')
+            .evaluate<void, Dropdown>((element) => {
+              element.filterable = true;
+              element.open = true;
+            });
+
+          await page.getByRole('combobox').fill('create ');
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Adds a Create button to filterable Dropdown that's shown when the user's filter query includes a space and doesn't match one of the existing option labels.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
