### PR TITLE
Change Link to a `<span>` internally when disabled

### DIFF
--- a/.changeset/fast-penguins-design.md
+++ b/.changeset/fast-penguins-design.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Link, when disabled, is no longer openable by right-clicking it and choosing "Open Link in New Tab" or similar.

--- a/src/link.test.aria.ts
+++ b/src/link.test.aria.ts
@@ -9,8 +9,7 @@ test('disabled=${true}', async ({ page }) => {
   });
 
   await expect(page.locator('glide-core-link')).toMatchAriaSnapshot(`
-    - link "Label" [disabled]:
-      - /url: /
+    - link "Label" [disabled]
   `);
 });
 

--- a/src/link.ts
+++ b/src/link.ts
@@ -60,22 +60,37 @@ export default class Link extends LitElement {
   }
 
   override render() {
-    return html`<a
-      aria-disabled=${this.disabled}
-      class=${classMap({
-        component: true,
-        disabled: this.disabled,
-        href: Boolean(this.href),
-      })}
-      data-test="component"
-      download=${ifDefined(this.download)}
-      href=${ifDefined(this.href)}
-      target=${ifDefined(this.target)}
-      @click=${this.#onClick}
-      ${ref(this.#componentElementRef)}
-    >
-      ${this.label}
-    </a>`;
+    /* eslint-disable lit-a11y/click-events-have-key-events */
+    return this.disabled
+      ? html`<span
+          aria-disabled="true"
+          class=${classMap({
+            component: true,
+            disabled: this.disabled,
+          })}
+          data-test="component"
+          role="link"
+          tabindex="0"
+          @click=${this.#onClick}
+          ${ref(this.#componentElementRef)}
+        >
+          ${this.label}
+        </span>`
+      : html`<a
+          class=${classMap({
+            component: true,
+            disabled: this.disabled,
+            href: Boolean(this.href),
+          })}
+          data-test="component"
+          download=${ifDefined(this.download)}
+          href=${ifDefined(this.href)}
+          target=${ifDefined(this.target)}
+          @click=${this.#onClick}
+          ${ref(this.#componentElementRef)}
+        >
+          ${this.label}
+        </a>`;
   }
 
   #componentElementRef = createRef<HTMLAnchorElement>();


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> 
> Link, when disabled, is no longer openable by right-clicking it and choosing "Open Link in New Tab" or similar.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to Link in Storybook.
2. Set `disabled` to `true`.
3. Right-click Link.
4. Verify the context menu doesn't have an option to open Link.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
