### PR TITLE
Dropdown Add button

### DIFF
--- a/.changeset/lucky-rules-float.md
+++ b/.changeset/lucky-rules-float.md
@@ -1,0 +1,9 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown now supports adding new options when filtering.
+
+When the `add-button` attribute is present, an Add button will appear when the user's filter query doesn't match the `label` of an existing Dropdown Option.
+
+Dropdown will dispatch an "add" event when the button is clicked. The event's `detail` property will be set to the user's filter query. Listen for "add" and, in its handler, add a new selected Dropdown Option based on the filter query to Dropdown's default slot.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2552,6 +2552,16 @@
             },
             {
               "kind": "field",
+              "name": "addButton",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "add-button",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "disabled",
               "type": {
                 "text": "boolean"
@@ -2866,6 +2876,12 @@
               }
             },
             {
+              "name": "add",
+              "type": {
+                "text": "CustomEvent"
+              }
+            },
+            {
               "name": "invalid",
               "type": {
                 "text": "Event"
@@ -2886,6 +2902,14 @@
               },
               "fieldName": "label",
               "required": true
+            },
+            {
+              "name": "add-button",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "addButton"
             },
             {
               "name": "disabled",

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -120,6 +120,7 @@ export default [
 
     .options-and-feedback {
       --private-border-width: 1px;
+      --private-option-height: 1.75rem;
 
       background-color: var(
         --glide-core-private-color-dialog-and-modal-surface-container
@@ -146,8 +147,6 @@ export default [
     }
 
     .options {
-      --private-option-height: 1.75rem;
-
       box-sizing: border-box;
       max-block-size: calc(
         var(--private-option-height) * 9 + var(--glide-core-spacing-base-xxxs) *
@@ -166,7 +165,10 @@ export default [
 
     .default-slot {
       display: block;
-      padding: var(--glide-core-spacing-base-xxxs);
+
+      &:not(.optionless) {
+        padding: var(--glide-core-spacing-base-xxxs);
+      }
     }
 
     .select-all {
@@ -329,6 +331,55 @@ export default [
         color: var(--glide-core-color-interactive-text-placeholder);
         font-family: var(--glide-core-typography-family-primary);
       }
+    }
+
+    .add-button-container {
+      padding: var(--glide-core-spacing-base-xxxs);
+
+      /*
+        "sticky" is a little hack so it's absolutely positioned but its space
+        in layout is preserved, so it doesn't overlap the last option.
+      */
+      position: sticky;
+
+      &.bordered {
+        border-block-start: 1px solid
+          var(--glide-core-color-static-stroke-secondary);
+        padding-block-start: var(--glide-core-spacing-base-xxxs);
+      }
+    }
+
+    .add-button {
+      align-items: center;
+      background-color: transparent;
+      block-size: var(--private-option-height);
+      border-radius: var(--glide-core-spacing-base-sm);
+      border-width: 0;
+      display: flex;
+      font-family: var(--glide-core-typography-family-primary);
+      font-size: var(--glide-core-typography-size-body-default);
+      inline-size: 100%;
+      max-inline-size: 21.875rem;
+      padding-inline: 0.625rem;
+      transition: background-color 100ms ease-in-out;
+      user-select: none;
+      white-space: nowrap;
+
+      &.active {
+        background-color: var(
+          --glide-core-color-interactive-surface-container--hover
+        );
+      }
+    }
+
+    .add-button-label {
+      font-weight: var(--glide-core-typography-weight-bold);
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .add-button-description {
+      color: var(--glide-core-color-interactive-text-placeholder);
     }
 
     .description {

--- a/src/dropdown.test.aria.ts
+++ b/src/dropdown.test.aria.ts
@@ -29,6 +29,44 @@ test('disabled=${false}', async ({ page }) => {
   `);
 });
 
+test.describe('filter("add")', () => {
+  test('open=${true}', async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        element.addButton = true;
+        element.filterable = true;
+        element.open = true;
+      });
+
+    await page.getByRole('combobox').fill('add');
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+      - text: Label
+      - combobox "Label 1 items" [expanded]
+      - listbox "add":
+        - option "add (Add)"
+    `);
+  });
+
+  test('open=${false}', async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        element.filterable = true;
+      });
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+      - text: Label
+      - combobox "Label"
+    `);
+  });
+});
+
 test.describe('filter("noMatchingOptions")', () => {
   test('open=${true}', async ({ page }) => {
     await page.goto('?id=dropdown--dropdown');
@@ -44,8 +82,8 @@ test.describe('filter("noMatchingOptions")', () => {
 
     await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
       - text: Label
-      - combobox "Label 0 items" [expanded]
-      - text: No matching options
+      - combobox "Label 0 items" [expanded]: noMatchingOptions
+      - listbox "noMatchingOptions": No matching options
     `);
   });
 
@@ -72,6 +110,7 @@ test.describe('filter("o")', () => {
     await page
       .locator('glide-core-dropdown')
       .evaluate<void, Dropdown>((element) => {
+        element.addButton = true;
         element.filterable = true;
         element.open = true;
       });
@@ -80,10 +119,11 @@ test.describe('filter("o")', () => {
 
     await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
       - text: Label
-      - combobox "Label 2 items" [expanded]
+      - combobox "Label 3 items" [expanded]
       - listbox "o":
         - option "One"
         - option "Two"
+        - option "o (Add)"
     `);
   });
 

--- a/src/dropdown.test.basics.ts
+++ b/src/dropdown.test.basics.ts
@@ -72,7 +72,7 @@ it('shows loading feedback', async () => {
   expect(feedback?.checkVisibility()).to.be.true;
 });
 
-it('selects options when `value` is set initially', async () => {
+it('selects options when `value` is set', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" .value=${['two']}>
       <glide-core-dropdown-option
@@ -91,12 +91,25 @@ it('selects options when `value` is set initially', async () => {
 
   expect(options[0]?.selected).to.be.false;
   expect(options[1]?.selected).to.be.true;
-
-  // https://github.com/CrowdStrike/glide-core/pull/764#discussion_r1995792862
   expect(host.value).to.deep.equal(['two']);
 });
 
-it('gives selected options precedence over an initial `value`', async () => {
+it('enables options when `value` is set', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" .value=${['one']}>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        disabled
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = host.querySelector('glide-core-dropdown-option');
+  expect(option?.disabled).to.be.false;
+});
+
+it('gives selected options precedence over `value`', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" .value=${['two']}>
       <glide-core-dropdown-option
@@ -130,22 +143,7 @@ it('cannot be open when disabled', async () => {
   expect(options?.checkVisibility()).to.be.false;
 });
 
-it('enables options when `value` is set initially', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" .value=${['one']}>
-      <glide-core-dropdown-option
-        label="one"
-        value="one"
-        disabled
-      ></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  const option = host.querySelector('glide-core-dropdown-option');
-  expect(option?.disabled).to.be.false;
-});
-
-it('activates the first enabled option when no options are initially selected', async () => {
+it('activates the first enabled option when no options are selected', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" open>
       <glide-core-dropdown-option

--- a/src/dropdown.test.events.filterable.ts
+++ b/src/dropdown.test.events.filterable.ts
@@ -1,8 +1,62 @@
 import * as sinon from 'sinon';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
+import { click } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import './dropdown.option.js';
+
+it('dispatches an "add" event on Add button selection via click', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('add', spy);
+
+  await click(host);
+  await sendKeys({ type: 'three' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  click(addButton);
+
+  const event = await oneEvent(host, 'add');
+
+  expect(event instanceof CustomEvent).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
+  expect(event.detail).to.equal('three');
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches an "add" event on Add button selection via Enter', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('add', spy);
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'three' });
+  sendKeys({ press: 'Enter' });
+
+  const event = await oneEvent(host, 'add');
+
+  expect(event instanceof CustomEvent).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
+  expect(event.detail).to.equal('three');
+  expect(spy.callCount).to.equal(1);
+});
 
 it('does not dispatch "input" events on input', async () => {
   const host = await fixture<Dropdown>(

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -47,7 +47,7 @@ it('closes on click', async () => {
   expect(options?.checkVisibility()).to.not.be.ok;
 });
 
-it('does not close on click when its input field is clicked', async () => {
+it('does not close when its input field is clicked', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -57,6 +57,88 @@ it('does not close on click when its input field is clicked', async () => {
 
   await aTimeout(0); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('[data-test="input"]'));
+
+  const options = host.shadowRoot?.querySelector('[data-test="options"]');
+
+  expect(host.open).to.be.true;
+  expect(options?.checkVisibility()).to.be.true;
+});
+
+it('closes when single-select and its Add button is clicked via mouse', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+  await click(host);
+  await sendKeys({ type: 'o' });
+
+  const addButton = host.shadowRoot?.querySelector('[data-test="add-button"]');
+  const options = host.shadowRoot?.querySelector('[data-test="options"]');
+
+  await click(addButton);
+
+  expect(host.open).to.be.false;
+  expect(options?.checkVisibility()).to.not.be.ok;
+});
+
+it('does not close when multiselect and its Add button is clicked via mouse', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable multiple open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+  await click(host);
+  await sendKeys({ type: 'o' });
+
+  const addButton = host.shadowRoot?.querySelector('[data-test="add-button"]');
+  const options = host.shadowRoot?.querySelector('[data-test="options"]');
+
+  await click(addButton);
+
+  expect(host.open).to.be.true;
+  expect(options?.checkVisibility()).to.be.true;
+});
+
+it('closes when single-select and its Add button is clicked via Enter', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'o' });
+  await sendKeys({ press: 'ArrowDown' }); // Two
+  await sendKeys({ press: 'ArrowDown' }); // Add
+  await sendKeys({ press: 'Enter' });
+
+  const options = host.shadowRoot?.querySelector('[data-test="options"]');
+
+  expect(host.open).to.be.false;
+  expect(options?.checkVisibility()).to.not.be.ok;
+});
+
+it('does not close when multiselect and its Add button is clicked via Enter', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable multiple open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'o' });
+  await sendKeys({ press: 'ArrowDown' }); // Two
+  await sendKeys({ press: 'ArrowDown' }); // Add
+  await sendKeys({ press: 'Enter' });
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
 
@@ -103,6 +185,59 @@ it('remains automatically filterable when an option is removed', async () => {
 
   const input = host.shadowRoot?.querySelector('[data-test="input"]');
   expect(input?.checkVisibility()).to.be.true;
+});
+
+it('has an Add button when its filter query does not match the label of an existing option', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'three' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  const feedback = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="optionless-feedback"]',
+  );
+
+  expect(addButton?.checkVisibility()).to.be.true;
+  expect(feedback?.checkVisibility()).to.not.be.ok;
+});
+
+it('does not have an Add button when its filter query is empty', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: '  ' });
+
+  const addButton = host.shadowRoot?.querySelector('[data-test="add-button"');
+  expect(addButton?.checkVisibility()).to.not.be.ok;
+});
+
+it('does not have an Add button when its filter query matches the label of an existing option', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'one' });
+
+  const addButton = host.shadowRoot?.querySelector('[data-test="add-button"');
+  expect(addButton?.checkVisibility()).to.not.be.ok;
 });
 
 it('unfilters when an option is selected via click', async () => {
@@ -600,7 +735,7 @@ it('updates its `value` when the `value` of an option is set programmatically', 
   expect(host.value).to.deep.equal(['two']);
 });
 
-it('updates its input field when made filterable', async () => {
+it('updates its input field when made filterable programmatically', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option
@@ -625,7 +760,7 @@ it('updates its input field when made filterable', async () => {
   expect(input?.value).to.equal('One');
 });
 
-it('clears its input field when multiselect is set programmatically', async () => {
+it('clears its input field when made multiselect programmatically', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option
@@ -663,7 +798,7 @@ it('does not select options on Space', async () => {
   expect(options[0]?.selected).to.be.false;
 });
 
-it('deselects the last selected option on Backspace', async () => {
+it('deselects the last selected option on Backspace when the insertion point is at the start of its input field', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable multiple open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -671,10 +806,9 @@ it('deselects the last selected option on Backspace', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await click(options[0]);
   await click(options[1]);
@@ -691,7 +825,7 @@ it('deselects the last selected option on Backspace', async () => {
   expect(options[0]?.selected).to.be.false;
 });
 
-it('deselects all options on Meta + Backspace', async () => {
+it('deselects all options on Meta + Backspace when the insertion point is at the start of its input field', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable multiple>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -878,54 +1012,36 @@ it('uses `placeholder` as a placeholder when multiselect and no option is select
   expect(input?.placeholder).to.equal('Placeholder');
 });
 
-it('sets an option as active on hover', async () => {
+it('activates options on hover', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open>
+    html`<glide-core-dropdown label="Label" add-button filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
-
-  await aTimeout(0); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
-
-  await hover(options[1]);
-
-  const activeOptions = [...options].filter(
-    ({ privateActive }) => privateActive,
-  );
-
   const input = host.shadowRoot?.querySelector('[data-test="input"]');
-
-  expect(activeOptions.length).to.equal(1);
-  expect(activeOptions.at(0)?.label).to.equal('Two');
-
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(
-    activeOptions.at(0)?.id,
-  );
-});
-
-it('sets an active option on ArrowDown', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open multiple>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
 
   await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'ArrowDown' }); // Two
+  await sendKeys({ type: 'o' });
 
-  const activeOptions = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ privateActive }) => privateActive);
-
-  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="input"]',
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
   );
 
+  await hover(addButton);
+  let activeOptions = [...options].filter(({ privateActive }) => privateActive);
+
+  expect(addButton?.dataset.testActive).to.equal('true');
+  expect(activeOptions.length).to.equal(0);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(addButton?.id);
+
+  await hover(options[1]);
+  activeOptions = [...options].filter(({ privateActive }) => privateActive);
+
+  expect(addButton?.dataset.testActive).to.equal('false');
   expect(activeOptions.length).to.equal(1);
   expect(activeOptions.at(0)?.label).to.equal('Two');
 
@@ -934,9 +1050,9 @@ it('sets an active option on ArrowDown', async () => {
   );
 });
 
-it('sets an active option on ArrowUp', async () => {
+it('activates options on ArrowDown', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open multiple>
+    html`<glide-core-dropdown label="Label" add-button filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
 
       <glide-core-dropdown-option
@@ -946,48 +1062,149 @@ it('sets an active option on ArrowUp', async () => {
     </glide-core-dropdown>`,
   );
 
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
   await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // Two
-  await sendKeys({ press: 'ArrowUp' }); // One
 
-  const activeOptions = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ privateActive }) => privateActive);
+  let activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('Two');
+  expect(activeOptions.at(0)?.privateIsEditActive).to.be.false;
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
+
+  await sendKeys({ press: 'ArrowDown' }); // Two (Edit)
+
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('Two');
+  expect(activeOptions.at(0)?.privateIsEditActive).to.be.true;
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
+
+  await sendKeys({ type: 'o' });
+  await sendKeys({ press: 'ArrowDown' }); // Add
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  expect(addButton?.checkVisibility()).to.be.true;
+  expect(addButton?.dataset.testActive).to.equal('true');
+  expect(activeOptions.length).to.equal(0);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(addButton?.id);
+});
+
+it('activates options on ArrowUp', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        editable
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'o' });
+  await sendKeys({ press: 'ArrowDown' }); // Two
+  await sendKeys({ press: 'ArrowDown' }); // Two (Edit)
+  await sendKeys({ press: 'ArrowDown' }); // Add
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  let activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  expect(addButton?.dataset.testActive).to.equal('true');
+  expect(activeOptions.length).to.equal(0);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(addButton?.id);
+
+  await sendKeys({ press: 'ArrowUp' }); // Two (Edit)
+  activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  expect(addButton?.dataset.testActive).to.equal('false');
   expect(activeOptions.length).to.equal(1);
-  expect(activeOptions.at(0)?.label).to.equal('One');
+  expect(activeOptions.at(0)?.label).to.equal('Two');
+  expect(activeOptions.at(0)?.privateIsEditActive).to.be.true;
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
+
+  await sendKeys({ press: 'ArrowUp' }); // Two
+  activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  expect(addButton?.dataset.testActive).to.equal('false');
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('Two');
+  expect(activeOptions.at(0)?.privateIsEditActive).to.be.false;
 
   expect(input?.getAttribute('aria-activedescendant')).to.equal(
     activeOptions.at(0)?.id,
   );
 });
 
-it('sets an active option on Home', async () => {
+it('activates the first option on Home', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open multiple>
+    html`<glide-core-dropdown label="Label" add-button filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
   await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'ArrowDown' });
+  await sendKeys({ press: 'End' });
   await sendKeys({ press: 'Home' });
 
-  const activeOptions = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ privateActive }) => privateActive);
+  let activeOptions = options.filter(({ privateActive }) => privateActive);
 
-  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="input"]',
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
   );
 
+  await sendKeys({ press: 'End' });
+  await sendKeys({ type: 'o' });
+  await sendKeys({ press: 'Home' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  expect(addButton?.dataset.testActive).to.equal('false');
   expect(activeOptions.length).to.equal(1);
   expect(activeOptions.at(0)?.label).to.equal('One');
 
@@ -996,27 +1213,45 @@ it('sets an active option on Home', async () => {
   );
 });
 
-it('sets an active option on PageUp', async () => {
+it('activates the first option on PageUp', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open multiple>
+    html`<glide-core-dropdown label="Label" add-button filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
   await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'ArrowDown' });
+  await sendKeys({ press: 'PageDown' });
   await sendKeys({ press: 'PageUp' });
 
-  const activeOptions = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ privateActive }) => privateActive);
+  let activeOptions = options.filter(({ privateActive }) => privateActive);
 
-  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="input"]',
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
   );
 
+  await sendKeys({ press: 'PageDown' });
+  await sendKeys({ type: 'o' });
+  await sendKeys({ press: 'PageUp' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  expect(addButton?.dataset.testActive).to.equal('false');
   expect(activeOptions.length).to.equal(1);
   expect(activeOptions.at(0)?.label).to.equal('One');
 
@@ -1025,29 +1260,51 @@ it('sets an active option on PageUp', async () => {
   );
 });
 
-it('sets an active option on Meta + ArrowUp', async () => {
+it('activates the first option on Meta + ArrowUp', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open multiple>
+    html`<glide-core-dropdown label="Label" add-button filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
   await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'ArrowDown' });
+  await sendKeys({ press: 'End' });
   await sendKeys({ down: 'Meta' });
   await sendKeys({ press: 'ArrowUp' });
   await sendKeys({ up: 'Meta' });
 
-  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="input"]',
+  let activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
   );
 
-  const activeOptions = [
+  await sendKeys({ type: 'o' });
+  await sendKeys({ press: 'End' });
+  await sendKeys({ down: 'Meta' });
+  await sendKeys({ press: 'ArrowUp' });
+  await sendKeys({ up: 'Meta' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  activeOptions = [
     ...host.querySelectorAll('glide-core-dropdown-option'),
   ].filter(({ privateActive }) => privateActive);
 
+  expect(addButton?.dataset.testActive).to.equal('false');
   expect(activeOptions.length).to.equal(1);
   expect(activeOptions.at(0)?.label).to.equal('One');
 
@@ -1056,78 +1313,25 @@ it('sets an active option on Meta + ArrowUp', async () => {
   );
 });
 
-it('sets an active option on open via click', async () => {
+it('activates the last option on End', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable>
+    html`<glide-core-dropdown label="Label" add-button filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  await click(host.shadowRoot?.querySelector('[data-test="primary-button"]'));
-
-  const activeOptions = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ privateActive }) => privateActive);
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
-  );
-
-  expect(activeOptions.length).to.equal(1);
-  expect(activeOptions.at(0)?.label).to.equal('One');
-
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(
-    activeOptions.at(0)?.id,
-  );
-});
-
-it('sets an active option on open via Space', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: ' ' });
-
-  const activeOptions = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ privateActive }) => privateActive);
-
-  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="input"]',
-  );
-
-  expect(activeOptions.length).to.equal(1);
-  expect(activeOptions.at(0)?.label).to.equal('One');
-
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(
-    activeOptions.at(0)?.id,
-  );
-});
-
-it('sets an active option on End', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open multiple>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
   );
 
   await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'End' });
 
-  const activeOptions = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ privateActive }) => privateActive);
-
-  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="input"]',
-  );
+  let activeOptions = options.filter(({ privateActive }) => privateActive);
 
   expect(activeOptions.length).to.equal(1);
   expect(activeOptions.at(0)?.label).to.equal('Two');
@@ -1135,27 +1339,41 @@ it('sets an active option on End', async () => {
   expect(input?.getAttribute('aria-activedescendant')).to.equal(
     activeOptions.at(0)?.id,
   );
+
+  await sendKeys({ press: 'Home' });
+  await sendKeys({ type: 'o' });
+  await sendKeys({ press: 'End' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  expect(addButton?.dataset.testActive).to.equal('true');
+  expect(activeOptions.length).to.equal(0);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(addButton?.id);
 });
 
-it('sets an active option on PageDown', async () => {
+it('activates the last option on PageDown', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open multiple>
+    html`<glide-core-dropdown label="Label" add-button filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
+  );
+
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
   );
 
   await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'PageDown' });
 
-  const activeOptions = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ privateActive }) => privateActive);
-
-  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="input"]',
-  );
+  let activeOptions = options.filter(({ privateActive }) => privateActive);
 
   expect(activeOptions.length).to.equal(1);
   expect(activeOptions.at(0)?.label).to.equal('Two');
@@ -1163,15 +1381,35 @@ it('sets an active option on PageDown', async () => {
   expect(input?.getAttribute('aria-activedescendant')).to.equal(
     activeOptions.at(0)?.id,
   );
+
+  await sendKeys({ press: 'PageUp' });
+  await sendKeys({ type: 'o' });
+  await sendKeys({ press: 'PageDown' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  expect(addButton?.dataset.testActive).to.equal('true');
+  expect(activeOptions.length).to.equal(0);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(addButton?.id);
 });
 
-it('sets an active option on Meta + ArrowDown', async () => {
+it('activates the last option on Meta + ArrowDown', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open multiple>
+    html`<glide-core-dropdown label="Label" add-button filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
 
   await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
@@ -1179,23 +1417,91 @@ it('sets an active option on Meta + ArrowDown', async () => {
   await sendKeys({ press: 'ArrowDown' });
   await sendKeys({ up: 'Meta' });
 
-  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="input"]',
+  let activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('Two');
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    options.at(1)?.id,
+  );
+
+  await sendKeys({ press: 'Home' });
+  await sendKeys({ type: 'o' });
+  await sendKeys({ down: 'Meta' });
+  await sendKeys({ press: 'ArrowDown' });
+  await sendKeys({ up: 'Meta' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  expect(addButton?.checkVisibility()).to.be.true;
+  expect(addButton?.dataset.testActive).to.equal('true');
+  expect(activeOptions.length).to.equal(0);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(addButton?.id);
+});
+
+it('retains its Add button as activated on ArrowUp when every option has been filtered out', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'three' });
+  await sendKeys({ press: 'ArrowUp' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
   );
 
   const activeOptions = [
     ...host.querySelectorAll('glide-core-dropdown-option'),
   ].filter(({ privateActive }) => privateActive);
 
-  expect(activeOptions.length).to.equal(1);
-  expect(activeOptions.at(0)?.label).to.equal('Two');
-
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(
-    activeOptions.at(0)?.id,
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
   );
+
+  expect(addButton?.dataset.testActive).to.equal('true');
+  expect(activeOptions.length).to.equal(0);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(addButton?.id);
 });
 
-it('sets no option as active when every option is filtered out', async () => {
+it('activates the Add button when every option has been filtered out', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'three' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(addButton?.dataset.testActive).to.equal('true');
+  expect(activeOptions.length).to.equal(0);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(addButton?.id);
+});
+
+it('deactivates the active option when the Add button is disabled and every option is filtered out', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1218,38 +1524,79 @@ it('sets no option as active when every option is filtered out', async () => {
   expect(input?.getAttribute('aria-activedescendant')).to.be.empty.string;
 });
 
-it('sets the previously active option as active when all options are filtered out', async () => {
+it('activates the previously active option when the Add button is active then filtered out', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open>
-      <glide-core-dropdown-option label="ABC"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="AB"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="A"></glide-core-dropdown-option>
+    html`<glide-core-dropdown label="Label" add-button filterable open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
   await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'ArrowDown' }); // AB
-  await sendKeys({ press: 'ArrowDown' }); // A
-  await sendKeys({ type: 'abd' });
+  await sendKeys({ type: 'o' });
+  await sendKeys({ press: 'ArrowDown' }); // Two
+  await sendKeys({ press: 'ArrowDown' }); // Add
   await sendKeys({ press: 'Backspace' });
 
-  const activeOptions = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ privateActive }) => privateActive);
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
+  const activeOptions = options.filter(({ privateActive }) => privateActive);
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
+  expect(addButton?.checkVisibility()).to.not.be.ok;
   expect(activeOptions.length).to.equal(1);
-  expect(activeOptions.at(0)?.label).to.equal('AB');
+  expect(activeOptions.at(0)?.label).to.equal('Two');
 
   expect(input?.getAttribute('aria-activedescendant')).to.equal(
     activeOptions.at(0)?.id,
   );
 });
 
-it('sets the previously active option as active when the active option is filtered out', async () => {
+it('activates the first option when the Add button is active then filtered out along with the previously active option', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Four"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'o' });
+  await sendKeys({ press: 'ArrowDown' }); // Two
+  await sendKeys({ press: 'ArrowDown' }); // Three
+  await sendKeys({ press: 'ArrowDown' }); // Four
+  await sendKeys({ press: 'ArrowDown' }); // Add
+  await sendKeys({ type: 'ne' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
+  const activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(addButton?.checkVisibility()).to.not.be.ok;
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
+});
+
+it('activates the previously active option when the active option is filtered out', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="ABC"></glide-core-dropdown-option>
@@ -1279,14 +1626,9 @@ it('sets the previously active option as active when the active option is filter
   );
 });
 
-it('sets the first enabled option as active when the previously active option is filtered out', async () => {
+it('activates the first option when the previously active option is filtered out', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open>
-      <glide-core-dropdown-option
-        label="ABCDE"
-        disabled
-      ></glide-core-dropdown-option>
-
+    html`<glide-core-dropdown label="Label" filterable multiple open>
       <glide-core-dropdown-option label="ABCD"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="ABC"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="AB"></glide-core-dropdown-option>
@@ -1301,9 +1643,8 @@ it('sets the first enabled option as active when the previously active option is
   await sendKeys({ press: 'ArrowDown' }); // A
   await sendKeys({ type: 'abc' });
 
-  const activeOptions = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ privateActive }) => privateActive);
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
+  const activeOptions = options.filter(({ privateActive }) => privateActive);
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
@@ -1317,7 +1658,7 @@ it('sets the first enabled option as active when the previously active option is
   );
 });
 
-it('sets no option as active when closed by clicking its primary button', async () => {
+it('deactivates the active option when closed', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1345,7 +1686,7 @@ it('sets no option as active when closed by clicking its primary button', async 
   expect(input?.getAttribute('aria-activedescendant')).to.be.empty.string;
 });
 
-it('sets no option as active when closed via Escape', async () => {
+it('selects the filter query when `click()` is called', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1366,53 +1707,6 @@ it('sets no option as active when closed via Escape', async () => {
 
   expect(activeOptions.length).to.equal(0);
   expect(input?.getAttribute('aria-activedescendant')).to.be.empty.string;
-});
-
-it('sets no option as active when closed because it lost focus', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  await aTimeout(0); // Wait for Floating UI
-  await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'Tab' });
-
-  const activeOptions = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ privateActive }) => privateActive);
-
-  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="input"]',
-  );
-
-  expect(activeOptions.length).to.equal(0);
-  expect(input?.getAttribute('aria-activedescendant')).to.be.empty.string;
-});
-
-it('sets no option as active when closed because something outside of it was clicked', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  await aTimeout(0); // Wait for Floating UI
-  await click(document.body);
-
-  const activeOptions = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ privateActive }) => privateActive);
-
-  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="input"]',
-  );
-
-  expect(input?.getAttribute('aria-activedescendant')).to.be.empty.string;
-  expect(activeOptions.length).to.equal(0);
 });
 
 it('cannot be tabbed to when disabled', async () => {
@@ -1568,7 +1862,7 @@ it('supports a custom `filter()` method', async () => {
 
 it('does nothing when filtering fails', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open>
+    html`<glide-core-dropdown label="Label" add-button filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
@@ -1579,18 +1873,20 @@ it('does nothing when filtering fails', async () => {
   };
 
   await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: ' ' });
-  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ type: 'o' });
 
-  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
 
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
   const activeOptions = options.filter(({ privateActive }) => privateActive);
   const visibleOptions = options.filter(({ hidden }) => !hidden);
 
+  expect(addButton?.checkVisibility()).to.be.true;
   expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
   expect(visibleOptions.length).to.equal(2);
-  expect(options[0]?.privateActive).to.be.true;
 });
 
 it('has an item count on open', async () => {
@@ -1609,17 +1905,22 @@ it('has an item count on open', async () => {
 
 it('updates its item count after filtering', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable>
+    html`<glide-core-dropdown label="Label" add-button filterable>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
+  const itemCount = host.shadowRoot?.querySelector('[data-test="item-count"]');
+
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'one' });
 
-  const itemCount = host.shadowRoot?.querySelector('[data-test="item-count"]');
   expect(itemCount?.ariaLabel).to.equal('1 items');
+
+  await sendKeys({ press: 'Backspace' });
+
+  expect(itemCount?.ariaLabel).to.equal('2 items');
 });
 
 it('shows an ellipsis when the label of its selected option overflows', async () => {
@@ -1754,7 +2055,7 @@ it('hides its ellipsis when previously overflowing and an option with a shorter 
   expect(ellipsis?.checkVisibility()).to.not.be.ok;
 });
 
-it('does not show its input tooltip when an option is selected via click', async () => {
+it('does not show its input tooltip on close when an option is selected via click', async () => {
   // The "x" is arbitrary. 500 of them ensures the component is wider
   // than the viewport even if the viewport's width is increased.
   const host = await fixture<Dropdown>(
@@ -1779,7 +2080,7 @@ it('does not show its input tooltip when an option is selected via click', async
   expect(tooltip?.open).to.be.false;
 });
 
-it('does not show its input tooltip when an option is selected via Enter', async () => {
+it('does not show its input tooltip on close when an option is selected via Enter', async () => {
   // The "x" is arbitrary. 500 of them ensures the component is wider
   // than the viewport even if the viewport's width is increased.
   const host = await fixture<Dropdown>(
@@ -1796,6 +2097,40 @@ it('does not show its input tooltip when an option is selected via Enter', async
 
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
+  await sendKeys({ press: 'Enter' });
+  await tooltip?.updateComplete;
+
+  expect(tooltip?.open).to.be.false;
+});
+
+it('does not show its input tooltip on close when an option is added via the Add button', async () => {
+  // The "x" is arbitrary. 500 of them ensures the component is wider
+  // than the viewport even if the viewport's width is increased.
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable>
+      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const tooltip = host.shadowRoot?.querySelector<Tooltip>(
+    '[data-test="input-tooltip"]',
+  );
+
+  host.addEventListener('add', (event: Event) => {
+    if (event instanceof CustomEvent) {
+      const option = document.createElement('glide-core-dropdown-option');
+
+      option.label = event.detail;
+      option.selected = true;
+
+      host.append(option);
+    }
+  });
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: ' ' });
+  await aTimeout(0); // Wait for Floating UI
+  await sendKeys({ type: 'x'.repeat(500) });
   await sendKeys({ press: 'Enter' });
   await tooltip?.updateComplete;
 
@@ -1881,7 +2216,7 @@ it('retains its filter query when single-select` and its default slot changes', 
   expect(input?.value).to.equal('one');
 });
 
-it('shows a fallback when every option has been hidden via filtering', async () => {
+it('shows a fallback when every option has been filtered out', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1938,6 +2273,51 @@ it('shows a fallback when every option has been removed via filtering', async ()
   expect(options?.checkVisibility()).to.be.false;
 });
 
+it('does not show a fallback when every option has been filtered out and the Add button is available', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'two' });
+
+  const feedback = host.shadowRoot?.querySelector(
+    '[data-test="optionless-feedback"]',
+  );
+
+  expect(feedback?.checkVisibility()).to.not.be.ok;
+});
+
+it('does not show a fallback when every option has been removed via filtering and the Add button is available', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+
+  host.filter = async () => {
+    const options = host.querySelectorAll('glide-core-dropdown-option');
+
+    for (const option of options) {
+      option.remove();
+    }
+  };
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'two' });
+
+  const feedback = host.shadowRoot?.querySelector(
+    '[data-test="optionless-feedback"]',
+  );
+
+  expect(feedback?.checkVisibility()).to.not.be.ok;
+});
+
 it('updates itself when multiple options are selected and the last selected option is disabled programmatically', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable>
@@ -1981,7 +2361,7 @@ it('updates itself when multiple options are selected and the last selected opti
   expect(input?.getAttribute('aria-activedescendant')).to.equal(options[0]?.id);
   expect(inputTooltip?.disabled).to.be.true;
   expect(activeOptions.length).to.equal(1);
-  expect(options[0]?.privateActive).to.be.true;
+  expect(activeOptions.at(0)?.label).to.equal('One');
 });
 
 it('updates itself when multiple options are selected and the last selected option is enabled programmatically', async () => {
@@ -2019,4 +2399,73 @@ it('updates itself when multiple options are selected and the last selected opti
   expect(input?.value).to.equal('Two');
   expect(inputTooltip?.disabled).to.be.true;
   expect(host.value).to.deep.equal(['two']);
+});
+
+it('resets itself when its Add button is clicked via mouse', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable multiple>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await click(host.shadowRoot?.querySelector('[data-test="input"]'));
+  await sendKeys({ type: 'three' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  await click(addButton);
+
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
+  const activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(addButton?.checkVisibility()).to.not.be.ok;
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
+  expect(input?.value).to.be.empty.string;
+  expect(host.shadowRoot?.activeElement).to.equal(input);
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
+});
+
+it('resets itself when its Add button is clicked via Enter', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" add-button filterable multiple>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'three' });
+  await sendKeys({ press: 'Enter' });
+
+  const addButton = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="add-button"]',
+  );
+
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
+  const activeOptions = options.filter(({ privateActive }) => privateActive);
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(addButton?.checkVisibility()).to.not.be.ok;
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
+  expect(input?.value).to.be.empty.string;
+  expect(host.shadowRoot?.activeElement).to.equal(input);
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
 });

--- a/src/dropdown.test.interactions.ts
+++ b/src/dropdown.test.interactions.ts
@@ -374,6 +374,53 @@ it('does not activate a disabled option on hover', async () => {
   expect(options[1]?.privateActive).to.be.false;
 });
 
+it('activates the first enabled option on open via click', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="One"
+        disabled
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await click(host.shadowRoot?.querySelector('[data-test="primary-button"]'));
+
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('Two');
+});
+
+it('activates the first enabled option on open via Space', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="One"
+        disabled
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: ' ' });
+
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('Two');
+});
+
 it('activates the next enabled option on ArrowDown', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" open>

--- a/src/dropdown.test.visuals.ts
+++ b/src/dropdown.test.visuals.ts
@@ -22,6 +22,24 @@ for (const story of stories.Dropdown) {
           );
         });
 
+        test('filter("add")', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-dropdown')
+            .evaluate<void, Dropdown>((element) => {
+              element.addButton = true;
+              element.filterable = true;
+              element.open = true;
+            });
+
+          await page.getByRole('combobox').fill('add');
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
         test('filter("noMatchingOptions")', async ({ page }, test) => {
           await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
@@ -45,6 +63,7 @@ for (const story of stories.Dropdown) {
           await page
             .locator('glide-core-dropdown')
             .evaluate<void, Dropdown>((element) => {
+              element.addButton = true;
               element.filterable = true;
               element.open = true;
             });

--- a/src/library/localize.ts
+++ b/src/library/localize.ts
@@ -35,6 +35,7 @@ export interface Translation extends DefaultTranslation {
   error: string;
   informational: string;
   loading: string;
+  add: string;
 
   announcedCharacterCount: (current: number, maximum: number) => string;
   displayedCharacterCount: (current: number, maximum: number) => string;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -15,7 +15,7 @@
   "error": "Error:",
   "informational": "Informational:",
   "loading": "Loading",
-  "add": "add",
+  "add": "Add",
   "announcedCharacterCount": "Character count {current} of {maximum}",
   "displayedCharacterCount": "{current}/{maximum}",
   "clearEntry": "Clear {label} entry",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -15,6 +15,7 @@
   "error": "Error:",
   "informational": "Informational:",
   "loading": "Loading",
+  "add": "add",
   "announcedCharacterCount": "Character count {current} of {maximum}",
   "displayedCharacterCount": "{current}/{maximum}",
   "clearEntry": "Clear {label} entry",

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -23,6 +23,7 @@ const translation: Translation = {
   error: 'Error:',
   informational: 'Informational:',
   loading: 'Loading',
+  add: 'Add',
 
   announcedCharacterCount: (current: number, maximum: number) =>
     `Character count ${current} of ${maximum}`,

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -14,6 +14,7 @@ export const PENDING_STRINGS = [
   'setMaximum',
   'minimum',
   'setMinimum',
+  'add',
 ] as const;
 
 type PendingTranslation = (typeof PENDING_STRINGS)[number];

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -14,6 +14,7 @@ export const PENDING_STRINGS = [
   'setMaximum',
   'minimum',
   'setMinimum',
+  'add',
 ] as const;
 
 type PendingTranslation = (typeof PENDING_STRINGS)[number];

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -102,9 +102,10 @@ export default {
           },
         ],
 
-  // If a test suite take longer than this, it's almost certainly hanging
-  // and won't finish. 2 minutes is the default.
-  testsFinishTimeout: process.env.CI ? 90_000 : 30_000,
+  // If a test suite take longer than this, it's almost certainly hanging and
+  // won't finish. 2 minutes is the default. These timeouts can be reduced by
+  // 30 seconds or so when Dropdown is moved out of the repository.
+  testsFinishTimeout: process.env.CI ? 90_000 : 60_000,
 
   testRunnerHtml(testFramework) {
     return `<html>

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -102,7 +102,7 @@ export default {
           },
         ],
 
-  // If a test suite take longer than this, it's almost certainly hanging and
+  // If a test suite takes longer than this, it's almost certainly hanging and
   // won't finish. 2 minutes is the default. These timeouts can be reduced by
   // 30 seconds or so when Dropdown is moved out of the repository.
   testsFinishTimeout: process.env.CI ? 90_000 : 60_000,


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Dropdown's Add button returns! The previous Add button wasn't useful to consumers. We've learned they don't want an Add button that kicks the user into a modal. They want an inline button shown when the user is filtering:


> ## Patch
>
> Dropdown now supports adding new options when filtering.
> 
> When the `add-button` attribute is present, an Add button will appear when the user's filter query doesn't match the `label` of an existing Dropdown Option.
>
> Dropdown will dispatch an "add" event when the button is clicked. The event's `detail` property will be set to the user's filter query. Listen for "add" and, in its handler, add a new selected Dropdown Option based on the filter query to Dropdown's default slot.



## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to Dropdown in Storybook.
2. Enable Dropdown's `add-button` and `filterable` attributes.
3. Open Dropdown.
4. Verify the Add button is hidden.
5. Filter by "o". 
6. Verify "One", "Two", and the Add button are visible.
7. Verify arrowing through Dropdown's options works as you'd expect.
8.  Filter by "four".
9. Verify only the Add button is visible.
10. Select the Add button.
11. Verify an "add" event is dispatched with a `detail` property equal to `"four"`.
12. Verify that a selected "Four" option is added to Dropdown.
13. Verify Dropdown's `value` is `["four"]`.
14. Rinse and repeat for multiselect Dropdown. Make sure to test with and without Select All.


<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
