### PR TITLE
Fix Textarea field-sizing bug

### DIFF
--- a/.changeset/tiny-experts-punch.md
+++ b/.changeset/tiny-experts-punch.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+When Textarea contains a long, unbroken string it no longer causes its width-constrained container to become scrollable.

--- a/src/textarea.styles.ts
+++ b/src/textarea.styles.ts
@@ -62,6 +62,21 @@ export default [
       resize: vertical;
       transition: border-color 200ms ease-in-out;
 
+      /*
+        Because 'field-sizing: content' is used, it allows the
+        element to grow to fill the content. This is problematic in
+        our case because it means our textarea could force its
+        container to scroll when a user enters long, unbroken text.
+        This issue was discussed at https://issues.chromium.org/issues/340291325,
+        but for the select element. Using 'max-width: 100%' won't
+        solve the issue, and we can't use a fixed max-width, as we
+        won't know the layouts our consumers will use our components
+        in. So setting this CSS property allows for the textarea to
+        naturally break the value up by words and prevent horizontal
+        scrolling.
+      */
+      word-break: break-word;
+
       ${fieldSizingContent};
 
       &:focus {


### PR DESCRIPTION
## 🚀 Description

Fixes a bug with Textarea when inside of a Modal, it would force the Modal to horizontally scroll on long words.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

Unfortunately, pulling this repo down and testing is probably the best way to do so. 

- Go to `src/modal.stories.ts`
- Add an import for `import './form-controls-layout.js';`
- Add an import for `import './textarea.js';`
- In the Modal default slot, render a form controls layout + textarea.

```html
<glide-core-form-controls-layout>
  <glide-core-textarea
    label="Label Label Label LabelLabel Label"
  ></glide-core-textarea>
</glide-core-form-controls-layout>
```

- Now type a long, single string of text into it: `fdasjfkldjasflkjdsalfkjdsaklfjdslafjsdlafjdslafkjsdlajfslkajflksdajflsajflsdajflka`.
- Verify it doesn't make the Modal grow.
- Delete the content and type a few sentences. Verify the words break in a reasonable way.

**Before**

https://github.com/user-attachments/assets/07f8842c-a214-4c74-8655-fe6571fc4697


