### PR TITLE
Update Split Button's radiuses

### DIFF
--- a/.changeset/nine-wombats-tease.md
+++ b/.changeset/nine-wombats-tease.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Split Button Primary Button and Split Button Secondary Button's border radiuses have been slightly reduced.

--- a/src/split-button.primary-button.styles.ts
+++ b/src/split-button.primary-button.styles.ts
@@ -10,8 +10,8 @@ export default [
     .component {
       align-items: center;
       block-size: 2.125rem;
-      border-radius: var(--glide-core-rounding-base-radius-md) 0 0
-        var(--glide-core-rounding-base-radius-md);
+      border-radius: var(--glide-core-rounding-base-radius-sm) 0 0
+        var(--glide-core-rounding-base-radius-sm);
       border-style: solid;
       border-width: 1px 0 1px 1px;
       box-sizing: border-box;

--- a/src/split-button.secondary-button.styles.ts
+++ b/src/split-button.secondary-button.styles.ts
@@ -18,8 +18,8 @@ export default [
       border-inline-start-color: var(
         --glide-core-private-color-button-stroke-default
       );
-      border-radius: 0 var(--glide-core-rounding-base-radius-md)
-        var(--glide-core-rounding-base-radius-md) 0;
+      border-radius: 0 var(--glide-core-rounding-base-radius-sm)
+        var(--glide-core-rounding-base-radius-sm) 0;
       border-style: solid;
       border-width: 1px;
       box-sizing: border-box;


### PR DESCRIPTION
## 🚀 Description


<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> 
> Split Button Primary Button and Split Button Secondary Button's border radiuses have been slightly reduced.
## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

N/A

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
