### PR TITLE
Tab Group bugfixes

### DIFF
--- a/.changeset/curly-apes-hide.md
+++ b/.changeset/curly-apes-hide.md
@@ -1,0 +1,7 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Tabs can now be deselected programmatically.
+- Tab Group now selects the first Tab when its selected Tab is deselected.
+- Tab Group now deselects all but the last selected Tab when multiple Tabs have a `selected` attribute.

--- a/src/tab.group.test.basics.ts
+++ b/src/tab.group.test.basics.ts
@@ -28,9 +28,13 @@ it('selects the first tab when none is selected', async () => {
   `);
 
   const tabs = host.querySelectorAll('glide-core-tab');
+  const panels = host.querySelectorAll('glide-core-tab-panel');
 
   expect(tabs[0]?.selected).to.be.true;
   expect(tabs[1]?.selected).to.be.false;
+
+  expect(panels[0]?.ariaHidden).to.equal('false');
+  expect(panels[1]?.ariaHidden).to.equal('true');
 });
 
 it('sets the width of its selected tab indicator to that of the selected tab', async () => {
@@ -62,6 +66,29 @@ it('sets the width of its selected tab indicator to that of the selected tab', a
   expect(selectedTabIndicator.clientWidth).to.equal(firstTab.clientWidth);
 });
 
+it('deselects all but its last selected tab when multiple are selected', async () => {
+  const host = await fixture(html`
+    <glide-core-tab-group>
+      <glide-core-tab slot="nav" panel="1" selected>One</glide-core-tab>
+      <glide-core-tab slot="nav" panel="2" selected>Two</glide-core-tab>
+
+      <glide-core-tab-panel name="1">One</glide-core-tab-panel>
+      <glide-core-tab-panel name="2">Two</glide-core-tab-panel>
+    </glide-core-tab-group>
+  `);
+
+  const tabs = host.querySelectorAll('glide-core-tab');
+  const panels = host.querySelectorAll('glide-core-tab-panel');
+
+  expect(tabs[0]?.selected).to.be.false;
+  expect(tabs[0]?.tabIndex).to.equal(-1);
+  expect(tabs[1]?.selected).to.be.true;
+  expect(tabs[1]?.tabIndex).to.equal(0);
+
+  expect(panels[0]?.ariaHidden).to.equal('true');
+  expect(panels[1]?.ariaHidden).to.equal('false');
+});
+
 it('throws when subclassed', async () => {
   const spy = sinon.spy();
 
@@ -74,7 +101,7 @@ it('throws when subclassed', async () => {
   expect(spy.callCount).to.equal(1);
 });
 
-it('throws when its default slot is thw wrong type', async () => {
+it('throws when its default slot is the wrong type', async () => {
   await expectWindowError(() => {
     return fixture(html`
       <glide-core-tab-group>

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -62,7 +62,7 @@ export default class Tab extends LitElement {
     const hasChanged = isSelected !== this.#isSelected;
     this.#isSelected = isSelected;
 
-    if (isSelected && hasChanged) {
+    if (hasChanged) {
       this.dispatchEvent(
         new Event('private-selected', {
           bubbles: true,


### PR DESCRIPTION
## 🚀 Description

> ### Patch
> - Tabs can now be deselected programmatically.
> - Tab Group now selects the first Tab when its selected Tab is deselected.
> - Tab Group now deselects all but the last selected Tab when multiple Tabs have a `selected` attribute.

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

### Tabs can now be deselected programmatically

1. Navigate to Tab Group in Storybook.
2. Select the second Tab.
3. Set the second Tab's `selected` property to `false.`
4. Verify the second Tab is no longer selected.

### Tab Group now selects the first Tab when its selected Tab is deselected

1. Navigate to Tab Group in Storybook.
5. Select the second Tab.
6. Set the second Tab's `selected` property to `false.`
7. Verify the first Tab is selected.

### Tab Group now deselects all but the last selected Tab when multiple Tabs have a `selected` attribute

This one is difficult to fully test without changing the story. But [these](https://github.com/CrowdStrike/glide-core/pull/942/files#diff-0c0e017eb2c63dad1cb82fe2f3eac3a6942216f93d7506892660c99e1b36680fR65-R87) [tests](https://github.com/CrowdStrike/glide-core/pull/942/files#diff-27f76f390c1afad4b13e30f7e85d7dc2096aed97294b996af3d01991dd0df559R587-R627) should have us covered.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
