### PR TITLE
Add type="color" support to Input

### DIFF
--- a/.changeset/chilly-beans-sniff.md
+++ b/.changeset/chilly-beans-sniff.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Input now supports `type="color"`.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -3822,7 +3822,7 @@
               "kind": "field",
               "name": "type",
               "type": {
-                "text": "| 'date'\n    | 'email'\n    | 'number'\n    | 'password'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'time'\n    | 'url'"
+                "text": "| 'color'\n    | 'date'\n    | 'email'\n    | 'number'\n    | 'password'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'time'\n    | 'url'"
               },
               "default": "'text'",
               "attribute": "type",
@@ -4131,7 +4131,7 @@
             {
               "name": "type",
               "type": {
-                "text": "| 'date'\n    | 'email'\n    | 'number'\n    | 'password'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'time'\n    | 'url'"
+                "text": "| 'color'\n    | 'date'\n    | 'email'\n    | 'number'\n    | 'password'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'time'\n    | 'url'"
               },
               "default": "'text'",
               "fieldName": "type"

--- a/src/input.stories.ts
+++ b/src/input.stories.ts
@@ -332,6 +332,7 @@ const meta: Meta = {
     type: {
       control: { type: 'select' },
       options: [
+        'color',
         'date',
         'email',
         'number',
@@ -348,7 +349,7 @@ const meta: Meta = {
         },
         type: {
           summary:
-            'date | email | number | password | search | tel | text | time | url',
+            'color | date | email | number | password | search | tel | text | time | url',
         },
       },
     },

--- a/src/input.styles.ts
+++ b/src/input.styles.ts
@@ -123,6 +123,22 @@ export default [
           outline: 2px solid var(--glide-core-color-interactive-stroke-focus);
         }
       }
+
+      &[type='color']::-webkit-color-swatch {
+        border: none;
+        border-radius: var(--glide-core-rounding-base-radius-xxs);
+      }
+
+      /*
+        Unfortunately Firefox requires a different selector. It also
+        sets the element to 100% height of its container, so we set
+        a fixed block-size to match the other browsers.
+      */
+      &[type='color']::-moz-color-swatch {
+        block-size: 1.5rem;
+        border: none;
+        border-radius: var(--glide-core-rounding-base-radius-xxs);
+      }
     }
 
     .suffix-icon {

--- a/src/input.test.visuals.ts
+++ b/src/input.test.visuals.ts
@@ -439,7 +439,7 @@ for (const story of stories.Input) {
               element.type = 'url';
             });
 
-          await page.getByRole('textbox').fill('www.crowdstrike.com');
+          await page.getByRole('textbox').fill('https://www.crowdstrike.com');
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,

--- a/src/input.test.visuals.ts
+++ b/src/input.test.visuals.ts
@@ -294,6 +294,20 @@ for (const story of stories.Input) {
           );
         });
 
+        test('type="color"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-input')
+            .evaluate<void, Input>((element) => {
+              element.type = 'color';
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
         test('type="date"', async ({ page }, test) => {
           await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
@@ -310,6 +324,54 @@ for (const story of stories.Input) {
           );
         });
 
+        test('type="email"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-input')
+            .evaluate<void, Input>((element) => {
+              element.type = 'email';
+            });
+
+          await page.getByRole('textbox').fill('crowdstrike@email.com');
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('type="number"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-input')
+            .evaluate<void, Input>((element) => {
+              element.type = 'number';
+            });
+
+          await page.getByRole('spinbutton').fill('9');
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('type="password"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-input')
+            .evaluate<void, Input>((element) => {
+              element.type = 'password';
+            });
+
+          await page.getByRole('textbox').fill('password');
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
         test('type="search"', async ({ page }, test) => {
           await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
@@ -320,6 +382,22 @@ for (const story of stories.Input) {
             });
 
           await page.getByRole('searchbox').fill('Test');
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('type="tel"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-input')
+            .evaluate<void, Input>((element) => {
+              element.type = 'tel';
+            });
+
+          await page.getByRole('textbox').fill('1234567890');
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,
@@ -346,6 +424,22 @@ for (const story of stories.Input) {
             });
 
           await page.getByRole('textbox').fill('00:00');
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('type="url"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-input')
+            .evaluate<void, Input>((element) => {
+              element.type = 'url';
+            });
+
+          await page.getByRole('textbox').fill('www.crowdstrike.com');
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,

--- a/src/input.test.visuals.ts
+++ b/src/input.test.visuals.ts
@@ -397,7 +397,7 @@ for (const story of stories.Input) {
               element.type = 'tel';
             });
 
-          await page.getByRole('textbox').fill('1234567890');
+          await page.getByRole('textbox').fill('555-0123');
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,

--- a/src/input.test.visuals.ts
+++ b/src/input.test.visuals.ts
@@ -333,7 +333,7 @@ for (const story of stories.Input) {
               element.type = 'email';
             });
 
-          await page.getByRole('textbox').fill('crowdstrike@email.com');
+          await page.getByRole('textbox').fill('crowdstrike@example.com');
 
           await expect(page).toHaveScreenshot(
             `${test.titlePath.join('.')}.png`,

--- a/src/input.ts
+++ b/src/input.ts
@@ -44,7 +44,7 @@ declare global {
  * @attr {boolean} [required=false]
  * @attr {boolean} [spellcheck=false]
  * @attr {string} [tooltip]
- * @attr {'date'|'email'|'number'|'password'|'search'|'tel'|'text'|'time'|'url'} [type='text']
+ * @attr {'color'|'date'|'email'|'number'|'password'|'search'|'tel'|'text'|'time'|'url'} [type='text']
  * @attr {string} [value='']
  *
  * @readonly
@@ -173,6 +173,7 @@ export default class Input extends LitElement implements FormControl {
 
   @property({ reflect: true, useDefault: true })
   type:
+    | 'color'
     | 'date'
     | 'email'
     | 'number'


### PR DESCRIPTION
## 🚀 Description

Adds `type="color"` support to Input.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

N/A
