### PR TITLE
Dropdown item count role fix

### DIFF
--- a/.changeset/small-comics-peel.md
+++ b/.changeset/small-comics-peel.md
@@ -2,4 +2,4 @@
 '@crowdstrike/glide-core': patch
 ---
 
-Dropdown's item count now has a role of `status`.
+Dropdown's item count is no longer reported as an error with axe accessibility tools.

--- a/.changeset/small-comics-peel.md
+++ b/.changeset/small-comics-peel.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown's item count now has a role of `status`.

--- a/src/dropdown.test.basics.filterable.ts
+++ b/src/dropdown.test.basics.filterable.ts
@@ -12,10 +12,6 @@ it('is accessible', async () => {
 
   await expect(host).to.be.accessible({
     ignoredRules: [
-      // Axe doesn't like that our item count element doesn't have a `role`. Yet
-      // it does label `<input>` and is announced correctly, at least by VoiceOver.
-      'aria-prohibited-attr',
-
       // Axe doesn't search within slots when determining whether an element
       // has an ID that matches `aria-activedescendant` exists.
       'aria-valid-attr-value',

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -871,6 +871,7 @@ export default class Dropdown extends LitElement implements FormControl {
                   class="item-count"
                   data-test="item-count"
                   id="item-count"
+                  role="status"
                 ></span>
               </div>
             </glide-core-tooltip>


### PR DESCRIPTION
## 🚀 Description

Resolves an error from axe accessibility tools:

```
Issue target: ..., glide-core-dropdown,#item-count
Context: <span aria-live="assertive" class="item-count" data-test="item-count" id="item-count" aria-label="0 items"></span>
Fix all of the following:
  aria-label attribute cannot be used on a span with no valid role attribute.
```

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

- Open [Dropdown's `filterable` story](https://glide-core.crowdstrike-ux.workers.dev/dropdown-count-a11y-fix?path=/story/dropdown--dropdown&args=filterable:!true)
- Turn on Voice Over
- Type something into Dropdown
- Press control+option+space
- Verify the item count is read aloud by Voice Over and reflects how many items are currently displayed in the options