### PR TITLE
Dropdown housekeeping

### DIFF
--- a/.changeset/hungry-points-boil.md
+++ b/.changeset/hungry-points-boil.md
@@ -1,0 +1,29 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+## Dropdown
+
+- The user's system preference for reduced motion is now respected when Dropdown is scrolled using the arrow keys.
+
+- The first enabled Dropdown Option is now activated when the currently active Dropdown Option is disabled programmatically.
+
+### Single-select
+
+- When a Dropdown Option is selected and a new Dropdown Option with a `selected` attribute is added to Dropdown's default slot, only the last selected Dropdown Option now appears as selected.
+
+- Dropdown's `value` and input field (if Dropdown is filterable) are now set to the `value` and `label` of the next last selected and enabled Dropdown Option when the previously last selected Dropdown Option is disabled programmatically. If no Dropdown Option is selected and enabled, Dropdown will clear its `value` and input field.
+
+### Filterable
+
+- `aria-activedescendant` is now set internally to an empty string when every Dropdown Option has been filtered out.
+
+- There's no longer a stray ellipsis at the end of Dropdown's input field when Dropdown's input field is visually truncated then subsequently cleared by the user.
+
+- A tooltip is no longer shown on Dropdown's input field when a Dropdown Option with a long label is selected then Dropdown is closed.
+
+- The value of Dropdown's input field no longer changes to the `label` of a selected Dropdown Option when its `label` is changed programmatically and it isn't the last selected Dropdown Option.
+
+- Single-select Dropdown's input field no longer retains the `label` of the previously selected Dropdown Option when the `label` of the now-selected Dropdown Option is an empty string.
+
+- When the currently and previously active Dropdown Options are filtered out, the first Dropdown Option was activated even if it was disabled. Now the first enabled Dropdown Option is activated instead.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2237,6 +2237,16 @@
             },
             {
               "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "attribute": "value",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "version",
               "type": {
                 "text": "string"
@@ -2248,16 +2258,6 @@
             {
               "kind": "method",
               "name": "click"
-            },
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "attribute": "value",
-              "reflects": true
             }
           ],
           "events": [
@@ -2406,20 +2406,20 @@
               "fieldName": "tabIndex"
             },
             {
-              "name": "version",
-              "type": {
-                "text": "string"
-              },
-              "readonly": true,
-              "fieldName": "version"
-            },
-            {
               "name": "value",
               "type": {
                 "text": "string"
               },
               "default": "''",
               "fieldName": "value"
+            },
+            {
+              "name": "version",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "fieldName": "version"
             }
           ],
           "superclass": {
@@ -2474,7 +2474,7 @@
           "slots": [
             {
               "name": "icon:value",
-              "description": "Icons for the selected option or options. Slot one icon per Dropdown Option. \\`<value>\\` should be equal to the \\`value\\` of each Dropdown Option.",
+              "description": "Icons for the selected Dropdown Option(s). Slot one icon per Dropdown Option. \\`<value>\\` should be equal to the \\`value\\` of each Dropdown Option.",
               "type": {
                 "text": "Element"
               }
@@ -2492,9 +2492,9 @@
                 "source": [
                   {
                     "number": 2,
-                    "source": "                  @required",
+                    "source": "                    @required",
                     "tokens": {
-                      "start": "                  ",
+                      "start": "                    ",
                       "delimiter": "",
                       "postDelimiter": "",
                       "tag": "@required",

--- a/src/dropdown.option.test.interactions.single.ts
+++ b/src/dropdown.option.test.interactions.single.ts
@@ -95,54 +95,6 @@ it('has no tooltip when active and with a short label set programmatically', asy
   expect(tooltip?.open).to.be.false;
 });
 
-it('sets `aria-selected` when selected programmatically', async () => {
-  const host = await fixture<DropdownOption>(
-    html`<glide-core-dropdown-option
-      label="Label"
-    ></glide-core-dropdown-option>`,
-  );
-
-  host.selected = true;
-  expect(host.ariaSelected).to.equal('true');
-});
-
-it('sets `aria-selected` when deselected programmatically', async () => {
-  const host = await fixture<DropdownOption>(
-    html`<glide-core-dropdown-option
-      label="Label"
-      selected
-    ></glide-core-dropdown-option>`,
-  );
-
-  host.selected = false;
-  expect(host.ariaSelected).to.equal('false');
-});
-
-it('sets `aria-selected` when disabled programmatically', async () => {
-  const host = await fixture<DropdownOption>(
-    html`<glide-core-dropdown-option
-      label="Label"
-      selected
-    ></glide-core-dropdown-option>`,
-  );
-
-  host.disabled = true;
-  expect(host.ariaSelected).to.equal('false');
-});
-
-it('sets `aria-selected` when enabled programmatically', async () => {
-  const host = await fixture<DropdownOption>(
-    html`<glide-core-dropdown-option
-      label="Label"
-      disabled
-      selected
-    ></glide-core-dropdown-option>`,
-  );
-
-  host.disabled = false;
-  expect(host.ariaSelected).to.equal('true');
-});
-
 it('sets `privateIsEditActive`', async () => {
   const host = await fixture<DropdownOption>(
     html`<glide-core-dropdown-option

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -25,7 +25,7 @@ const meta: Meta = {
   ],
   parameters: {
     actions: {
-      handles: ['change', 'input', 'invalid', 'toggle'],
+      handles: ['change', 'edit', 'input', 'invalid', 'toggle'],
     },
     docs: {
       story: {
@@ -94,7 +94,7 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail:
-            '(event: "add" | "change" | "input" | "invalid" | "toggle", handler: (event: Event) => void): void',
+            '(event: "change" | "input" | "invalid" | "toggle", handler: (event: Event) => void): void',
         },
       },
     },
@@ -129,7 +129,15 @@ const meta: Meta = {
         type: {
           summary: 'method',
           detail: `
-async (query: string): Promise<DropdownOption[] | void> => {
+// By default, \`filter()\` is implemented similar to the first example below. It filters against
+// Dropdown Options already present in Dropdown's default slot.
+//
+// You can override \`filter()\` to change what gets filtered out by returning the options you want
+// visible. The rest will be hidden:
+
+const dropdown = document.querySelector('glide-core-dropdown');
+
+dropdown.filter = async (query: string): Promise<DropdownOption[] | void> => {
   const options = [...this.querySelectorAll('glide-core-dropdown-option)];
 
   return options.filter(({ label }) => {
@@ -137,10 +145,32 @@ async (query: string): Promise<DropdownOption[] | void> => {
   });
 }
 
-// When overriding this method, return the options you want visible. The rest will be hidden.
-//
-// If you fetch when filtering, this is the place to do it. Just make sure you've updated
-// Dropdown's default slot with the new set of options before you query for and filter them.
+// Alternatively, you can override \`filter()\` to support server-side filtering:
+
+class Component extends LitElement {
+  @state()
+  options = [{ label: 'One', key: 'one' }, { label: 'Two', key: 'two' }];
+
+  firstUpdated() {
+    this.#dropdownRef.value.filter = async (query: string): Promise<DropdownOption[] | void> => {
+      this.options = window.fetch(query);
+    }
+  }
+
+  render() {
+    return html\`
+      <glide-core-dropdown label="Label" \${ref(this.#dropdownRef)}>
+        \${repeat(
+          this.options,
+          ({ key }) => key),
+          ({ label }) => {
+            return html\`<glide-core-dropdown-option label=\${label}></glide-core-dropdown-option>\`;
+          }
+        )}
+      </glide-core-dropdown>
+    \`;
+  }
+}
 `,
         },
       },

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -154,7 +154,10 @@ export default [
           2 + var(--private-border-width) * 2
       );
       overflow: auto;
-      scroll-behavior: smooth;
+
+      @media (prefers-reduced-motion: no-preference) {
+        scroll-behavior: smooth;
+      }
 
       &.hidden {
         display: none;

--- a/src/dropdown.test.aria.ts
+++ b/src/dropdown.test.aria.ts
@@ -29,7 +29,7 @@ test('disabled=${false}', async ({ page }) => {
   `);
 });
 
-test.describe('filterable', () => {
+test.describe('filter("noMatchingOptions")', () => {
   test('open=${true}', async ({ page }) => {
     await page.goto('?id=dropdown--dropdown');
 
@@ -40,13 +40,50 @@ test.describe('filterable', () => {
         element.open = true;
       });
 
+    await page.getByRole('combobox').fill('noMatchingOptions');
+
     await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
       - text: Label
-      - combobox "Label" [expanded]
-      - listbox:
+      - combobox "Label 0 items" [expanded]
+      - text: No matching options
+    `);
+  });
+
+  test('open=${false}', async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        element.filterable = true;
+      });
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+      - text: Label
+      - combobox "Label"
+    `);
+  });
+});
+
+test.describe('filter("o")', () => {
+  test('open=${true}', async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        element.filterable = true;
+        element.open = true;
+      });
+
+    await page.getByRole('combobox').fill('o');
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+      - text: Label
+      - combobox "Label 2 items" [expanded]
+      - listbox "o":
         - option "One"
         - option "Two"
-        - option "Three"
     `);
   });
 

--- a/src/dropdown.test.basics.multiple.ts
+++ b/src/dropdown.test.basics.multiple.ts
@@ -114,8 +114,7 @@ it('shows Select All', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const selectAll = host.shadowRoot?.querySelector<DropdownOption>(
     '[data-test="select-all"]',
@@ -237,9 +236,11 @@ it('sets its internal label to `placeholder` when no option is selected', async 
     </glide-core-dropdown>`,
   );
 
-  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
 
-  expect(label?.textContent?.trim()).to.equal('Placeholder');
+  expect(internalLabel?.textContent?.trim()).to.equal('Placeholder');
 });
 
 it('has no internal label when an option is selected', async () => {
@@ -254,9 +255,11 @@ it('has no internal label when an option is selected', async () => {
     </glide-core-dropdown>`,
   );
 
-  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
 
-  expect(label?.checkVisibility()).to.not.be.ok;
+  expect(internalLabel?.checkVisibility()).to.not.be.ok;
 });
 
 it('has a "multiselect" icon for each selected option with a value', async () => {

--- a/src/dropdown.test.basics.single.ts
+++ b/src/dropdown.test.basics.single.ts
@@ -30,6 +30,52 @@ it('has a selected option label when an option is initially selected', async () 
   expect(labels?.[0]?.textContent?.trim()).to.equal('One,');
 });
 
+it('has an Edit button when its last selected option is editable', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        editable
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const editButton = host.shadowRoot?.querySelector(
+    '[data-test="edit-button"]',
+  );
+
+  expect(editButton?.checkVisibility()).to.be.true;
+});
+
+it('does not have an Edit button when its last selected option is not editable', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="One"
+        selected
+        editable
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const editButton = host.shadowRoot?.querySelector(
+    '[data-test="edit-button"]',
+  );
+
+  expect(editButton?.checkVisibility()).to.not.be.ok;
+});
+
 it('sets its internal `label` to the last initially selected option', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label">
@@ -45,9 +91,11 @@ it('sets its internal `label` to the last initially selected option', async () =
     </glide-core-dropdown>`,
   );
 
-  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
 
-  expect(label?.textContent?.trim()).to.equal('Two');
+  expect(internalLabel?.textContent?.trim()).to.equal('Two');
 });
 
 it('sets `value` to that of the last initially selected option', async () => {
@@ -185,8 +233,7 @@ it('only shows the last selected option as selected when multiple are selected i
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 

--- a/src/dropdown.test.basics.ts
+++ b/src/dropdown.test.basics.ts
@@ -35,8 +35,7 @@ it('can be open', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
   expect(options?.checkVisibility()).to.be.true;
@@ -47,8 +46,7 @@ it('shows a fallback when open and there are no options', async () => {
     html`<glide-core-dropdown label="Label" open></glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const feedback = host.shadowRoot?.querySelector(
     '[data-test="optionless-feedback"]',
@@ -65,8 +63,7 @@ it('shows loading feedback', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const feedback = host.shadowRoot?.querySelector(
     '[data-test="loading-feedback"]',
@@ -148,42 +145,26 @@ it('enables options when `value` is set initially', async () => {
   expect(option?.disabled).to.be.false;
 });
 
-it('activates the first option when no options are initially selected', async () => {
+it('activates the first enabled option when no options are initially selected', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" open>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="One"
+        disabled
+      ></glide-core-dropdown-option>
+
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Three"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  const options = host.querySelectorAll('glide-core-dropdown-option');
-
-  expect(options[0]?.privateActive).to.be.true;
-  expect(options[1]?.privateActive).to.be.false;
-});
-
-it('activates the last selected option when options are initially selected', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" open>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option
-        label="Two"
-        selected
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option
-        label="Three"
-        selected
-      ></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
   expect(options[0]?.privateActive).to.be.false;
-  expect(options[1]?.privateActive).to.be.false;
-  expect(options[2]?.privateActive).to.be.true;
+  expect(options[1]?.privateActive).to.be.true;
+  expect(options[2]?.privateActive).to.be.false;
 });
 
 it('is scrollable', async () => {
@@ -202,8 +183,7 @@ it('is scrollable', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
   assert(options);
@@ -226,8 +206,7 @@ it('is not scrollable', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
   assert(options);
@@ -248,8 +227,7 @@ it('hides the tooltip of the active option when open', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const tooltip = host
     .querySelector('glide-core-dropdown-option')

--- a/src/dropdown.test.focus.filterable.ts
+++ b/src/dropdown.test.focus.filterable.ts
@@ -26,9 +26,7 @@ it('retains focus on the input when an option is selected via click', async () =
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await click(host.querySelector('glide-core-dropdown-option'));
 
@@ -46,9 +44,7 @@ it('retains focus on the the input when an option is selected via Enter', async 
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
 
   host
@@ -138,8 +134,7 @@ it('sets the `value` of its `<input> to the selected option when focus is lost',
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
   assert(option);

--- a/src/dropdown.test.focus.ts
+++ b/src/dropdown.test.focus.ts
@@ -64,9 +64,7 @@ it('shows a fallback on focus when there are no options', async () => {
 
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
-
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const feedback = host.shadowRoot?.querySelector(
     '[data-test="optionless-feedback"]',

--- a/src/dropdown.test.forms.multiple.ts
+++ b/src/dropdown.test.forms.multiple.ts
@@ -37,10 +37,12 @@ it('can be reset', async () => {
 
   await host.updateComplete;
 
-  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
 
   expect(host.value).to.deep.equal([]);
-  expect(label?.textContent?.trim()).to.equal('Placeholder');
+  expect(internalLabel?.textContent?.trim()).to.equal('Placeholder');
 });
 
 it('can be reset to its initially selected options', async () => {

--- a/src/dropdown.test.forms.single.ts
+++ b/src/dropdown.test.forms.single.ts
@@ -31,9 +31,11 @@ it('can be reset', async () => {
 
   await host.updateComplete;
 
-  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
 
-  expect(label?.textContent?.trim()).to.equal('Placeholder');
+  expect(internalLabel?.textContent?.trim()).to.equal('Placeholder');
   expect(host.value).to.deep.equal([]);
 });
 
@@ -65,9 +67,11 @@ it('can be reset to the initially selected option', async () => {
 
   form.reset();
 
-  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
 
-  expect(label?.textContent?.trim()).to.equal('Two');
+  expect(internalLabel?.textContent?.trim()).to.equal('Two');
   expect(host.value).to.deep.equal(['two']);
 });
 

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -12,8 +12,7 @@ import sinon from 'sinon';
 import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import './dropdown.option.js';
-import './tag.js';
-import './tooltip.js';
+import type Tooltip from './tooltip.js';
 
 it('opens on click', async () => {
   const host = await fixture<Dropdown>(
@@ -39,9 +38,7 @@ it('closes on click', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('[data-test="primary-button"]'));
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
@@ -50,7 +47,7 @@ it('closes on click', async () => {
   expect(options?.checkVisibility()).to.not.be.ok;
 });
 
-it('does not close on click', async () => {
+it('does not close on click when its input field is clicked', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -58,9 +55,7 @@ it('does not close on click', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('[data-test="input"]'));
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
@@ -118,15 +113,15 @@ it('unfilters when an option is selected via click', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'one' });
 
-  [...host.querySelectorAll('glide-core-dropdown-option')]
-    .find(({ hidden }) => !hidden)
-    ?.click();
+  await click(
+    [...host.querySelectorAll('glide-core-dropdown-option')].find(
+      ({ hidden }) => !hidden,
+    ),
+  );
 
   const options = [
     ...host.querySelectorAll('glide-core-dropdown-option'),
@@ -162,7 +157,7 @@ it('unfilters on Backspace', async () => {
     </glide-core-dropdown>`,
   );
 
-  host.focus();
+  await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'one' });
   await sendKeys({ press: 'Backspace' });
   await sendKeys({ press: 'Backspace' });
@@ -271,9 +266,7 @@ it('hides its magnifying glass icon when single-select and an option is selected
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'one' });
 
@@ -299,8 +292,7 @@ it('hides its magnifying glass icon when single-select and closed programmatical
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
   assert(option);
@@ -365,11 +357,8 @@ it('clears its filter on close when single-select and no option is selected', as
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-
   await sendKeys({ type: 'o' });
   await click(document.body);
 
@@ -388,9 +377,7 @@ it('clears its filter on close when multiselect and no option is selected', asyn
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'o' });
   await click(document.body);
@@ -414,9 +401,7 @@ it('clears its filter on close when multiselect and an option is selected', asyn
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'o' });
   await click(document.body);
@@ -440,9 +425,7 @@ it('does not clear its filter when a tag is removed via Backspace', async () => 
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' }); // Focus the tag.
   await sendKeys({ press: 'Tab' }); // Focus the input.
   await sendKeys({ type: 'o' });
@@ -468,15 +451,14 @@ it('does not clear its filter when every tag is removed via Meta + Backspace', a
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
   await sendKeys({ press: 'Tab' }); // Focus the tag.
-  await sendKeys({ press: 'Tab' }); // Focus the input.
+  await sendKeys({ press: 'Tab' }); // Focus the input field.
   await sendKeys({ type: 'o' });
   await sendKeys({ press: 'ArrowLeft' });
   await sendKeys({ down: 'Meta' });
@@ -502,30 +484,6 @@ it('does not filter on only whitespace', async () => {
   ].filter(({ hidden }) => !hidden);
 
   expect(options.length).to.equal(2);
-});
-
-it('hides the options when all of them are filtered out', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  await sendKeys({ press: 'Tab' });
-  await sendKeys({ type: 'fifty' });
-
-  // Wait for it to close.
-  await aTimeout(0);
-
-  const options = host.shadowRoot?.querySelector<HTMLElement>(
-    '[data-test="options"]',
-  );
-
-  expect(options?.checkVisibility()).to.be.false;
 });
 
 it('hides Select All when filtering', async () => {
@@ -558,46 +516,20 @@ it('unhides every option after filtering when one is selected and Dropdown is re
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'two' });
   await sendKeys({ press: 'Tab' });
 
   host.open = true;
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = [
     ...host.querySelectorAll('glide-core-dropdown-option'),
   ].filter(({ hidden }) => !hidden);
 
   expect(options.length).to.equal(2);
-});
-
-it('sets the first unfiltered option as active when the previously active option is filtered out', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable multiple select-all>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  await sendKeys({ press: 'Tab' });
-  await sendKeys({ type: 'two' });
-
-  const option = [...host.querySelectorAll('glide-core-dropdown-option')].find(
-    ({ hidden }) => !hidden,
-  );
-
-  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="input"]',
-  );
-
-  expect(option?.privateActive).to.be.true;
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(option?.id);
 });
 
 it('updates its input field when the `label` of its selected option is set programmatically', async () => {
@@ -623,6 +555,34 @@ it('updates its input field when the `label` of its selected option is set progr
   );
 
   expect(input?.value).to.equal('Three');
+});
+
+it('does not update its input field when multiple options are selected and the `label` of a selected option that is not the last is set programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+  assert(options[0]);
+
+  options[0].label = 'Three';
+  await host.updateComplete;
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(input?.value).to.equal(options[1]?.label);
 });
 
 it('updates its `value` when the `value` of an option is set programmatically', async () => {
@@ -665,7 +625,7 @@ it('updates its input field when made filterable', async () => {
   expect(input?.value).to.equal('One');
 });
 
-it('clears its input field when `multiple` is set programmatically', async () => {
+it('clears its input field when multiselect is set programmatically', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option
@@ -711,8 +671,7 @@ it('deselects the last selected option on Backspace', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -758,22 +717,24 @@ it('deselects all options on Meta + Backspace', async () => {
   expect(options[0]?.selected).to.be.false;
 });
 
-it('sets its input field to the `label` of its selected option when not `multiple`', async () => {
+it('sets its input field to the `label` of its selected option when single-select`', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable>
+    html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  const option = host?.querySelector('glide-core-dropdown-option');
-  option?.click();
+  const options = host?.querySelectorAll('glide-core-dropdown-option');
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
-  expect(input?.value).to.equal(option?.label);
+  await aTimeout(0); // Wait for Floating UI
+  await click(options[0]);
+
+  expect(input?.value).to.equal(options[0]?.label);
 });
 
 it('clears its input field when single-select and `value` is emptied programmatically', async () => {
@@ -797,7 +758,7 @@ it('clears its input field when single-select and `value` is emptied programmati
   expect(input?.value).to.be.empty.string;
 });
 
-it('clears the `value` of its `<input>` when single-select and its selected option is removed', async () => {
+it('clears its input field when single-select and its selected option is removed', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option
@@ -811,11 +772,8 @@ it('clears the `value` of its `<input>` when single-select and its selected opti
 
   host.querySelector('glide-core-dropdown-option')?.remove();
 
-  // Wait for `#onDefaultSlotChange()`.
-  await aTimeout(0);
-
-  // Now wait for the forced update in `#onDefaultSlotChange()`.
-  await host.updateComplete;
+  await aTimeout(0); // Wait for `#onDefaultSlotChange()`.
+  await host.updateComplete; // Now wait for the forced update in `#onDefaultSlotChange()`.
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
@@ -824,7 +782,29 @@ it('clears the `value` of its `<input>` when single-select and its selected opti
   expect(input?.value).to.be.empty.string;
 });
 
-it('clears its input field when multiselect and an option is selected', async () => {
+it('clears its input field when multiselect and an option is selected via mouse', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable multiple open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = host?.querySelectorAll('glide-core-dropdown-option');
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'one' });
+  await click(options[0]);
+
+  expect(input?.value).to.be.empty.string;
+});
+
+it('clears its input field when multiselect and an option is selected via Enter', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable multiple>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -834,9 +814,7 @@ it('clears its input field when multiselect and an option is selected', async ()
 
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'one' });
-
-  const option = host?.querySelector('glide-core-dropdown-option');
-  option?.click();
+  await sendKeys({ press: 'Enter' });
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
@@ -852,6 +830,7 @@ it('does not clear its filter when a tag is removed', async () => {
         label="One"
         selected
       ></glide-core-dropdown-option>
+
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
@@ -888,8 +867,9 @@ it('uses `placeholder` as a placeholder when multiselect and no option is select
     </glide-core-dropdown>`,
   );
 
-  host?.querySelector('glide-core-dropdown-option')?.click();
+  const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await click(options[0]);
   await host.updateComplete;
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
@@ -899,26 +879,35 @@ it('uses `placeholder` as a placeholder when multiselect and no option is select
   expect(input?.placeholder).to.equal('Placeholder');
 });
 
-it('sets `aria-activedescendant` on option hover', async () => {
+it('sets an option as active on hover', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" open>
+    html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
-  const input = host.shadowRoot?.querySelector('[data-test="input"]');
 
   await hover(options[1]);
 
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(options[1]?.id);
+  const activeOptions = [...options].filter(
+    ({ privateActive }) => privateActive,
+  );
+
+  const input = host.shadowRoot?.querySelector('[data-test="input"]');
+
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('Two');
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
 });
 
-it('sets `aria-activedescendant` on ArrowDown', async () => {
+it('sets an active option on ArrowDown', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open multiple>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -926,47 +915,60 @@ it('sets `aria-activedescendant` on ArrowDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'ArrowDown' });
+  await sendKeys({ press: 'ArrowDown' }); // Two
+
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
-  const options = host.querySelectorAll('glide-core-dropdown-option');
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('Two');
 
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(options[1]?.id);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
 });
 
-it('sets `aria-activedescendant` on ArrowUp', async () => {
+it('sets an active option on ArrowUp', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open multiple>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        editable
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'ArrowDown' });
+  await sendKeys({ press: 'ArrowDown' }); // Two
+  await sendKeys({ press: 'ArrowUp' }); // One
+
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
-  const option = host.querySelector(
-    'glide-core-dropdown-option:nth-of-type(2)',
-  );
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
 
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(option?.id);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
 });
 
-it('sets `aria-activedescendant` on ArrowUp', async () => {
+it('sets an active option on Home', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open multiple>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -974,23 +976,28 @@ it('sets `aria-activedescendant` on ArrowUp', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' });
   await sendKeys({ press: 'Home' });
 
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
-  const option = host.querySelector('glide-core-dropdown-option');
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
 
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(option?.id);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
 });
 
-it('sets `aria-activedescendant` on ArrowUp', async () => {
+it('sets an active option on PageUp', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open multiple>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -998,23 +1005,28 @@ it('sets `aria-activedescendant` on ArrowUp', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' });
   await sendKeys({ press: 'PageUp' });
 
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
-  const option = host.querySelector('glide-core-dropdown-option');
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
 
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(option?.id);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
 });
 
-it('sets `aria-activedescendant` on Meta + ArrowUp', async () => {
+it('sets an active option on Meta + ArrowUp', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open multiple>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1022,9 +1034,7 @@ it('sets `aria-activedescendant` on Meta + ArrowUp', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' });
   await sendKeys({ down: 'Meta' });
@@ -1035,12 +1045,19 @@ it('sets `aria-activedescendant` on Meta + ArrowUp', async () => {
     '[data-test="input"]',
   );
 
-  const option = host.querySelector('glide-core-dropdown-option');
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
 
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(option?.id);
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
 });
 
-it('sets `aria-activedescendant` on open via click', async () => {
+it('sets an active option on open via click', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1050,16 +1067,23 @@ it('sets `aria-activedescendant` on open via click', async () => {
 
   await click(host.shadowRoot?.querySelector('[data-test="primary-button"]'));
 
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
-  const option = host.querySelector('glide-core-dropdown-option');
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
 
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(option?.id);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
 });
 
-it('sets `aria-activedescendant` on open via Space', async () => {
+it('sets an active option on open via Space', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1070,16 +1094,23 @@ it('sets `aria-activedescendant` on open via Space', async () => {
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
 
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
-  const option = host.querySelector('glide-core-dropdown-option');
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('One');
 
-  expect(input?.getAttribute('aria-activedescendant')).to.equal(option?.id);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
 });
 
-it('sets `aria-activedescendant` on End', async () => {
+it('sets an active option on End', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open multiple>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1087,28 +1118,27 @@ it('sets `aria-activedescendant` on End', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-
-  // Made into an array because the linter forces `at(-1)` instead of
-  // `[options.length - 1]` but doesn't take into account that `options`
-  // isn't an actual array and doesn't have an `at()` method.
-  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
-
   await sendKeys({ press: 'End' });
 
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('Two');
+
   expect(input?.getAttribute('aria-activedescendant')).to.equal(
-    options.at(-1)?.id,
+    activeOptions.at(0)?.id,
   );
 });
 
-it('sets `aria-activedescendant` on PageDown', async () => {
+it('sets an active option on PageDown', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open multiple>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1116,28 +1146,27 @@ it('sets `aria-activedescendant` on PageDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-
-  // Made into an array because the linter forces `at(-1)` instead of
-  // `[options.length - 1]` but doesn't take into account that `options`
-  // isn't an actual array and doesn't have an `at()` method.
-  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
-
   await sendKeys({ press: 'PageDown' });
 
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('Two');
+
   expect(input?.getAttribute('aria-activedescendant')).to.equal(
-    options.at(-1)?.id,
+    activeOptions.at(0)?.id,
   );
 });
 
-it('sets `aria-activedescendant` on Meta + ArrowDown', async () => {
+it('sets an active option on Meta + ArrowDown', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open multiple>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1145,16 +1174,8 @@ it('sets `aria-activedescendant` on Meta + ArrowDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-
-  // Spread into an array because the linter forces `at(-1)` instead of
-  // `[options.length - 1]` but doesn't take into account that `options`
-  // isn't an actual array and doesn't have an `at()` method.
-  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
-
   await sendKeys({ down: 'Meta' });
   await sendKeys({ press: 'ArrowDown' });
   await sendKeys({ up: 'Meta' });
@@ -1163,33 +1184,19 @@ it('sets `aria-activedescendant` on Meta + ArrowDown', async () => {
     '[data-test="input"]',
   );
 
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('Two');
+
   expect(input?.getAttribute('aria-activedescendant')).to.equal(
-    options.at(-1)?.id,
+    activeOptions.at(0)?.id,
   );
 });
 
-it('sets `aria-activedescendant` when closed via click', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable open>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  host.shadowRoot
-    ?.querySelector<HTMLButtonElement>('[data-test="primary-button"]')
-    ?.click();
-
-  await host.updateComplete;
-
-  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="input"]',
-  );
-
-  expect(input?.getAttribute('aria-activedescendant')).to.be.empty.string;
-});
-
-it('sets `aria-activedescendant` when closed because it lost focus', async () => {
+it('sets no option as active when every option is filtered out', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1198,16 +1205,120 @@ it('sets `aria-activedescendant` when closed because it lost focus', async () =>
   );
 
   await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'three' });
+
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
+  expect(activeOptions.length).to.equal(0);
   expect(input?.getAttribute('aria-activedescendant')).to.be.empty.string;
 });
 
-it('sets `aria-activedescendant` when closed because something outside of it was clicked', async () => {
+it('sets the previously active option as active when all options are filtered out', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable open>
+      <glide-core-dropdown-option label="ABC"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="AB"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="A"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'ArrowDown' }); // AB
+  await sendKeys({ press: 'ArrowDown' }); // A
+  await sendKeys({ type: 'abd' });
+  await sendKeys({ press: 'Backspace' });
+
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('AB');
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
+});
+
+it('sets the previously active option as active when the active option is filtered out', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable open>
+      <glide-core-dropdown-option label="ABC"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="AB"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="A"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'ArrowDown' }); // AB
+  await sendKeys({ press: 'ArrowDown' }); // A
+  await sendKeys({ type: 'b' });
+
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('AB');
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
+});
+
+it('sets the first enabled option as active when the previously active option is filtered out', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable open>
+      <glide-core-dropdown-option
+        label="ABCDE"
+        disabled
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="ABCD"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="ABC"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="AB"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="A"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'ArrowDown' }); // ABC
+  await sendKeys({ press: 'ArrowDown' }); // AB
+  await sendKeys({ press: 'ArrowDown' }); // A
+  await sendKeys({ type: 'abc' });
+
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(activeOptions.length).to.equal(1);
+  expect(activeOptions.at(0)?.label).to.equal('ABCD');
+
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(
+    activeOptions.at(0)?.id,
+  );
+});
+
+it('sets no option as active when closed by clicking its primary button', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1215,16 +1326,27 @@ it('sets `aria-activedescendant` when closed because something outside of it was
     </glide-core-dropdown>`,
   );
 
-  await click(document.body);
+  await aTimeout(0); // Wait for Floating UI
+
+  await click(
+    host.shadowRoot?.querySelector<HTMLButtonElement>(
+      '[data-test="primary-button"]',
+    ),
+  );
+
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
+  expect(activeOptions.length).to.equal(0);
   expect(input?.getAttribute('aria-activedescendant')).to.be.empty.string;
 });
 
-it('sets `aria-activedescendant` when closed via Escape', async () => {
+it('sets no option as active when closed via Escape', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1235,11 +1357,63 @@ it('sets `aria-activedescendant` when closed via Escape', async () => {
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Escape' });
 
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(activeOptions.length).to.equal(0);
+  expect(input?.getAttribute('aria-activedescendant')).to.be.empty.string;
+});
+
+it('sets no option as active when closed because it lost focus', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(activeOptions.length).to.equal(0);
+  expect(input?.getAttribute('aria-activedescendant')).to.be.empty.string;
+});
+
+it('sets no option as active when closed because something outside of it was clicked', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+  await click(document.body);
+
+  const activeOptions = [
+    ...host.querySelectorAll('glide-core-dropdown-option'),
+  ].filter(({ privateActive }) => privateActive);
+
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
   );
 
   expect(input?.getAttribute('aria-activedescendant')).to.be.empty.string;
+  expect(activeOptions.length).to.equal(0);
 });
 
 it('cannot be tabbed to when disabled', async () => {
@@ -1262,15 +1436,14 @@ it('sets its input field back to the `label` of the selected option when somethi
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
-  assert(option);
 
+  assert(option);
   option.selected = true;
 
-  // Now type something other than "One" so we can check that it's reverted
+  // Now we type something other than "One" so we can check that it's reverted
   // back to "One" when something else is clicked.
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'o' });
@@ -1284,7 +1457,31 @@ it('sets its input field back to the `label` of the selected option when somethi
   expect(input?.value).to.equal('One');
 });
 
-it('selects the filter text when `click()` is called', async () => {
+it('sets its input field to the `label` of the selected option when `label` is an empty string', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable open>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label=""></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+  await click(options[1]);
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  expect(input?.value).to.be.empty.string;
+});
+
+it('selects its filter query when `click()` is called', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option
@@ -1301,7 +1498,7 @@ it('selects the filter text when `click()` is called', async () => {
   expect(window.getSelection()?.toString()).to.equal('One');
 });
 
-it('clicks the `<input>` when `click()` is called', async () => {
+it('clicks its input field when `click()` is called', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1309,14 +1506,14 @@ it('clicks the `<input>` when `click()` is called', async () => {
     </glide-core-dropdown>`,
   );
 
-  const button = host.shadowRoot?.querySelector('[data-test="input"]');
-  assert(button);
+  const input = host.shadowRoot?.querySelector('[data-test="input"]');
+  assert(input);
 
   setTimeout(() => {
     host.click();
   });
 
-  const event = await oneEvent(button, 'click');
+  const event = await oneEvent(input, 'click');
   expect(event instanceof PointerEvent).to.be.true;
 });
 
@@ -1345,7 +1542,7 @@ it('has no icon when filtering and an option is selected', async () => {
   expect(iconSlot).to.be.null;
 });
 
-it('supports custom filtering', async () => {
+it('supports a custom `filter()` method', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
@@ -1354,9 +1551,9 @@ it('supports custom filtering', async () => {
   );
 
   host.filter = async (filter) => {
-    const options = [...host.querySelectorAll('glide-core-dropdown-option')];
-
-    return options.filter(({ label }) => label?.includes(filter));
+    return [...host.querySelectorAll('glide-core-dropdown-option')].filter(
+      ({ label }) => label?.includes(filter),
+    );
   };
 
   await sendKeys({ press: 'Tab' });
@@ -1372,7 +1569,7 @@ it('supports custom filtering', async () => {
 
 it('does nothing when filtering fails', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" filterable>
+    html`<glide-core-dropdown label="Label" filterable open>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
@@ -1383,13 +1580,32 @@ it('does nothing when filtering fails', async () => {
   };
 
   await sendKeys({ press: 'Tab' });
-  await sendKeys({ type: 'O' });
+  await sendKeys({ press: ' ' });
+  await aTimeout(0); // Wait for Floating UI
+  await sendKeys({ type: 'o' });
 
-  const options = [
-    ...host.querySelectorAll('glide-core-dropdown-option'),
-  ].filter(({ hidden }) => !hidden);
+  const options = [...host.querySelectorAll('glide-core-dropdown-option')];
 
-  expect(options.length).to.equal(2);
+  const activeOptions = options.filter(({ privateActive }) => privateActive);
+  const visibleOptions = options.filter(({ hidden }) => !hidden);
+
+  expect(activeOptions.length).to.equal(1);
+  expect(visibleOptions.length).to.equal(2);
+  expect(options[0]?.privateActive).to.be.true;
+});
+
+it('has an item count on open', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await click(host);
+
+  const itemCount = host.shadowRoot?.querySelector('[data-test="item-count"]');
+  expect(itemCount?.ariaLabel).to.equal('2 items');
 });
 
 it('updates its item count after filtering', async () => {
@@ -1404,7 +1620,6 @@ it('updates its item count after filtering', async () => {
   await sendKeys({ type: 'one' });
 
   const itemCount = host.shadowRoot?.querySelector('[data-test="item-count"]');
-
   expect(itemCount?.ariaLabel).to.equal('1 items');
 });
 
@@ -1419,14 +1634,11 @@ it('shows an ellipsis when the label of its selected option overflows', async ()
     </glide-core-dropdown>`,
   );
 
-  const option = host.querySelector('glide-core-dropdown-option');
-  assert(option);
-
-  option.selected = true;
-  await host.updateComplete;
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: ' ' });
+  await sendKeys({ press: 'Enter' });
 
   const ellipsis = host.shadowRoot?.querySelector('[data-test="ellipsis"]');
-
   expect(ellipsis?.checkVisibility()).to.be.true;
 });
 
@@ -1482,8 +1694,113 @@ it('shows an ellipsis when made filterable programmatically and the label of its
   });
 
   const ellipsis = host.shadowRoot?.querySelector('[data-test="ellipsis"]');
-
   expect(ellipsis?.checkVisibility()).to.be.true;
+});
+
+it('hides its ellipsis when previously overflowing and an option with a shorter label is selected via click', async () => {
+  // The "x" is arbitrary. 500 of them ensures the component is wider
+  // than the viewport even if the viewport's width is increased.
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable open>
+      <glide-core-dropdown-option
+        label=${'x'.repeat(500)}
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  await aTimeout(0); // Wait for Floating UI
+  await click(options[1]);
+
+  await waitUntil(() => {
+    return !host.shadowRoot
+      ?.querySelector('[data-test="ellipsis"]')
+      ?.checkVisibility();
+  });
+
+  const ellipsis = host.shadowRoot?.querySelector('[data-test="ellipsis"]');
+  expect(ellipsis?.checkVisibility()).to.not.be.ok;
+});
+
+it('hides its ellipsis when previously overflowing and an option with a shorter label is selected via Enter', async () => {
+  // The "x" is arbitrary. 500 of them ensures the component is wider
+  // than the viewport even if the viewport's width is increased.
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable open>
+      <glide-core-dropdown-option
+        label=${'x'.repeat(500)}
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'ArrowDown' });
+  await sendKeys({ press: 'Enter' });
+
+  await waitUntil(() => {
+    return !host.shadowRoot
+      ?.querySelector('[data-test="ellipsis"]')
+      ?.checkVisibility();
+  });
+
+  const ellipsis = host.shadowRoot?.querySelector('[data-test="ellipsis"]');
+  expect(ellipsis?.checkVisibility()).to.not.be.ok;
+});
+
+it('does not show its input tooltip when an option is selected via click', async () => {
+  // The "x" is arbitrary. 500 of them ensures the component is wider
+  // than the viewport even if the viewport's width is increased.
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable>
+      <glide-core-dropdown-option
+        label=${'x'.repeat(500)}
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = host.querySelector('glide-core-dropdown-option');
+
+  const tooltip = host.shadowRoot?.querySelector<Tooltip>(
+    '[data-test="input-tooltip"]',
+  );
+
+  await click(host);
+  await aTimeout(0); // Wait for Floating UI
+  await click(option);
+  await tooltip?.updateComplete;
+
+  expect(tooltip?.open).to.be.false;
+});
+
+it('does not show its input tooltip when an option is selected via Enter', async () => {
+  // The "x" is arbitrary. 500 of them ensures the component is wider
+  // than the viewport even if the viewport's width is increased.
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable>
+      <glide-core-dropdown-option
+        label=${'x'.repeat(500)}
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const tooltip = host.shadowRoot?.querySelector<Tooltip>(
+    '[data-test="input-tooltip"]',
+  );
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: ' ' });
+  await sendKeys({ press: 'Enter' });
+  await tooltip?.updateComplete;
+
+  expect(tooltip?.open).to.be.false;
 });
 
 it('does not allow its "toggle" event to propagate', async () => {
@@ -1498,8 +1815,7 @@ it('does not allow its "toggle" event to propagate', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const tooltip = host.shadowRoot
     ?.querySelector('[data-test="input-tooltip"]')
@@ -1516,17 +1832,15 @@ it('does not allow its "toggle" event to propagate', async () => {
   expect(spy.callCount).to.equal(0);
 });
 
-it('retains its filter query when `multiple` and its default slot changes', async () => {
+it('retains its filter query when multiselect and its default slot changes', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable multiple>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  host.focus();
+  await aTimeout(0); // Wait for Floating UI
+  await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'one' });
 
   const option = document.createElement('glide-core-dropdown-option');
@@ -1543,17 +1857,15 @@ it('retains its filter query when `multiple` and its default slot changes', asyn
   expect(input?.value).to.equal('one');
 });
 
-it('retains its filter query when not `multiple` and its default slot changes', async () => {
+it('retains its filter query when single-select` and its default slot changes', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable>
       <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  host.focus();
+  await aTimeout(0); // Wait for Floating UI
+  await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'one' });
 
   const option = document.createElement('glide-core-dropdown-option');
@@ -1573,33 +1885,35 @@ it('retains its filter query when not `multiple` and its default slot changes', 
 it('shows a fallback when every option has been hidden via filtering', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
-      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  host.focus();
-  await sendKeys({ type: 'test' });
+  await aTimeout(0); // Wait for Floating UI
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'two' });
 
   const feedback = host.shadowRoot?.querySelector(
     '[data-test="optionless-feedback"]',
   );
 
+  const options = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="options"]',
+  );
+
   expect(feedback?.checkVisibility()).to.be.true;
   expect(feedback?.textContent?.trim()).to.equal('No matching options');
+  expect(options?.checkVisibility()).to.be.false;
 });
 
 it('shows a fallback when every option has been removed via filtering', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable open>
-      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   host.filter = async () => {
     const options = host.querySelectorAll('glide-core-dropdown-option');
@@ -1609,13 +1923,101 @@ it('shows a fallback when every option has been removed via filtering', async ()
     }
   };
 
-  host.focus();
-  await sendKeys({ type: 'test' });
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ type: 'two' });
 
   const feedback = host.shadowRoot?.querySelector(
     '[data-test="optionless-feedback"]',
   );
 
+  const options = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="options"]',
+  );
+
   expect(feedback?.checkVisibility()).to.be.true;
   expect(feedback?.textContent?.trim()).to.equal('No options available');
+  expect(options?.checkVisibility()).to.be.false;
+});
+
+it('updates itself when multiple options are selected and the last selected option is disabled programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label=${'x'.repeat(500)}
+        value="x"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  await click(host);
+  await hover(options[1]);
+
+  assert(options[1]);
+  options[1].disabled = true;
+  await host.updateComplete;
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  const inputTooltip = host.shadowRoot?.querySelector<Tooltip>(
+    '[data-test="input-tooltip"]',
+  );
+
+  const activeOptions = [...options].filter(
+    ({ privateActive }) => privateActive,
+  );
+
+  expect(host.value).to.deep.equal(['one']);
+  expect(input?.value).to.equal('One');
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(options[0]?.id);
+  expect(inputTooltip?.disabled).to.be.true;
+  expect(activeOptions.length).to.equal(1);
+  expect(options[0]?.privateActive).to.be.true;
+});
+
+it('updates itself when multiple options are selected and the last selected option is enabled programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable>
+      <glide-core-dropdown-option
+        label=${'x'.repeat(500)}
+        value="x"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        disabled
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  assert(options[1]);
+  options[1].disabled = false;
+  await host.updateComplete;
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  const inputTooltip = host.shadowRoot?.querySelector<Tooltip>(
+    '[data-test="input-tooltip"]',
+  );
+
+  expect(input?.value).to.equal('Two');
+  expect(inputTooltip?.disabled).to.be.true;
+  expect(host.value).to.deep.equal(['two']);
 });

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -773,7 +773,6 @@ it('clears its input field when single-select and its selected option is removed
   host.querySelector('glide-core-dropdown-option')?.remove();
 
   await aTimeout(0); // Wait for `#onDefaultSlotChange()`.
-  await host.updateComplete; // Now wait for the forced update in `#onDefaultSlotChange()`.
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',

--- a/src/dropdown.test.interactions.multiple.ts
+++ b/src/dropdown.test.interactions.multiple.ts
@@ -58,7 +58,7 @@ it('toggles open and closed when the button is clicked', async () => {
   expect(options?.checkVisibility()).to.be.false;
 });
 
-it('selects options on click', async () => {
+it('selects options on click via mouse', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" open multiple>
       <glide-core-dropdown-option
@@ -73,11 +73,9 @@ it('selects options on click', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await click(options[0]);
   await click(options[1]);
 
@@ -86,13 +84,51 @@ it('selects options on click', async () => {
   );
 
   expect(options[0]?.selected).to.be.true;
+  expect(options[1]?.selected).to.be.true;
   expect(labels?.length).to.equal(2);
   expect(labels?.[0]?.textContent?.trim()).to.equal('One,');
   expect(labels?.[1]?.textContent?.trim()).to.equal('Two,');
   expect(host.value).to.deep.equal(['one', 'two']);
 });
 
-it('deselects options on click', async () => {
+it('selects options on click via `click()`', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" multiple>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  options[0]?.click();
+  await options[0]?.updateComplete;
+
+  options[1]?.click();
+  await options[1]?.updateComplete;
+
+  await host.updateComplete;
+
+  const labels = host.shadowRoot?.querySelectorAll(
+    '[data-test="selected-option-label"]',
+  );
+
+  expect(options[0]?.selected).to.be.true;
+  expect(options[1]?.selected).to.be.true;
+  expect(labels?.length).to.equal(2);
+  expect(labels?.[0]?.textContent?.trim()).to.equal('One,');
+  expect(labels?.[1]?.textContent?.trim()).to.equal('Two,');
+  expect(host.value).to.deep.equal(['one', 'two']);
+});
+
+it('deselects options on click via mouse', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" open multiple>
       <glide-core-dropdown-option
@@ -109,11 +145,9 @@ it('deselects options on click', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await click(options[0]);
   await click(options[1]);
 
@@ -127,7 +161,44 @@ it('deselects options on click', async () => {
   expect(host.value).to.deep.equal([]);
 });
 
-it('does not select a disabled option on click', async () => {
+it('deselects options on click via `click()`', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" multiple>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  options[0]?.click();
+  await options[0]?.updateComplete;
+
+  options[1]?.click();
+  await options[1]?.updateComplete;
+
+  await host.updateComplete;
+
+  const labels = host.shadowRoot?.querySelectorAll(
+    '[data-test="selected-option-label"]',
+  );
+
+  expect(options[0]?.selected).to.be.false;
+  expect(options[1]?.selected).to.be.false;
+  expect(labels?.length).to.equal(0);
+  expect(host.value).to.deep.equal([]);
+});
+
+it('does not select a disabled option on click via mouse', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" open multiple>
       <glide-core-dropdown-option
@@ -138,11 +209,9 @@ it('does not select a disabled option on click', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const option = host.querySelector('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await click(option);
 
   const labels = host.shadowRoot?.querySelectorAll(
@@ -169,8 +238,7 @@ it('selects options on Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -211,8 +279,7 @@ it('deselects options on Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -249,8 +316,7 @@ it('selects options on Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -289,8 +355,7 @@ it('deselects options on Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -337,14 +402,12 @@ it('deactivates all other options when an option is hovered', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = [
     ...host.querySelectorAll('glide-core-dropdown-option'),
     host.shadowRoot?.querySelector<DropdownOption>('[data-test="select-all"]'),
   ];
 
+  await aTimeout(0); // Wait for Floating UI
   await hover(options[0]);
   await hover(options[1]);
 
@@ -358,9 +421,7 @@ it('remains open when an option is selected via click', async () => {
     html`<glide-core-dropdown-in-another-component></glide-core-dropdown-in-another-component>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('glide-core-dropdown-option'));
 
   const dropdown = host.shadowRoot?.querySelector('glide-core-dropdown');
@@ -379,8 +440,7 @@ it('remains open when an option is selected via Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   host.querySelector('glide-core-dropdown-option')?.focus();
   await sendKeys({ press: 'Enter' });
@@ -400,8 +460,7 @@ it('remains open when an option is selected via Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
 
@@ -420,11 +479,9 @@ it('activates Select All on hover', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await hover(options[0]);
 
   expect(options[0]?.privateActive).to.be.true;
@@ -446,8 +503,7 @@ it('does not activate the next option on ArrowDown when a tag is focused', async
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -568,9 +624,7 @@ it('does not update `value` when a disabled option is selected via click', async
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await click(host.querySelector('glide-core-dropdown-option'));
 
   expect(host.value).to.deep.equal([]);
@@ -687,14 +741,15 @@ it('has no internal label when an option is newly selected', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   await click(host.querySelector('glide-core-dropdown-option:last-of-type'));
 
-  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
 
-  expect(label?.checkVisibility()).to.not.be.ok;
+  expect(internalLabel?.checkVisibility()).to.not.be.ok;
 });
 
 it('hides tags to prevent overflow', async () => {
@@ -715,18 +770,14 @@ it('hides tags to prevent overflow', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await click(options[0]);
   await click(options[1]);
   await click(options[2]);
   await click(options[3]);
-
-  // Wait for the Resize Observer to do its thing.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for the Resize Observer to do its thing.
 
   const tagContainers = [
     ...(host.shadowRoot?.querySelectorAll<HTMLElement>(
@@ -755,18 +806,14 @@ it('has overflow text when its tags are overflowing', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await click(options[0]);
   await click(options[1]);
   await click(options[2]);
   await click(options[3]);
-
-  // Wait for the Resize Observer to do its thing.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for the Resize Observer to do its thing.
 
   const tagOverflow = host.shadowRoot?.querySelector(
     '[data-test="tag-overflow-count"]',
@@ -854,9 +901,7 @@ it('selects all enabled options when none are selected and Select All is selecte
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('[data-test="select-all"]'));
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
@@ -894,9 +939,7 @@ it('selects all enabled options when some are selected and Select All is selecte
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('[data-test="select-all"]'));
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
@@ -923,8 +966,7 @@ it('deselects all options when all are selected and Select All is selected via c
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   await click(
     host.shadowRoot?.querySelector<DropdownOption>('[data-test="select-all"]'),
@@ -958,8 +1000,7 @@ it('selects all enabled options when none are selected and Select All is selecte
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   host.focus();
   await sendKeys({ press: ' ' });
@@ -988,8 +1029,7 @@ it('selects all options when some are selected and Select All is selected via Sp
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   host.focus();
   await sendKeys({ press: 'ArrowUp' });
@@ -1019,8 +1059,7 @@ it('deselects all options when all are selected and Select All is selected via S
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   host.focus();
   await sendKeys({ press: 'Home' });
@@ -1054,8 +1093,7 @@ it('selects all enabled options when none are selected and Select All is selecte
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   host.focus();
   await sendKeys({ press: 'Enter' });
@@ -1095,8 +1133,7 @@ it('selects all enabled options when some are selected and Select All is selecte
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   host.focus();
   await sendKeys({ press: 'ArrowUp' });
@@ -1128,8 +1165,7 @@ it('deselects all options when all are selected and Select All is selected via E
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   host.focus();
   await sendKeys({ press: 'Home' });
@@ -1154,8 +1190,7 @@ it('shows Select All when it is set programmatically', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   host.selectAll = true;
   await host.updateComplete;
@@ -1180,11 +1215,9 @@ it('sets Select All as selected when all enabled options are selected', async ()
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await click(options[1]);
   await click(options[2]);
 
@@ -1203,11 +1236,9 @@ it('sets Select All as deselected when no options are selected', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await click(options[0]);
   await click(options[1]);
   await click(options[0]);
@@ -1228,9 +1259,7 @@ it('sets Select All as indeterminate when not all options are selected', async (
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await click(host.querySelector('glide-core-dropdown-option'));
 
   const selectAll = host.shadowRoot?.querySelector<DropdownOption>(
@@ -1243,22 +1272,22 @@ it('sets Select All as indeterminate when not all options are selected', async (
 it('does not set Select All as indeterminate when no options are selected', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" multiple open select-all>
-      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
       <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
-
-  await click(options[0]);
-  await click(options[0]);
 
   const selectAll = host.shadowRoot?.querySelector<DropdownOption>(
     '[data-test="select-all"]',
   );
+
+  await aTimeout(0); // Wait for Floating UI
+  await click(options[0]);
 
   expect(selectAll?.privateIndeterminate).to.be.false;
 });
@@ -1271,17 +1300,15 @@ it('does not set Select All as indeterminate when all options are selected', asy
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
-
-  await click(options[0]);
-  await click(options[1]);
 
   const selectAll = host.shadowRoot?.querySelector<DropdownOption>(
     '[data-test="select-all"]',
   );
+
+  await aTimeout(0); // Wait for Floating UI
+  await click(options[0]);
+  await click(options[1]);
 
   expect(selectAll?.privateIndeterminate).to.be.false;
 });
@@ -1317,8 +1344,7 @@ it('closes on edit via click', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   await click(
     host.shadowRoot
@@ -1342,8 +1368,7 @@ it('closes on edit via Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   host.shadowRoot
     ?.querySelector('glide-core-tag')
@@ -1368,8 +1393,7 @@ it('closes on edit via Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   host.shadowRoot
     ?.querySelector('glide-core-tag')
@@ -1463,63 +1487,211 @@ it('removes the `value` of a programmatically disabled option from its `value`',
   expect(host.value).to.deep.equal(['two']);
 });
 
-it('updates its tags when a selected option is enabled programmatically', async () => {
+it('updates itself when an option is disabled programmatically', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" multiple>
+    html`<glide-core-dropdown label="Label" filterable multiple>
       <glide-core-dropdown-option
         label="One"
         value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  await click(host);
+  await hover(options[1]);
+
+  assert(options[1]);
+  options[1].disabled = true;
+  await host.updateComplete;
+
+  const input = host.shadowRoot?.querySelector<HTMLInputElement>(
+    '[data-test="input"]',
+  );
+
+  const activeOptions = [...options].filter(
+    ({ privateActive }) => privateActive,
+  );
+
+  const tagContainers = host.shadowRoot?.querySelectorAll<HTMLElement>(
+    '[data-test="tag-container"]',
+  );
+
+  expect(host.value).to.deep.equal(['one']);
+  expect(input?.getAttribute('aria-activedescendant')).to.equal(options[0]?.id);
+  expect(activeOptions.length).to.equal(1);
+  expect(options[0]?.privateActive).to.be.true;
+  expect(tagContainers?.length).to.equal(1);
+});
+
+it('updates itself when an option is enabled programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable multiple>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
         disabled
         selected
       ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option
-        label="Two"
-        value="two"
-        selected
-      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  const option = host.querySelector('glide-core-dropdown-option');
-  assert(option);
+  const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  option.disabled = false;
+  assert(options[1]);
+  options[1].disabled = false;
   await host.updateComplete;
 
   const tagContainers = host.shadowRoot?.querySelectorAll<HTMLElement>(
     '[data-test="tag-container"]',
   );
 
+  expect(host.value).to.deep.equal(['one', 'two']);
   expect(tagContainers?.length).to.equal(2);
 });
 
-it('updates its tags when a selected option is disabled programmatically', async () => {
+it('sets `aria-selected` when an option is selected programmatically', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" multiple>
+    html`<glide-core-dropdown label="Label" multiple open>
       <glide-core-dropdown-option
         label="One"
-        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  assert(options[1]);
+  options[1].selected = true;
+  await options[1].updateComplete;
+
+  expect(options[0]?.ariaSelected).to.equal('true');
+  expect(options[1]?.ariaSelected).to.equal('true');
+});
+
+it('sets `aria-selected` when an option is deselected programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" multiple open>
+      <glide-core-dropdown-option
+        label="One"
         selected
       ></glide-core-dropdown-option>
 
       <glide-core-dropdown-option
         label="Two"
-        value="two"
         selected
       ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
-  const option = host.querySelector('glide-core-dropdown-option');
-  assert(option);
+  await aTimeout(0); // Wait for Floating UI
 
-  option.disabled = true;
-  await host.updateComplete;
+  const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  const tagContainers = host.shadowRoot?.querySelectorAll<HTMLElement>(
-    '[data-test="tag-container"]',
+  assert(options[0]);
+  options[0].selected = false;
+  await options[0].updateComplete;
+
+  expect(options[0]?.ariaSelected).to.equal('false');
+  expect(options[1]?.ariaSelected).to.equal('true');
+});
+
+it('sets `aria-selected` when an option is disabled programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" multiple open>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
   );
 
-  expect(tagContainers?.length).to.equal(1);
+  await aTimeout(0); // Wait for Floating UI
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  assert(options[1]);
+  options[1].disabled = true;
+  await options[1].updateComplete;
+
+  expect(options[0]?.ariaSelected).to.equal('true');
+  expect(options[1]?.ariaSelected).to.equal('false');
+});
+
+it('sets `aria-selected` when an option is enabled programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" multiple open>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        disabled
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  assert(options[1]);
+  options[1].disabled = false;
+  await options[1].updateComplete;
+
+  expect(options[0]?.ariaSelected).to.equal('true');
+  expect(options[1]?.ariaSelected).to.equal('true');
+});
+
+it('sets `aria-selected` when `multiple` is set to `true` programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" open>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+
+  host.multiple = true;
+  await host.updateComplete;
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  expect(options[0]?.ariaSelected).to.equal('true');
+  expect(options[1]?.ariaSelected).to.equal('true');
 });

--- a/src/dropdown.test.interactions.single.ts
+++ b/src/dropdown.test.interactions.single.ts
@@ -12,6 +12,7 @@ import sinon from 'sinon';
 import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import DropdownOption from './dropdown.option.js';
+import type Tooltip from './tooltip.js';
 
 it('opens on click', async () => {
   const host = await fixture<Dropdown>(
@@ -43,7 +44,7 @@ it('toggles open and closed when its primary button is clicked', async () => {
   expect(options?.checkVisibility()).to.be.false;
 });
 
-it('selects an option on click', async () => {
+it('selects an option on click via mouse', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" open>
       <glide-core-dropdown-option
@@ -53,12 +54,36 @@ it('selects an option on click', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  const option = host.querySelector('glide-core-dropdown-option');
+
+  await aTimeout(0); // Wait for Floating UI
+  await click(option);
+
+  const labels = host.shadowRoot?.querySelectorAll(
+    '[data-test="selected-option-label"]',
+  );
+
+  expect(option?.selected).to.be.true;
+  expect(labels?.length).to.equal(1);
+  expect(labels?.[0]?.textContent?.trim()).to.equal('One,');
+  expect(host.value).to.deep.equal(['one']);
+});
+
+it('selects an option on click via `click()`', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
 
   const option = host.querySelector('glide-core-dropdown-option');
 
-  await click(option);
+  option?.click();
+  await option?.updateComplete;
+  await host.updateComplete;
 
   const labels = host.shadowRoot?.querySelectorAll(
     '[data-test="selected-option-label"]',
@@ -81,16 +106,14 @@ it('does not select a disabled option on click', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const option = host.querySelector('glide-core-dropdown-option');
-
-  await click(option);
 
   const labels = host.shadowRoot?.querySelectorAll(
     '[data-test="selected-option-label"]',
   );
+
+  await aTimeout(0); // Wait for Floating UI
+  await click(option);
 
   expect(option?.selected).to.be.false;
   expect(labels?.length).to.equal(0);
@@ -107,8 +130,7 @@ it('selects an option on Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
 
@@ -178,9 +200,7 @@ it('does not deselect options on Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
 
@@ -206,8 +226,7 @@ it('selects an option on Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
   option?.focus();
@@ -231,11 +250,9 @@ it('deactivates all other options when an option is hovered', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await hover(options[0]);
   await hover(options[1]);
 
@@ -250,9 +267,7 @@ it('closes when an option is selected via click', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await click(host.querySelector('glide-core-dropdown-option'));
 
   expect(host.open).to.be.false;
@@ -265,9 +280,7 @@ it('closes when an option is selected via Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
 
@@ -281,9 +294,7 @@ it('closes when an option is selected via Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Enter' });
 
@@ -297,9 +308,7 @@ it('closes when an option is selected via Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   host.querySelector('glide-core-dropdown-option')?.focus();
   await sendKeys({ press: 'Enter' });
 
@@ -313,8 +322,7 @@ it('closes when an option is selected via Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
 
@@ -334,9 +342,7 @@ it('closes when an already selected option is clicked', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await click(host.querySelector('glide-core-dropdown-option'));
 
   expect(host.open).to.be.false;
@@ -353,9 +359,7 @@ it('closes on edit via click', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('[data-test="edit-button"]'));
 
   expect(host.open).to.be.false;
@@ -382,38 +386,15 @@ it('deselects all other options when one is newly selected', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await click(options[1]);
 
   expect(options[0]?.selected).to.be.false;
   expect(options[1]?.selected).to.be.true;
   expect(options[2]?.selected).to.be.false;
   expect(host.value).to.deep.equal(['two']);
-});
-
-it('updates its internal label when `label` of the selected option is set programmatically', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label">
-      <glide-core-dropdown-option
-        label="One"
-        selected
-      ></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  const option = host.querySelector('glide-core-dropdown-option');
-  assert(option);
-
-  option.label = 'Two';
-  await host.updateComplete;
-
-  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
-
-  expect(label?.textContent?.trim()).to.equal(option?.label);
 });
 
 it('shows an Edit button when `editable` of the selected option is set programmatically', async () => {
@@ -519,17 +500,15 @@ it('does not update `value` when a disabled option is selected via click', async
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await click(host.querySelector('glide-core-dropdown-option'));
 
   expect(host.value).to.deep.equal([]);
 });
 
-it('updates `value` when `multiple` is changed to `false` programmatically', async () => {
+it('updates its `value` when `multiple` is set to `false` programmatically', async () => {
   const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" open multiple>
+    html`<glide-core-dropdown label="Label" multiple>
       <glide-core-dropdown-option
         label="One"
         value="one"
@@ -541,24 +520,28 @@ it('updates `value` when `multiple` is changed to `false` programmatically', asy
         value="two"
         selected
       ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Three"
+        value="three"
+        disabled
+        selected
+      ></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );
 
   host.multiple = false;
+  await host.updateComplete;
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  const checkbox = options[1]?.shadowRoot?.querySelector<HTMLInputElement>(
-    '[data-test="checkbox"]',
-  );
-
   expect(options[0]?.selected).to.be.false;
   expect(options[1]?.selected).to.be.true;
-  expect(checkbox?.checked).to.be.true;
+  expect(options[2]?.selected).to.be.false;
   expect(host.value).to.deep.equal(['two']);
 });
 
-it('updates `value` when the `value` of the selected option is set programmatically', async () => {
+it('updates its `value` when the `value` of the selected option is set programmatically', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" open>
       <glide-core-dropdown-option
@@ -581,7 +564,7 @@ it('updates `value` when the `value` of the selected option is set programmatica
   expect(host.value).to.deep.equal(['three']);
 });
 
-it('updates `value` when the `value` of the selected option is removed programmatically', async () => {
+it('updates its `value` when the `value` of the selected option is removed programmatically', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" open>
       <glide-core-dropdown-option
@@ -602,35 +585,6 @@ it('updates `value` when the `value` of the selected option is removed programma
   option.value = '';
 
   expect(host.value).to.deep.equal([]);
-});
-
-it('updates its internal label when an option is newly selected', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" open>
-      <glide-core-dropdown-option
-        label="One"
-        value="one"
-      ></glide-core-dropdown-option>
-
-      <glide-core-dropdown-option
-        label="Two"
-        value="two"
-      ></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  // Wait for Floating UI.
-  await aTimeout(0);
-
-  const option = host.querySelector<DropdownOption>(
-    'glide-core-dropdown-option:last-of-type',
-  );
-
-  await click(option);
-
-  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
-
-  expect(label?.textContent?.trim()).to.equal(option?.label);
 });
 
 it('hides Select All', async () => {
@@ -751,7 +705,72 @@ it('removes the `value` of a programmatically disabled option from its `value`',
   expect(option.selected).to.be.true;
 });
 
-it('updates its internal label when a selected option is enabled programmatically', async () => {
+it('updates itself when an option is newly selected', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" open>
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+
+  const option = host.querySelector<DropdownOption>(
+    'glide-core-dropdown-option:last-of-type',
+  );
+
+  await click(option);
+
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
+
+  const internalLabelTooltip = host.shadowRoot?.querySelector<Tooltip>(
+    '[data-test="internal-label-tooltip"]',
+  );
+
+  expect(host.value).to.deep.equal(['two']);
+  expect(internalLabel?.textContent?.trim()).to.equal(option?.label);
+  expect(internalLabelTooltip?.label).to.equal(option?.label);
+});
+
+it('updates itself when `label` of the selected option is set programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const option = host.querySelector('glide-core-dropdown-option');
+  assert(option);
+
+  option.label = 'Two';
+  await host.updateComplete;
+
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
+
+  const internalLabelTooltip = host.shadowRoot?.querySelector<Tooltip>(
+    '[data-test="internal-label-tooltip"]',
+  );
+
+  expect(internalLabel?.textContent?.trim()).to.equal(option?.label);
+  expect(internalLabelTooltip?.label).to.equal(option?.label);
+});
+
+it('updates itself when a selected option is enabled programmatically', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label">
       <glide-core-dropdown-option
@@ -774,16 +793,25 @@ it('updates its internal label when a selected option is enabled programmaticall
   option.disabled = false;
   await host.updateComplete;
 
-  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
-  expect(label?.textContent?.trim()).to.equal('One');
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
+
+  const internalLabelTooltip = host.shadowRoot?.querySelector<Tooltip>(
+    '[data-test="internal-label-tooltip"]',
+  );
+
+  expect(host.value).to.deep.equal(['one']);
+  expect(internalLabel?.textContent?.trim()).to.equal('One');
+  expect(internalLabelTooltip?.label).to.equal('One');
 });
 
-it('updates its internal label when a selected option is disabled programmatically', async () => {
+it('updates itself when the selected option is disabled programmatically', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label">
       <glide-core-dropdown-option
-        label="One"
-        value="one"
+        label=${'x'.repeat(500)}
+        value="x"
         selected
       ></glide-core-dropdown-option>
 
@@ -794,12 +822,308 @@ it('updates its internal label when a selected option is disabled programmatical
     </glide-core-dropdown>`,
   );
 
-  const option = host.querySelector('glide-core-dropdown-option');
-  assert(option);
+  await click(host);
 
-  option.disabled = true;
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+  assert(options[0]);
+
+  options[0].disabled = true;
   await host.updateComplete;
 
-  const label = host.shadowRoot?.querySelector('[data-test="internal-label"]');
-  expect(label?.textContent?.trim()).to.be.empty.string;
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
+
+  const internalLabelTooltip = host.shadowRoot?.querySelector<Tooltip>(
+    '[data-test="internal-label-tooltip"]',
+  );
+
+  const activeOptions = [...options].filter(
+    ({ privateActive }) => privateActive,
+  );
+
+  expect(host.value).to.deep.equal([]);
+  expect(internalLabel?.textContent?.trim()).to.be.empty.string;
+  expect(internalLabelTooltip?.disabled).to.be.true;
+  expect(internalLabelTooltip?.label).to.be.empty.string;
+  expect(activeOptions.length).to.equal(1);
+  expect(options[1]?.privateActive).to.be.true;
+});
+
+it('updates itself when multiple options are selected and the last selected option is disabled programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label="One"
+        value="one"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label=${'x'.repeat(500)}
+        value="x"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await click(host);
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  assert(options[1]);
+  options[1].disabled = true;
+  await host.updateComplete;
+
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
+
+  const internalLabelTooltip = host.shadowRoot?.querySelector<Tooltip>(
+    '[data-test="internal-label-tooltip"]',
+  );
+
+  const activeOptions = [...options].filter(
+    ({ privateActive }) => privateActive,
+  );
+
+  expect(host.value).to.deep.equal(['one']);
+  expect(internalLabel?.textContent?.trim()).to.equal('One');
+  expect(internalLabelTooltip?.disabled).to.be.true;
+  expect(internalLabelTooltip?.label).to.equal('One');
+  expect(activeOptions.length).to.equal(1);
+  expect(options[0]?.privateActive).to.be.true;
+});
+
+it('updates itself when multiple options are selected and the last selected option is enabled programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option
+        label=${'x'.repeat(500)}
+        value="x"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        value="two"
+        disabled
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  assert(options[1]);
+  options[1].disabled = false;
+  await host.updateComplete;
+
+  const internalLabel = host.shadowRoot?.querySelector(
+    '[data-test="internal-label"]',
+  );
+
+  const internalLabelTooltip = host.shadowRoot?.querySelector<Tooltip>(
+    '[data-test="internal-label-tooltip"]',
+  );
+
+  expect(host.value).to.deep.equal(['two']);
+  expect(internalLabel?.textContent?.trim()).to.equal('Two');
+  expect(internalLabelTooltip?.disabled).to.be.true;
+  expect(internalLabelTooltip?.label).to.equal('Two');
+});
+
+it('shows the icon of the last selected option when `multiple` is set to `false` programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" multiple>
+      <div slot="icon:one">✓</div>
+      <div slot="icon:two">✓</div>
+      <div slot="icon:three">✓</div>
+
+      <glide-core-dropdown-option label="One" value="one" selected>
+        <div slot="icon:one">✓</div>
+      </glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two" value="two" selected>
+        <div slot="icon:two">✓</div>
+      </glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Three" value="three" disabled selected>
+        <div slot="icon:three">✓</div>
+      </glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  host.multiple = false;
+  await host.updateComplete;
+
+  const icons = host.querySelectorAll('div');
+  expect(icons[1]?.checkVisibility()).to.be.true;
+});
+
+it('only shows the last selected option as selected when a selected option is dynamically added', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" open>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+
+  const firstOption = host.querySelector('glide-core-dropdown-option');
+  const secondOption = document.createElement('glide-core-dropdown-option');
+
+  secondOption.label = 'Two';
+  secondOption.selected = true;
+
+  host.append(secondOption);
+  await aTimeout(0); // Wait for `#onDefaultSlotChange()`.
+  await firstOption?.updateComplete;
+  await secondOption?.updateComplete;
+
+  expect(
+    firstOption?.shadowRoot
+      ?.querySelector('[data-test="checked-icon-container"]')
+      ?.querySelector('[data-test="check"]')
+      ?.checkVisibility(),
+  ).to.not.be.ok;
+
+  expect(
+    secondOption?.shadowRoot
+      ?.querySelector('[data-test="checked-icon-container"]')
+      ?.querySelector('[data-test="check"]')
+      ?.checkVisibility(),
+  ).to.be.true;
+});
+
+it('sets `aria-selected` when an option is selected programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" open>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  assert(options[1]);
+  options[1].selected = true;
+  await options[1].updateComplete;
+
+  expect(options[0]?.ariaSelected).to.equal('false');
+  expect(options[1]?.ariaSelected).to.equal('true');
+});
+
+it('sets `aria-selected` when an option is deselected programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" open>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  assert(options[0]);
+  options[0].selected = false;
+  await options[0].updateComplete;
+
+  expect(options[0]?.ariaSelected).to.equal('false');
+  expect(options[1]?.ariaSelected).to.equal('false');
+});
+
+it('sets `aria-selected` when an option is disabled programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" open>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  assert(options[1]);
+  options[1].disabled = true;
+  await options[1].updateComplete;
+
+  expect(options[0]?.ariaSelected).to.equal('true');
+  expect(options[1]?.ariaSelected).to.equal('false');
+});
+
+it('sets `aria-selected` when an option is enabled programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" open>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        disabled
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  assert(options[1]);
+  options[1].disabled = false;
+  await options[1].updateComplete;
+
+  expect(options[0]?.ariaSelected).to.equal('false');
+  expect(options[1]?.ariaSelected).to.equal('true');
+});
+
+it('sets `aria-selected` when `multiple` is set to `false` programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" multiple open>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+
+  host.multiple = false;
+  await host.updateComplete;
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  expect(options[0]?.ariaSelected).to.equal('false');
+  expect(options[1]?.ariaSelected).to.equal('true');
 });

--- a/src/dropdown.test.interactions.ts
+++ b/src/dropdown.test.interactions.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import './dropdown.option.js';
-import Tooltip from './tooltip.js';
+import type Tooltip from './tooltip.js';
 
 it('opens when opened programmatically', async () => {
   const host = await fixture<Dropdown>(
@@ -14,9 +14,7 @@ it('opens when opened programmatically', async () => {
   );
 
   host.open = true;
-
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
   expect(options?.checkVisibility()).to.be.true;
@@ -28,9 +26,7 @@ it('shows a fallback when opened programmatically and there are no options', asy
   );
 
   host.open = true;
-
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const feedback = host.shadowRoot?.querySelector(
     '[data-test="optionless-feedback"]',
@@ -46,9 +42,7 @@ it('does not open when opened programmatically and there are no options', async 
   );
 
   host.open = true;
-
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
   expect(options?.checkVisibility()).to.be.false;
@@ -238,9 +232,7 @@ it('closes when something outside of it is clicked', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await click(document.body);
   expect(host.open).to.be.false;
 });
@@ -257,9 +249,7 @@ it('closes on Escape', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Escape' });
 
@@ -301,9 +291,7 @@ it('opens when open and enabled programmatically', async () => {
   );
 
   host.disabled = false;
-
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host?.shadowRoot?.querySelector('[data-test="options"]');
   expect(options?.checkVisibility()).to.be.true;
@@ -321,9 +309,7 @@ it('closes when open and disabled programmatically', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   host.disabled = true;
 
   const options = host?.shadowRoot?.querySelector('[data-test="options"]');
@@ -338,15 +324,33 @@ it('activates an option on hover', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await hover(options[1]);
 
   expect(options[0]?.privateActive).to.be.false;
   expect(options[1]?.privateActive).to.be.true;
+});
+
+it('hides option tooltips on close', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" open>
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label=${'x'.repeat(500)}
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await aTimeout(0); // Wait for Floating UI
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'ArrowDown' });
+  await sendKeys({ press: 'Tab' });
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+  expect(options[1]?.privateIsTooltipOpen).to.be.false;
 });
 
 it('does not activate a disabled option on hover', async () => {
@@ -361,11 +365,9 @@ it('does not activate a disabled option on hover', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
+  await aTimeout(0); // Wait for Floating UI
   await hover(options[1]);
 
   expect(options[0]?.privateActive).to.be.true;
@@ -386,9 +388,7 @@ it('activates the next enabled option on ArrowDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // Three
 
@@ -411,9 +411,7 @@ it('activates the Edit button on ArrowDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // One's edit button
 
@@ -442,11 +440,8 @@ it('activates the next enabled option on ArrowDown when the Edit button is activ
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-
   await sendKeys({ press: 'ArrowDown' }); // One's edit button
   await sendKeys({ press: 'ArrowDown' }); // Three
 
@@ -475,11 +470,8 @@ it('activates the previous enabled option on ArrowUp', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-
   await sendKeys({ press: 'ArrowDown' }); // Three
   await sendKeys({ press: 'ArrowUp' }); // Two
 
@@ -505,9 +497,7 @@ it('activates the Edit button on on ArrowUp', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // One's Edit button
   await sendKeys({ press: 'ArrowDown' }); // Two
@@ -538,11 +528,8 @@ it('activates the first enabled option on Home', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-
   await sendKeys({ press: 'End' });
   await sendKeys({ press: 'Home' });
 
@@ -572,11 +559,8 @@ it('activates the first enabled option on PageUp', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-
   await sendKeys({ press: 'PageDown' });
   await sendKeys({ press: 'PageUp' });
 
@@ -606,11 +590,8 @@ it('activates the first enabled option on ArrowUp + Meta', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
-
   await sendKeys({ press: 'End' });
   await sendKeys({ down: 'Meta' });
   await sendKeys({ press: 'ArrowUp' });
@@ -642,9 +623,7 @@ it('activates the last enabled option on End', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'End' });
 
@@ -674,9 +653,7 @@ it('activates the last option on PageDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'PageDown' });
 
@@ -706,9 +683,7 @@ it('activates the last option on Meta + ArrowDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ down: 'Meta' });
   await sendKeys({ press: 'ArrowDown' });
@@ -727,6 +702,29 @@ it('activates the last option on Meta + ArrowDown', async () => {
   expect(options[2]?.privateIsTooltipOpen).to.be.false;
 });
 
+it('activates the first option on open when the previously active open is disabled programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label">
+      <glide-core-dropdown-option label="One"></glide-core-dropdown-option>
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = host.querySelectorAll('glide-core-dropdown-option');
+
+  await click(host);
+  await hover(options[1]);
+  await click(document.body);
+
+  assert(options[1]);
+  options[1].disabled = true;
+
+  await click(host);
+
+  expect(options[0]?.privateActive).to.be.true;
+  expect(options[1]?.privateActive).to.be.false;
+});
+
 it('does not wrap on ArrowUp', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" open>
@@ -735,9 +733,7 @@ it('does not wrap on ArrowUp', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowUp' });
 
@@ -755,9 +751,7 @@ it('does not wrap on ArrowDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
-
+  await aTimeout(0); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // Two
   await sendKeys({ press: 'ArrowDown' }); // Two
@@ -844,8 +838,7 @@ it('shows a fallback when open and its options are removed', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -853,8 +846,7 @@ it('shows a fallback when open and its options are removed', async () => {
     option.remove();
   }
 
-  // Wait for `#onDefaultSlotChange()`.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for `#onDefaultSlotChange()`.
 
   const feedback = host.shadowRoot?.querySelector(
     '[data-test="optionless-feedback"]',
@@ -898,8 +890,7 @@ it('does not allow its "toggle" event to propagate', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await aTimeout(0); // Wait for Floating UI
 
   const tooltip = host.shadowRoot
     ?.querySelector('[data-test="internal-label-tooltip"]')

--- a/src/dropdown.test.visuals.ts
+++ b/src/dropdown.test.visuals.ts
@@ -22,16 +22,34 @@ for (const story of stories.Dropdown) {
           );
         });
 
-        test('filterable', async ({ page }, test) => {
+        test('filter("noMatchingOptions")', async ({ page }, test) => {
           await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
           await page
             .locator('glide-core-dropdown')
             .evaluate<void, Dropdown>((element) => {
               element.filterable = true;
+              element.open = true;
             });
 
-          await page.getByRole('combobox').fill('test');
+          await page.getByRole('combobox').fill('noMatchingOptions');
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('filter("o")', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-dropdown')
+            .evaluate<void, Dropdown>((element) => {
+              element.filterable = true;
+              element.open = true;
+            });
+
+          await page.getByRole('combobox').fill('o');
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -1416,11 +1416,9 @@ export default class Dropdown extends LitElement implements FormControl {
           // whether to show themselves as selected using a checkmark) via their internal
           // `lastSelectedAndEnabledOption` getter.
           //
-          // However, an additional selected Dropdown Option can be added to Dropdown's default
-          // slot at any time. And it may now be the last selected option. But what was the last
-          // selected option won't know that a new selected option was added and that it's is no
-          // longer the last. So we force an update of its `lastSelectedAndEnabledOption` getter
-          // and a rerender.
+          // An additional selected option can be added to Dropdown's default slot at any time.
+          // And it may now be the last selected option. But what was the last selected option
+          // won't know it's no longer the last. So we force selected options to rerender.
           option.requestUpdate();
         }
       }
@@ -2268,11 +2266,9 @@ export default class Dropdown extends LitElement implements FormControl {
           // whether to show themselves as selected using a checkmark) via their internal
           // `lastSelectedAndEnabledOption` getter.
           //
-          // However, it's possible that previously last selected option was just disabled
-          // and there's another selected option that's enabled. But that option won't know
-          // it's now the last selected option until it reruns its `lastSelectedAndEnabledOption`
-          // getter. But it doesn't know that it needs to rerun that getter. So will tell it
-          // to by forcing a rerender.
+          // The previously last selected option may have been the one that was disabled
+          // and another selected option may be enabled. But the enabled option won't know
+          // it's now the last selected option. So we force selected options to rerender.
           option.requestUpdate();
         }
       }
@@ -2309,10 +2305,9 @@ export default class Dropdown extends LitElement implements FormControl {
           // whether to show themselves as selected using a checkmark) via their internal
           // `lastSelectedAndEnabledOption` getter.
           //
-          // However, others option may be enabled and selected, and what was previously the
-          // last selected and enabled option may no longer be the last. But the option won't
-          // know that because it doesn't know that a later option was enabled. So we force an
-          // update its `lastSelectedAndEnabledOption` getter and a rerender.
+          // What was previously the last selected and enabled option may no longer be the last.
+          // But it won't know that because it doesn't know another option was enabled. So we
+          // force selected options to rerender.
           option.requestUpdate();
         }
       }

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -1254,9 +1254,6 @@ export default class Dropdown extends LitElement implements FormControl {
 
   #optionsAndFeedbackElementRef = createRef<HTMLElement>();
 
-  // Used to set the previously active option as active when Dropdown is opened, and
-  // when filtering and the user filters out all options then changes the filter query
-  // to filter some
   #previouslyActiveOption?: DropdownOption | null;
 
   #primaryButtonElementRef = createRef<HTMLButtonElement>();

--- a/src/icons/checked.ts
+++ b/src/icons/checked.ts
@@ -18,6 +18,7 @@ export default html`
   >
     <path
       class="check"
+      data-test="check"
       d="M20 6L9 17L4 12"
       stroke="currentColor"
       stroke-width="2"

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -482,7 +482,7 @@ export default class Menu extends LitElement {
       event.preventDefault();
 
       if (event.key === ' ' && isSpanOrDiv) {
-        event.preventDefault(); // Prevent scroll.
+        event.preventDefault(); // Prevent page scroll.
       }
 
       // For VoiceOver. Options normally don't receive focus. But VoiceOver
@@ -496,7 +496,7 @@ export default class Menu extends LitElement {
     }
 
     if ([' ', 'Enter'].includes(event.key) && !this.open && isSpanOrDiv) {
-      event.preventDefault(); // Prevent scroll when Space is pressed.
+      event.preventDefault(); // Prevent page scroll when Space is pressed.
 
       // `<span>`s and `<div>`s don't emit "click" events on Enter and Space.
       // If they did, it would get picked up by `#onTargetSlotClick` and we
@@ -526,7 +526,7 @@ export default class Menu extends LitElement {
       this.#activeOption &&
       this.#optionsElement
     ) {
-      event.preventDefault(); // Prevent scroll.
+      event.preventDefault(); // Prevent page scroll.
 
       this.open = true;
       this.#optionsElement.ariaActivedescendant = this.#activeOption.id;
@@ -544,7 +544,7 @@ export default class Menu extends LitElement {
       // Menu as a whole because more than one Button or Link is required to test
       // these interactions.
       if (event.key === 'ArrowUp' && !event.metaKey) {
-        event.preventDefault(); // Prevent scroll.
+        event.preventDefault(); // Prevent page scroll.
 
         const previousOption = this.#optionElements.findLast(
           (option, index) => {
@@ -562,7 +562,7 @@ export default class Menu extends LitElement {
       }
 
       if (event.key === 'ArrowDown' && !event.metaKey) {
-        event.preventDefault(); // Prevent scroll.
+        event.preventDefault(); // Prevent page scroll.
 
         const nextOption = this.#optionElements.find((option, index) => {
           return !option.disabled && index > activeOptionIndex;
@@ -582,7 +582,7 @@ export default class Menu extends LitElement {
         event.key === 'Home' ||
         event.key === 'PageUp'
       ) {
-        event.preventDefault(); // Prevent scroll.
+        event.preventDefault(); // Prevent page scroll.
 
         const firstOption = [...this.#optionElements]
           .reverse()
@@ -602,7 +602,7 @@ export default class Menu extends LitElement {
         event.key === 'End' ||
         event.key === 'PageDown'
       ) {
-        event.preventDefault(); // Prevent scroll.
+        event.preventDefault(); // Prevent page scroll.
 
         const lastOption = [...this.#optionElements].findLast(
           (option) => !option.disabled,

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -104,7 +104,7 @@ export default {
 
   // If a test suite take longer than this, it's almost certainly hanging
   // and won't finish. 2 minutes is the default.
-  testsFinishTimeout: process.env.CI ? 60_000 : 30_000,
+  testsFinishTimeout: process.env.CI ? 90_000 : 30_000,
 
   testRunnerHtml(testFramework) {
     return `<html>


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Dropdown has seen tons of feature additions since I first built it. But, due to time constraints, it hasn't yet been given a proper once-over. It'll also be getting an Add button feature soon. So I thought now was a good time simplify, increase consistency, add documentation, and fix a number of longstanding bugs. 

Dropdown still isn't perfect, and there are plenty of tests gaps—some of which will never be filled due to the sheer number of state combinations there are to test. But the changes here hopefully keep us ahead of the curve with respect to consumers' expectations and the bugs they're likely to encounter.

It's a big one. So thank you for reviewing it. I did my best to add comments to help walk you through it.

> ## Patch
> ### Dropdown
> 
> - The user's system preference for reduced motion is now respected when Dropdown is scrolled using the arrow keys.
> - The first enabled Dropdown Option is now activated when the currently active Dropdown Option is disabled programmatically.
> 
> #### Single-select
>
> - When a Dropdown Option is selected and a new Dropdown Option with a `selected` attribute is added to Dropdown's default slot, only the last selected Dropdown Option now appears as selected.
> 
> - Dropdown's `value` and input field (if Dropdown is filterable) are now set to the `value` and `label` of the next last selected and enabled Dropdown Option when the previously last selected Dropdown Option is disabled programmatically. If no Dropdown Option is selected and enabled, Dropdown will clear its `value` and input field.
>
> #### Filterable
> 
> - `aria-activedescendant` is now set internally to an empty string when every Dropdown Option has been filtered out.
> - There's no longer a stray ellipsis at the end of Dropdown's input field when Dropdown's input field is visually truncated then subsequently cleared by the user.
> - A tooltip is no longer shown on Dropdown's input field when a Dropdown Option with a long label is selected then Dropdown is closed.
> - The value of Dropdown's input field no longer changes to the `label` of a selected Dropdown Option when its `label` is changed programmatically and it isn't the last selected Dropdown Option.
> - Single-select Dropdown's input field no longer retains the `label` of the previously selected Dropdown Option when the `label` of the now-selected Dropdown Option is an empty string.
> - When the currently and previously active Dropdown Options are filtered out, the first Dropdown Option was activated even if it was disabled. Now the first enabled Dropdown Option is activated instead.



## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

### All


#### The user's system preference for reduced motion is now respected when Dropdown is scrolled using the arrow keys

1. Reduce motion using your system setting.
2. Navigate to Dropdown in Storybook.
3. Copy an existing option using DevTools and paste it into Dropdown so there are at least 10 options.
4. Verify Dropdown doesn't animate when scrolled using the arrow keys.

#### The first enabled Dropdown Option is now activated when the currently active Dropdown Option is disabled programmatically

1. Navigate to Dropdown in Storybook.
2. Open Dropdown. The first option will be activated.
3. Close Dropdown.
4. Disabled the option programmatically.
5. Open Dropdown.
6. Verify the next enabled option is active.


###  Single-select

#### When a Dropdown Option is selected and a new Dropdown Option with a `selected` attribute is added to Dropdown's default slot, only the last selected Dropdown Option now appears as selected

A tough one to test manually. But I've [written a test](https://github.com/CrowdStrike/glide-core/pull/929/files#diff-184e16667f744bc1f07ce8c6048d5603bf36a16c41c048e78d938d16f0e9063aR938-R964) for it that should have us covered.

#### Dropdown's `value` and input field (if Dropdown is filterable) are now set to the `value` and `label` of the next last selected and enabled Dropdown Option when the previously last selected Dropdown Option is disabled programmatically. If no Dropdown Option is selected and enabled, Dropdown will clear its `value` and input field.

1. Check out this branch.
2. Change Dropdown's story so that two options are initially selected.
3. Navigate to Dropdown in Storybook locally.
4. Use DevTools to programmatically disable the second option.
5. Verify Dropdown's internal label is equal to the that of the first option.
6. Verify Dropdown's `value` is equal to that of the first option.
<br>

1. Navigate to Dropdown in Storybook.
2. Select an option.
3. Use DevTools to programmatically disable the option.
4. Verify Dropdown's internal label is empty.
5. Verify Dropdown's `value` is empty.

### Filterable

#### `aria-activedescendant` is now set internally to an empty string when every Dropdown Option has been filtered out.

1. Navigate to Dropdown in Storybook.
2. Add the `filterable` attribute.
3. Use DevTools to bring Dropdown's input field into view in the Elements pane.
4. Filter out every option.
5. Verify the `aria-activedescendant` on the input field is empty.

#### There's no longer a stray ellipsis at the end of Dropdown's input field when Dropdown's input field is visually truncated then subsequently cleared by the user.

1. Navigate to Dropdown in Storybook.
2. Add the `filterable` attribute.
3. Set the first option's label to [something long](https://www.lipsum.com/) using the controls table.
4. Select the option.
5. Reduce the size of your viewport so Dropdown's internal label is truncated with an ellipsis.
6. Select another option.
7. Verify the ellipsis is gone.

#### A tooltip is no longer shown on Dropdown's input field when a Dropdown Option with a long label is selected then Dropdown is closed.

1. Navigate to Dropdown in Storybook.
2. Set the first option's label to [something long](https://www.lipsum.com/) using the controls table.
3. Select the first option.
4. Verify a tooltip isn't shown on Dropdown's internal label when Dropdown closes.

#### The value of Dropdown's input field no longer changes to the `label` of a selected Dropdown Option when its `label` is changed programmatically and it isn't the last selected Dropdown Option.

1. Check out this branch.
2. Change Dropdown's story so that two options are initially selected.
3. Navigate to Storybook locally.
4. Add the `filterable` attribute.
5. Change the label of the first selected option.
6. Verify Dropdown's input field doesn't change to the label of the first selected option.

#### Single-select Dropdown's input field no longer retains the `label` of the previously selected Dropdown Option when the `label` of the now-selected Dropdown Option is an empty string.

1. Navigate to Dropdown in Storybook.
2. Add the `filterable` attribute.
3. Select the second option.
4. Use DevTools to set the label of the first option to an empty string.
5. Select the first option.
6. Verify value of the input field is an empty string instead of "Two".

#### When the currently and previously active Dropdown Options are filtered out, the first Dropdown Option was activated even if it was disabled. Now the first enabled Dropdown Option is activated instead.

1. Navigate to Dropdown in Storybook.
2. Programmatically disable the second option.
3. Open Dropdown. The first option should be active.
4. Type "t".
5. Verify "Three" is active.


<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
