### PR TITLE
Tab Group tweak

### DIFF
--- a/src/tab.group.ts
+++ b/src/tab.group.ts
@@ -323,6 +323,18 @@ export default class TabGroup extends LitElement {
       clearTimeout(this.#resizeTimeout);
     }
 
+    // TODO
+    //
+    // This only needs to be called here so the indicator is updated when the content of
+    // Tab's slots changes.
+    //
+    // Tab's default slot will soon be replaced by a `label` attribute. When that happens,
+    // this call can be removed, and `#updateSelectedTabIndicator()` can be instead called
+    // when Tab dispatches "private-label-change" and "private-icon-slotchange" events.
+    //
+    // Those changes will certainly require slightly more code. But they'll make it much
+    // clearer why `#updateSelectedTabIndicator()` is being called. Additionally, Tab Group
+    // will no longer be doing unncessary work every time the viewport is resized.
     this.#updateSelectedTabIndicator();
 
     // Toggling the overflow buttons will itself cause a resize. So we
@@ -347,6 +359,8 @@ export default class TabGroup extends LitElement {
       this.#firstTab.privateSelect();
       this.#firstTab.tabIndex = 0;
     }
+
+    this.#updateSelectedTabIndicator();
 
     for (const panel of this.#panelElements) {
       panel.privateIsSelected = panel.name === this.#lastSelectedTab?.panel;


### PR DESCRIPTION
## 🚀 Description

We got a report today that Tab Group's selected tab indicator is on the wrong tab in a visual test—and only in CI—when a tab is clicked. 

It has to do with the fact that `#updateSelectedTabIndicator()` is [no longer](https://github.com/CrowdStrike/glide-core/pull/946/files#diff-cfa9ddb827a45a55c1fb21f5a32268f138d6cf89ca688cc9e0cd0c443d33dafaL356) unnecessarily being called by `#onTabSelected()`. It's now [exclusively](https://github.com/CrowdStrike/glide-core/blob/main/src/tab.group.ts#L326) called by `#onTabListResize()`.

The reason the indicator is on the wrong tab is because `#onTabListResize()` isn't called by the browser immediately, and everything is slower in CI. So there's a slight delay between when the visual test clicks a tab and when `#onTabListResize()` is called. Inside of that delay, before the indicator has been repositioned, Playwright is taking a screenshot.

This issue isn't a Tab Group bug. But it's simpler for us to add the `#updateSelectedTabIndicator()` call back to `#onTabSelected()` instead of asking consumers to add `await emulateMedia({ reducedMotion: 'reduce' })` to their test—only for us to tell them they can remove it after we've reworked Tab Group (which @ynotdraw will be working on next).

When Tab Group is reworked, the `#updateSelectedTabIndicator()` call in `#onTabSelected()` will remain, and we'll [remove](https://github.com/CrowdStrike/glide-core/pull/949/files#diff-cfa9ddb827a45a55c1fb21f5a32268f138d6cf89ca688cc9e0cd0c443d33dafaR326-R337) the its call in `#onTabListResize()`. The overall result will be more explicit but also avoid unnecessary work.

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

N/A

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
