### PR TITLE
Remove Menu out-of-bounds check

### DIFF
--- a/.changeset/twenty-zebras-change.md
+++ b/.changeset/twenty-zebras-change.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Menu Option(s) are now activated when they are hovered and Menu's `position` attribute is "top", "top-start", or "top-end".


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->
> ### Patch
> 
> Menu Option(s) are now activated when they are hovered and Menu's `position` attribute is "top", "top-start", or "top-end".

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to Menu in Storybook.
2. Set Menu's `placement` attribute to `"top"`.
3. Open Menu.
4. Verify you can activate Option(s).

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
