### PR TITLE
Tab Group overflow fixes

### DIFF
--- a/.changeset/tricky-owls-clap.md
+++ b/.changeset/tricky-owls-clap.md
@@ -1,0 +1,6 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Tab Group's selected tab indicator is no longer slightly too wide when the last Tab is selected.
+- Tab Group no longer flashes its selected Tab indicator when the user switches between Tabs.

--- a/src/tab.group.styles.ts
+++ b/src/tab.group.styles.ts
@@ -17,6 +17,7 @@ export default [
     .component {
       --private-transition-duration: 250ms;
 
+      /* https://github.com/CrowdStrike/glide-core/pull/476#issue-2659854067 */
       display: contents;
     }
 
@@ -57,7 +58,9 @@ export default [
 
       &.animated {
         @media (prefers-reduced-motion: no-preference) {
-          transition: translate var(--private-transition-duration);
+          transition:
+            inline-size var(--private-transition-duration),
+            translate var(--private-transition-duration);
         }
       }
     }

--- a/src/tab.group.test.basics.ts
+++ b/src/tab.group.test.basics.ts
@@ -1,4 +1,11 @@
-import { assert, expect, fixture, html } from '@open-wc/testing';
+import {
+  assert,
+  aTimeout,
+  expect,
+  fixture,
+  html,
+  waitUntil,
+} from '@open-wc/testing';
 import { emulateMedia } from '@web/test-runner-commands';
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
@@ -45,12 +52,50 @@ it('sets the width of its selected tab indicator to that of the selected tab', a
   const host = await fixture(html`
     <glide-core-tab-group>
       <glide-core-tab slot="nav" panel="1">One</glide-core-tab>
-      <glide-core-tab slot="nav" panel="2">Two</glide-core-tab>
+      <glide-core-tab slot="nav" panel="2" selected>Two</glide-core-tab>
 
       <glide-core-tab-panel name="1">One</glide-core-tab-panel>
       <glide-core-tab-panel name="2">Two</glide-core-tab-panel>
     </glide-core-tab-group>
   `);
+
+  const firstTab = host
+    .querySelector('glide-core-tab:last-of-type')
+    ?.shadowRoot?.querySelector('[data-test="component"]');
+
+  const selectedTabIndicator = host.shadowRoot?.querySelector(
+    '[data-test="selected-tab-indicator"]',
+  );
+
+  assert(firstTab);
+  assert(selectedTabIndicator);
+
+  // Wait for the Resize Observer
+  await waitUntil(() => {
+    return selectedTabIndicator.clientWidth === firstTab.clientWidth;
+  });
+
+  await emulateMedia({ reducedMotion: 'no-preference' });
+});
+
+it('offsets the width of its tab indicator when its first tab is selected', async () => {
+  // The selected tab indicator transitions its width and position. The transitions
+  // are disabled to simplify and speed up the test.
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  const host = await fixture(html`
+    <glide-core-tab-group>
+      <glide-core-tab slot="nav" panel="1" selected>One</glide-core-tab>
+      <glide-core-tab slot="nav" panel="2">Two</glide-core-tab>
+      <glide-core-tab slot="nav" panel="3">Three</glide-core-tab>
+
+      <glide-core-tab-panel name="1">One</glide-core-tab-panel>
+      <glide-core-tab-panel name="2">Two</glide-core-tab-panel>
+      <glide-core-tab-panel name="3">Three</glide-core-tab-panel>
+    </glide-core-tab-group>
+  `);
+
+  await aTimeout(0); // Wait for the Resize Observer
 
   const firstTab = host
     .querySelector('glide-core-tab')
@@ -63,7 +108,88 @@ it('sets the width of its selected tab indicator to that of the selected tab', a
   assert(firstTab);
   assert(selectedTabIndicator);
 
-  expect(selectedTabIndicator.clientWidth).to.equal(firstTab.clientWidth);
+  // Wait for the Resize Observer
+  await waitUntil(() => {
+    return selectedTabIndicator.clientWidth === firstTab.clientWidth;
+  });
+
+  await emulateMedia({ reducedMotion: 'no-preference' });
+});
+
+it('offsets the width of its tab indicator when its middle tab is selected', async () => {
+  // The selected tab indicator transitions its width and position. The transitions
+  // are disabled to simplify and speed up the test.
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  const host = await fixture(html`
+    <glide-core-tab-group>
+      <glide-core-tab slot="nav" panel="1">One</glide-core-tab>
+      <glide-core-tab slot="nav" panel="2" selected>Two</glide-core-tab>
+      <glide-core-tab slot="nav" panel="3">Three</glide-core-tab>
+
+      <glide-core-tab-panel name="1">One</glide-core-tab-panel>
+      <glide-core-tab-panel name="2">Two</glide-core-tab-panel>
+      <glide-core-tab-panel name="3">Three</glide-core-tab-panel>
+    </glide-core-tab-group>
+  `);
+
+  await aTimeout(0); // Wait for the Resize Observer
+
+  const middleTab = host
+    .querySelector('glide-core-tab:nth-of-type(2)')
+    ?.shadowRoot?.querySelector('[data-test="component"]');
+
+  const selectedTabIndicator = host.shadowRoot?.querySelector(
+    '[data-test="selected-tab-indicator"]',
+  );
+
+  assert(middleTab);
+  assert(selectedTabIndicator);
+
+  // Wait for the Resize Observer
+  await waitUntil(() => {
+    return selectedTabIndicator.clientWidth === middleTab.clientWidth;
+  });
+
+  await emulateMedia({ reducedMotion: 'no-preference' });
+});
+
+it('offsets the width of its tab indicator when its last tab is selected', async () => {
+  // The selected tab indicator transitions its width and position. The transitions
+  // are disabled to simplify and speed up the test.
+  await emulateMedia({ reducedMotion: 'reduce' });
+
+  const host = await fixture(html`
+    <glide-core-tab-group>
+      <glide-core-tab slot="nav" panel="1">One</glide-core-tab>
+      <glide-core-tab slot="nav" panel="2">Two</glide-core-tab>
+      <glide-core-tab slot="nav" panel="3" selected>three</glide-core-tab>
+
+      <glide-core-tab-panel name="1">One</glide-core-tab-panel>
+      <glide-core-tab-panel name="2">Two</glide-core-tab-panel>
+      <glide-core-tab-panel name="3">Three</glide-core-tab-panel>
+    </glide-core-tab-group>
+  `);
+
+  await aTimeout(0); // Wait for the Resize Observer
+
+  const lastTab = host
+    .querySelector('glide-core-tab:last-of-type')
+    ?.shadowRoot?.querySelector('[data-test="component"]');
+
+  const selectedTabIndicator = host.shadowRoot?.querySelector(
+    '[data-test="selected-tab-indicator"]',
+  );
+
+  assert(lastTab);
+  assert(selectedTabIndicator);
+
+  // Wait for the Resize Observer
+  await waitUntil(() => {
+    return selectedTabIndicator.clientWidth === lastTab.clientWidth;
+  });
+
+  await emulateMedia({ reducedMotion: 'no-preference' });
 });
 
 it('deselects all but its last selected tab when multiple are selected', async () => {

--- a/src/tab.group.test.interactions.ts
+++ b/src/tab.group.test.interactions.ts
@@ -291,6 +291,8 @@ it('hides its overflow buttons when overall tab content is reduced', async () =>
       !host.shadowRoot?.querySelector('[data-test="overflow-end-button"]')
     );
   });
+
+  await emulateMedia({ reducedMotion: 'no-preference' });
 });
 
 it('disables its overflow buttons on scroll', async () => {
@@ -519,7 +521,7 @@ it('can be nested', async () => {
   expect(panels[3]?.ariaHidden).to.equal('true');
 });
 
-it('updates the width of its selected tab indicator when the width of a tab changes', async () => {
+it('updates the width of its selected tab indicator when the label of a tab changes', async () => {
   // The selected tab indicator transitions its width and position. The transitions
   // are disabled to simplify and speed up the test.
   await emulateMedia({ reducedMotion: 'reduce' });
@@ -545,13 +547,23 @@ it('updates the width of its selected tab indicator when the width of a tab chan
   );
 
   assert(firstTab);
+  assert(selectedTabIndicator);
+
+  // Wait for the Resize Observer
+  await waitUntil(() => {
+    return selectedTabIndicator?.clientWidth === firstTabInitialWidth;
+  });
+
   firstTab.innerHTML = 'One (But Longer)';
 
+  // Wait for the Resize Observer
   await waitUntil(() => {
     return selectedTabIndicator?.clientWidth !== firstTabInitialWidth;
   });
 
   expect(selectedTabIndicator?.clientWidth).to.equal(firstTab.clientWidth);
+
+  await emulateMedia({ reducedMotion: 'no-preference' });
 });
 
 it('sets aria attributes on tabs and panels when new ones are added', async () => {

--- a/src/tab.group.ts
+++ b/src/tab.group.ts
@@ -352,8 +352,6 @@ export default class TabGroup extends LitElement {
       panel.privateIsSelected = panel.name === this.#lastSelectedTab?.panel;
       panel.tabIndex = panel.name === this.#lastSelectedTab?.panel ? 0 : -1;
     }
-
-    this.#updateSelectedTabIndicator();
   }
 
   #setAriaAttributes() {
@@ -391,11 +389,22 @@ export default class TabGroup extends LitElement {
       this.#tabElements.length > 0 &&
       this.#selectedTabIndicatorElementRef.value
     ) {
-      const selectedTabInlinePadding = Number.parseInt(
-        window
-          .getComputedStyle(this.#lastSelectedTab)
-          .getPropertyValue('padding-inline-start'),
-      );
+      const isFirstTab = this.#lastSelectedTab === this.#tabElements.at(0);
+      const isLastTab = this.#lastSelectedTab === this.#tabElements.at(-1);
+
+      const selectedTabInlinePadding = isFirstTab
+        ? Number.parseInt(
+            window
+              .getComputedStyle(this.#lastSelectedTab)
+              .getPropertyValue('padding-inline-start'),
+          )
+        : isLastTab
+          ? Number.parseInt(
+              window
+                .getComputedStyle(this.#lastSelectedTab)
+                .getPropertyValue('padding-inline-end'),
+            )
+          : 0;
 
       const selectedTabIndicatorTranslateLeft =
         this.#lastSelectedTab === this.#tabElements.at(0)
@@ -412,18 +421,12 @@ export default class TabGroup extends LitElement {
         `${selectedTabIndicatorTranslateLeft}px`,
       );
 
-      const selectedTabIndicatorWidthAdjustment =
-        this.#lastSelectedTab === this.#tabElements.at(0) ||
-        this.#lastSelectedTab === this.#tabElements.at(-1)
-          ? selectedTabInlinePadding
-          : 0;
-
       const { width: selectedTabWidth } =
         this.#lastSelectedTab.getBoundingClientRect();
 
       this.#selectedTabIndicatorElementRef.value.style.setProperty(
         '--private-selected-tab-indicator-width',
-        `${selectedTabWidth - selectedTabIndicatorWidthAdjustment}px`,
+        `${selectedTabWidth - selectedTabInlinePadding}px`,
       );
     }
   }

--- a/src/tab.styles.ts
+++ b/src/tab.styles.ts
@@ -22,7 +22,6 @@ export default [
       gap: 0.4375rem;
       justify-content: center;
       padding-block: 0.4375rem;
-      transition: font-weight var(--private-transition-duration) ease-in-out;
       user-select: none;
 
       &:hover {


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
>
> - Tab Group's selected tab indicator is no longer slightly too wide when the last Tab is selected.
> - Tab Group no longer flashes its selected Tab indicator when the user switches between Tabs.

The root cause of both the second issue above and one in the screenshot below was the fact that the selected tab indicator's width [wasn't being](https://github.com/CrowdStrike/glide-core/pull/946/files) offset when the last tab was selected. 

The last tab has padding on its right side (`padding-inline-end`)—not its left side (`padding-inline-start`). So `selectedTabInlinePadding` always was `0px` when the last tab was selected. That meant the overflow indicator was always overflowing by 3 pixels because the last tab's padding wasn't being subtracted from the indicator's width.

Then, when the user selected tab next to the last tab, `#onTabListResize()` was called because the next to last tab was boldened and the last tab was unboldened. 

`#onTabListResize()` then called `#setOverflowButtonsState()`, which detected overflow because the position and width of selected tab indicator hadn't yet transitioned and was still overflowing the edge of the last tab.

<img width="791" alt="image" src="https://github.com/user-attachments/assets/a0fdc9e9-0052-4222-b026-5ceb026a1bc7" />





## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

### Tab Group's selected tab indicator is no longer slightly too wide when the last Tab is selected

1. Navigate to Tab Group in Storybook.
2. Select the second tab.
3. Verify that the width of the selected tab overflow indicator is equal to the width of the second tab.

### Tab Group no longer flashes its selected Tab indicator when the user switches between Tabs

This one is difficult to test to programmatically and manually. But [these tests](https://github.com/CrowdStrike/glide-core/pull/946/files#diff-0c0e017eb2c63dad1cb82fe2f3eac3a6942216f93d7506892660c99e1b36680fR81-R192) should have us covered indirectly.





<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
