### PR TITLE
Move Menu's private variables to Menu Button and Menu Link

### DIFF
--- a/src/menu.button.styles.ts
+++ b/src/menu.button.styles.ts
@@ -9,10 +9,10 @@ export default [
       border-radius: var(--glide-core-spacing-base-sm);
       display: flex;
       font: inherit;
-      gap: var(--private-gap);
+      gap: var(--glide-core-spacing-base-sm);
       inline-size: 100%;
-      padding-block: var(--private-padding-block);
-      padding-inline: var(--private-padding-inline);
+      padding-block: var(--glide-core-spacing-base-xxs);
+      padding-inline: var(--glide-core-spacing-base-sm);
       transition: background-color 100ms ease-in-out;
       user-select: none;
 

--- a/src/menu.link.styles.ts
+++ b/src/menu.link.styles.ts
@@ -10,10 +10,10 @@ export default [
       box-sizing: border-box;
       display: flex;
       font: inherit;
-      gap: var(--private-gap);
+      gap: var(--glide-core-spacing-base-sm);
       inline-size: 100%;
-      padding-block: var(--private-padding-block);
-      padding-inline: var(--private-padding-inline);
+      padding-block: var(--glide-core-spacing-base-xxs);
+      padding-inline: var(--glide-core-spacing-base-sm);
       text-decoration: none;
       transition: background-color 100ms ease-in-out;
       user-select: none;

--- a/src/menu.options.styles.ts
+++ b/src/menu.options.styles.ts
@@ -12,10 +12,6 @@ export default [
     }
 
     .component {
-      --private-gap: var(--glide-core-spacing-base-sm);
-      --private-padding-inline: var(--glide-core-spacing-base-sm);
-      --private-padding-block: var(--glide-core-spacing-base-xxs);
-
       font-family: var(--glide-core-typography-family-primary);
       font-size: var(--glide-core-typography-size-body-default);
       font-weight: var(--glide-core-typography-weight-regular);


### PR DESCRIPTION
## 🚀 Description

Menu previously set a few private CSS variables on itself for use in Menu Button and Menu Link. It did that to control their size when Menu's `size` attribute changed. Menu no longer has a `size` attribute. So I've moved the variables' values into Menu Button and Menu Link.

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

N/A

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
