### PR TITLE
Fix Menu activating the wrong option on open

### DIFF
--- a/.changeset/thin-ghosts-eat.md
+++ b/.changeset/thin-ghosts-eat.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Menu no longer activates the wrong Option on open when Menu's [containing block](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Containing_block#identifying_the_containing_block) isn't the document.

--- a/src/library/request-idle-callback.ts
+++ b/src/library/request-idle-callback.ts
@@ -1,0 +1,5 @@
+export default function () {
+  return new Promise((resolve) => {
+    requestIdleCallback(resolve);
+  });
+}

--- a/src/menu.styles.ts
+++ b/src/menu.styles.ts
@@ -36,7 +36,6 @@ export default [
       padding-block-end: 0;
       padding-block-start: var(--glide-core-spacing-base-xxxs);
       padding-inline: var(--glide-core-spacing-base-xxxs);
-      position: absolute;
 
       /*
         This little hack replaces "padding-block-end", which the last option overlaps

--- a/src/menu.test.basics.filterable.ts
+++ b/src/menu.test.basics.filterable.ts
@@ -1,11 +1,12 @@
 import './options.js';
 import { LitElement } from 'lit';
-import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import { click } from './library/mouse.js';
 import './option.js';
 import './input.js';
 import Menu from './menu.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 @customElement('glide-core-target-as-slot')
 class TargetAsSlot extends LitElement {
@@ -79,6 +80,6 @@ it('has `#isFilterable` coverage', async () => {
     </glide-core-target-as-slot>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.querySelector('glide-core-input'));
 });

--- a/src/menu.test.basics.ts
+++ b/src/menu.test.basics.ts
@@ -1,12 +1,13 @@
 import './options.js';
 import './option.js';
 import './input.js';
-import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import Menu from './menu.js';
 import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
 import expectWindowError from './library/expect-window-error.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends Menu {}
@@ -171,7 +172,7 @@ it('is open', async () => {
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(host.open).to.be.true;
   expect(target?.ariaExpanded).to.equal('true');
@@ -207,7 +208,7 @@ it('is open when it and its sub-Menu are open', async () => {
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(hosts[0]?.open).to.be.true;
   expect(hosts[1]?.open).to.be.true;
@@ -261,7 +262,7 @@ it('closes open sub-Menus when it is not open', async () => {
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(hosts[0]?.open).to.be.false;
   expect(hosts[1]?.open).to.be.false;
@@ -320,7 +321,7 @@ it('closes all but the first open sub-Menu when it and multiple sub-Menus are op
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(hosts[0]?.open).to.be.true;
   expect(hosts[1]?.open).to.be.true;
@@ -381,7 +382,7 @@ it('activates the first enabled Option when open', async () => {
   const hosts = [host, ...host.querySelectorAll('glide-core-menu')];
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(options[0]?.privateActive).to.be.false;
   expect(options[1]?.privateActive).to.be.false;
@@ -449,7 +450,7 @@ it('is not opened when open and its target is `disabled`', async () => {
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(targets[0]?.ariaExpanded).to.equal('false');
   expect(targets[1]?.ariaExpanded).to.be.null;
@@ -499,7 +500,7 @@ it('is not opened when open and its target is `aria-disabled`', async () => {
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(defaultSlot?.checkVisibility()).to.be.false;
   expect(target?.ariaExpanded).to.equal('false');
@@ -528,7 +529,7 @@ it('shows loading feedback when open', async () => {
     ?.querySelector('glide-core-options')
     ?.shadowRoot?.querySelector('[data-test="loading-feedback"]');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(target?.ariaDescription).to.equal('Loading');
   expect(feedback?.checkVisibility()).to.be.true;

--- a/src/menu.test.events.ts
+++ b/src/menu.test.events.ts
@@ -12,6 +12,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { click } from './library/mouse.js';
 import Menu from './menu.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('dispatches a "click" event when an Option is selected via mouse', async () => {
   const host = await fixture<Menu>(
@@ -29,7 +30,7 @@ it('dispatches a "click" event when an Option is selected via mouse', async () =
 
   option?.addEventListener('click', spy);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   click(option);
 
   const event = await oneEvent(host, 'click');
@@ -57,7 +58,7 @@ it('dispatches a "click" event when an Option is selected via Space', async () =
 
   option?.addEventListener('click', spy);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   sendKeys({ press: ' ' });
 
@@ -87,7 +88,7 @@ it('dispatches a "click" event when an Option is selected via Enter', async () =
 
   option?.addEventListener('click', spy);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   sendKeys({ press: 'Enter' });
 
@@ -115,7 +116,7 @@ it('does not dispatch a "click" event when a disabled Option is selected via mou
   const spy = sinon.spy();
   const option = host.querySelector('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   option?.addEventListener('click', spy);
   await click(option);
 
@@ -139,7 +140,7 @@ it('does not dispatch a "click" event when a disabled Option is focused then sel
 
   host.addEventListener('click', spy);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   options[0]?.focus();
   await sendKeys({ press: ' ' });
 
@@ -163,7 +164,7 @@ it('does not dispatch a "click" event when a disabled Option is focused then sel
 
   host.addEventListener('click', spy);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   options[0]?.focus();
   await sendKeys({ press: 'Enter' });
 
@@ -194,7 +195,7 @@ it('does not let sub-Menu target "click" events propagate', async () => {
 
   host.querySelector('glide-core-options')?.addEventListener('click', spy);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(targets[1]);
 
   expect(spy.callCount).to.equal(0);
@@ -221,7 +222,7 @@ it('cancels "click" events that come from a sub-Menu target whose parent Option 
 
   const targets = host.querySelectorAll('button');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   click(targets[1]);
 
   assert(targets[1]);

--- a/src/menu.test.focus.ts
+++ b/src/menu.test.focus.ts
@@ -1,8 +1,9 @@
 import './option.js';
 import './options.js';
-import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import Menu from './menu.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('closes when it loses focus', async () => {
   const host = await fixture<Menu>(
@@ -54,9 +55,9 @@ it('remains open when Options is focused programatically', async () => {
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   host.querySelector('glide-core-options')?.focus();
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(host.open).to.be.true;
   expect(target?.ariaExpanded).to.equal('true');
@@ -88,9 +89,9 @@ it('remains open when an Option is focused programmatically', async () => {
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   options[0]?.focus();
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(host.open).to.be.true;
   expect(target?.ariaExpanded).to.equal('true');
@@ -123,7 +124,7 @@ it('remains open when arbitrary content in its default slot is focused via keybo
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' }); // Target
   await sendKeys({ press: 'Tab' }); // Button
 
@@ -152,7 +153,7 @@ it('sets an Option as active when the Option is focused programmatically', async
 
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   options[1]?.focus();
   await host.updateComplete;
 
@@ -180,7 +181,7 @@ it('focuses its target on Enter after an Option is focused programmatically', as
   const target = host.querySelector('button');
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   options[0]?.focus();
   await sendKeys({ press: 'Enter' });
 
@@ -201,7 +202,7 @@ it('focuses its target on Space after an Option is focused programmatically', as
   const target = host.querySelector('button');
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   options[0]?.focus();
   await sendKeys({ press: ' ' });
 
@@ -222,7 +223,7 @@ it('focuses its target on Escape after an Option is focused programmatically', a
   const target = host.querySelector('button');
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   options[0]?.focus();
   await sendKeys({ press: 'Escape' });
 
@@ -272,7 +273,7 @@ it('focuses the parent Option of a sub-Menu on Escape after a sub-Menu Option wa
 
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   options[1]?.focus();
   await sendKeys({ press: 'Escape' });
 

--- a/src/menu.test.interactions.filterable.ts
+++ b/src/menu.test.interactions.filterable.ts
@@ -7,6 +7,7 @@ import './option.js';
 import './input.js';
 import './button.js';
 import Tooltip from './tooltip.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('opens on "input"', async () => {
   const host = await fixture<Menu>(
@@ -139,7 +140,7 @@ it('allows the insertion point to move on ArrowRight when not opening a sub-Menu
     .querySelector('[slot="target"]')
     ?.shadowRoot?.querySelector<HTMLInputElement>('[data-test="input"]');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'test' });
 
@@ -171,7 +172,7 @@ it('allows the insertion point to move on ArrowLeft when not closing a sub-Menu'
     </glide-core-menu>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'test' });
   await sendKeys({ press: 'ArrowLeft' }); // One
@@ -220,7 +221,7 @@ it('allows the insertion point to move on ArrowUp when its first Option or the f
     .querySelector('[slot="target"]')
     ?.shadowRoot?.querySelector<HTMLInputElement>('[data-test="input"]');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'test' });
   await sendKeys({ press: 'ArrowUp' }); // One
@@ -279,7 +280,7 @@ it('allows the insertion point to move on ArrowDown when its last Option of the 
     .querySelector('[slot="target"]')
     ?.shadowRoot?.querySelector<HTMLInputElement>('[data-test="input"]');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'test' });
 
@@ -341,7 +342,7 @@ it('does not allow the insertion point to move on ArrowRight when opening a sub-
     .querySelector('[slot="target"]')
     ?.shadowRoot?.querySelector<HTMLInputElement>('[data-test="input"]');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'test' });
 
@@ -389,7 +390,7 @@ it('does not allow the insertion point to move on ArrowLeft when closing a sub-M
     .querySelector('[slot="target"]')
     ?.shadowRoot?.querySelector<HTMLInputElement>('[data-test="input"]');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'test' });
   await sendKeys({ press: 'ArrowLeft' }); // Two
@@ -439,7 +440,7 @@ it('does not allow the insertion point to move on ArrowUp when the first Option 
     .querySelector('[slot="target"]')
     ?.shadowRoot?.querySelector<HTMLInputElement>('[data-test="input"]');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'test' });
   await sendKeys({ press: 'ArrowDown' }); // Six
@@ -503,7 +504,7 @@ it('does not allow the insertion point to move on ArrowDown when the last Option
     .querySelector('[slot="target"]')
     ?.shadowRoot?.querySelector<HTMLInputElement>('[data-test="input"]');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'test' });
 

--- a/src/menu.test.interactions.ts
+++ b/src/menu.test.interactions.ts
@@ -12,6 +12,7 @@ import {
 } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import { sendKeys } from '@web/test-runner-commands';
+import requestIdleCallback from './library/request-idle-callback.js';
 import { click, hover } from './library/mouse.js';
 import Menu from './menu.js';
 import './option.js';
@@ -106,7 +107,7 @@ it('opens when opened programmatically', async () => {
     .filter((element): element is Tooltip => element instanceof Tooltip);
 
   host.open = true;
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(host.open).to.be.true;
   expect(target?.ariaExpanded).to.equal('true');
@@ -150,7 +151,7 @@ it('remains open when the edge of its default slot or the edge of its sub-Menu d
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(defaultSlots[0], 'left');
 
   expect(hosts[0]?.open).to.be.true;
@@ -168,7 +169,7 @@ it('remains open when the edge of its default slot or the edge of its sub-Menu d
       ?.getAttribute('aria-activedescendant'),
   ).to.equal(options[0]?.id);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(defaultSlots[1], 'left');
 
   expect(hosts[0]?.open).to.be.true;
@@ -229,23 +230,8 @@ it('remains open when its sub-Menus are opened via click', async () => {
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
-
-  // A programmatic click instead of an actual one because `sendMouse()` (via
-  // `mouse.ts`) turned out to be flaky in CI.
-  //
-  // After a bunch of experimentation and source code digging, the ultimate cause of
-  // the `sendMouse()` flakiness isn't clear. The immediate cause seems to be
-  // that it clicks an Option or an element outside Menu instead of the target,
-  // causing Menu to close. Though it only happens when nested popovers are present
-  // via sub-Menus.
-  //
-  // `sendMouse()` is just a thin abstraction over Playwright's equivalent API. So
-  // the ultimate cause is likely Playwright or Chromium's DevTools Protocol, which
-  // Playwright relies on. It's that or I'm missing something obvious. Either way,
-  // it was time to move on.
-  targets[1]?.click();
-
+  await requestIdleCallback(); // Wait for Floating UI
+  await click(targets[1]);
   await aTimeout(0); // Wait for the timeout in `#onTargetSlotClick()`
 
   expect(hosts[0]?.open).to.be.true;
@@ -258,7 +244,7 @@ it('remains open when its sub-Menus are opened via click', async () => {
       ?.getAttribute('aria-activedescendant'),
   ).to.equal(options[0]?.id);
 
-  targets[2]?.click();
+  await click(targets[2]);
   await aTimeout(0); // Wait for the timeout in `#onTargetSlotClick()`
 
   expect(hosts[0]?.open).to.be.true;
@@ -302,7 +288,7 @@ it('remains open when a disabled Option is clicked via `click()`', async () => {
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   options[0]?.click();
 
   expect(host.open).to.be.true;
@@ -335,7 +321,7 @@ it('remains open when a disabled Option is clicked via `sendMouse()`', async () 
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
 
   expect(host.open).to.be.true;
@@ -371,7 +357,7 @@ it('remains open when an Option is clicked and the event is canceled at the Opti
     event.preventDefault();
   });
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(option);
 
   expect(host.open).to.be.true;
@@ -434,7 +420,7 @@ it('remains open when an Option is clicked and the event is canceled at Options'
       event.preventDefault();
     });
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(option);
 
   expect(host.open).to.be.true;
@@ -495,7 +481,7 @@ it('remains open when its target is clicked and the event is canceled at its tar
     event.preventDefault();
   });
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(target);
 
   expect(host.open).to.be.true;
@@ -531,7 +517,7 @@ it('remains open when its target is clicked and the event is canceled at its hos
     event.preventDefault();
   });
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(target);
 
   expect(host.open).to.be.true;
@@ -567,7 +553,7 @@ it('remains open when arbitrary content in its default slot is clicked', async (
 
   const content = host.querySelectorAll('button')[1];
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(content);
 
   expect(host.open).to.be.true;
@@ -663,7 +649,7 @@ it('closes when closed programmatically', async () => {
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   host.open = false;
   await host.updateComplete;
 
@@ -1145,7 +1131,7 @@ it('opens its sub-Menus on ArrowRight', async () => {
     .map((option) => option.shadowRoot?.querySelector('[data-test="tooltip"]'))
     .filter((element): element is Tooltip => element instanceof Tooltip);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowRight' });
 
@@ -1378,7 +1364,7 @@ it('opens its sub-Menus when its sub-Menu targets are clicked', async () => {
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   // A programmatic click instead of an actual one because `sendMouse()` (via
   // `mouse.ts`) turned out to be flaky in CI.
@@ -1431,7 +1417,7 @@ it('opens its sub-Menus when its sub-Menu targets are clicked', async () => {
       ?.getAttribute('aria-activedescendant'),
   ).to.be.empty.string;
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   targets[2]?.click();
   await aTimeout(0); // Wait for the timeout in `#onTargetSlotClick()`
 
@@ -1487,7 +1473,7 @@ it('closes when its target is clicked', async () => {
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(target);
 
   expect(host.open).to.be.false;
@@ -1513,7 +1499,7 @@ it('closes when in another component and its target clicked', async () => {
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(target);
 
   expect(menu?.open).to.be.false;
@@ -1540,7 +1526,7 @@ it('closes when in another component and an Option is clicked', async () => {
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(option);
 
   expect(menu?.open).to.be.false;
@@ -1591,7 +1577,7 @@ it('closes itself and its sub-Menus when something outside of it is clicked', as
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(document.body);
 
   expect(hosts[0]?.open).to.be.false;
@@ -1666,23 +1652,8 @@ it('closes its sub-Menus when their targets are clicked', async () => {
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
-
-  // A programmatic click instead of an actual one because `sendMouse()` (via
-  // `mouse.ts`) turned out to be flaky in CI.
-  //
-  // After a bunch of experimentation and source code digging, the ultimate cause of
-  // the `sendMouse()` flakiness isn't clear. The immediate cause seems to be
-  // that it clicks an Option or an element outside Menu instead of the target,
-  // causing Menu to close. Though it only happens when nested popovers are present
-  // via sub-Menus.
-  //
-  // `sendMouse()` is just a thin abstraction over Playwright's equivalent API. So
-  // the ultimate cause is likely Playwright or Chromium's DevTools Protocol, which
-  // Playwright relies on. It's that or I'm missing something obvious. Either way,
-  // it was time to move on.
-  targets[2]?.click();
-
+  await requestIdleCallback(); // Wait for Floating UI
+  await click(targets[2]);
   await aTimeout(0); // Wait for the timeout in `#onTargetSlotClick()`
 
   expect(hosts[0]?.open).to.be.true;
@@ -1719,8 +1690,8 @@ it('closes its sub-Menus when their targets are clicked', async () => {
       ?.getAttribute('aria-activedescendant'),
   ).to.be.empty.string;
 
-  await aTimeout(0); // Wait for Floating UI
-  targets[1]?.click();
+  await requestIdleCallback(); // Wait for Floating UI
+  await click(targets[1]);
   await aTimeout(0); // Wait for the timeout in `#onTargetSlotClick()`
 
   expect(hosts[0]?.open).to.be.true;
@@ -1795,7 +1766,7 @@ it('closes its nested sub-Menu when the super-Menu of the sub-Menu is closed', a
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(targets[1]);
 
   expect(hosts[0]?.open).to.be.true;
@@ -1876,7 +1847,7 @@ it('closes its sub-Menus and itself on Escape', async () => {
     .map((option) => option.shadowRoot?.querySelector('[data-test="tooltip"]'))
     .filter((element): element is Tooltip => element instanceof Tooltip);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Escape' });
 
@@ -2018,7 +1989,7 @@ it('closes on Escape when arbitrary content in its default slot has focus ', asy
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' }); // Target
   await sendKeys({ press: 'Tab' }); // Button
   await sendKeys({ press: 'Escape' });
@@ -2051,7 +2022,7 @@ it('closes when an Option is selected via click', async () => {
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.querySelector('glide-core-option'));
 
   expect(host.open).to.be.false;
@@ -2102,7 +2073,7 @@ it('closes when a sub-Menu Option is selected via click', async () => {
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[2]);
 
   expect(hosts[0]?.open).to.be.false;
@@ -2157,7 +2128,7 @@ it('closes when an Option is selected via Enter', async () => {
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Enter' });
 
@@ -2209,7 +2180,7 @@ it('closes when a sub-Menu Option is selected via Enter', async () => {
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Enter' });
 
@@ -2265,7 +2236,7 @@ it('closes when its target is a SPAN and an Option is selected via Enter', async
     '[data-test="default-slot"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Enter' });
 
@@ -2348,7 +2319,7 @@ it('closes when a sub-Menu Option is selected via Space', async () => {
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
 
@@ -2471,7 +2442,7 @@ it('closes its sub-Menus on ArrowLeft', async () => {
     .map((option) => option.shadowRoot?.querySelector('[data-test="tooltip"]'))
     .filter((element): element is Tooltip => element instanceof Tooltip);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowLeft' });
 
@@ -2596,7 +2567,7 @@ it('closes its tooltip when a sub-Menu target is hovered', async () => {
     }
   }
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[0]);
 
   // For whatever reason, there's a significant delay between hovering and
@@ -2654,7 +2625,7 @@ it('closes sibling sub-Menus when a new sub-Menu is opened', async () => {
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(targets[2]);
 
   expect(hosts[0]?.open).to.be.true;
@@ -2713,12 +2684,12 @@ it('closes child sub-Menus when the target of a super-Menu is disabled', async (
     ),
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   assert(targets[1]);
   targets[1].disabled = true;
 
-  await aTimeout(0); // Wait for the Mutation Observer
+  await requestIdleCallback(); // Wait for the Mutation Observer
 
   expect(hosts[0]?.open).to.be.true;
   expect(hosts[1]?.open).to.be.true;
@@ -2758,7 +2729,7 @@ it('is opened when open and `disabled` is set on its target programmatically', a
   assert(target);
   target.disabled = false;
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(host.open).to.be.true;
   expect(target?.ariaExpanded).to.equal('true');
@@ -2792,7 +2763,7 @@ it('is opened when open and `aria-disabled` is set on its target programmaticall
   assert(target);
   target.ariaDisabled = 'false';
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(host.open).to.be.true;
   expect(target?.ariaExpanded).to.equal('true');
@@ -2847,7 +2818,7 @@ it('activates its previously active Option when reopened', async () => {
   const target = host.querySelector('button');
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[1]);
   await click(target); // Close
   await click(target); // Reopen
@@ -2878,7 +2849,7 @@ it('activates its first Option when reopened and its previously active Option ha
   const target = host.querySelector('button');
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[2]);
   await click(target); // Close
 
@@ -2934,25 +2905,10 @@ it('activates the first Option(s) of its sub-Menus they are opened via click', a
   const targets = host.querySelectorAll('button');
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
-
-  // A programmatic click instead of an actual one because `sendMouse()` (via
-  // `mouse.ts`) turned out to be flaky in CI.
-  //
-  // After a bunch of experimentation and source code digging, the ultimate cause of
-  // the `sendMouse()` flakiness isn't clear. The immediate cause seems to be
-  // that it clicks an Option or an element outside Menu instead of the target,
-  // causing Menu to close. Though it only happens when nested popovers are present
-  // via sub-Menus.
-  //
-  // `sendMouse()` is just a thin abstraction over Playwright's equivalent API. So
-  // the ultimate cause is likely Playwright or Chromium's DevTools Protocol, which
-  // Playwright relies on. It's that or I'm missing something obvious. Either way,
-  // it was time to move on.
-  targets[1]?.click();
-
-  await aTimeout(0); // Wait for Floating UI
-  targets[2]?.click();
+  await requestIdleCallback(); // Wait for Floating UI
+  await click(targets[1]);
+  await requestIdleCallback(); // Wait for Floating UI
+  await click(targets[2]);
   await aTimeout(0); // Wait for the timeout in `#onTargetSlotClick()`
 
   expect(options[0]?.privateActive).to.be.true;
@@ -3008,7 +2964,7 @@ it('activates an Option on hover', async () => {
     }
   }
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[1]);
   await aTimeout(0); // Wait for Tooltip's `#onComponentMouseOver()`
 
@@ -3046,14 +3002,7 @@ it('does not open the tooltip of a super-Menu Option when one of its sub-Menu Op
     </glide-core-menu>`,
   );
 
-  const hosts = [host, ...host.querySelectorAll('glide-core-menu')];
   const options = host.querySelectorAll('glide-core-option');
-
-  const defaultSlots = hosts.map((host) =>
-    host.shadowRoot?.querySelector<HTMLSlotElement>(
-      '[data-test="default-slot"]',
-    ),
-  );
 
   const tooltips = [...options]
     .map((option) => option.shadowRoot?.querySelector('[data-test="tooltip"]'))
@@ -3068,14 +3017,7 @@ it('does not open the tooltip of a super-Menu Option when one of its sub-Menu Op
     }
   }
 
-  // Replaces the usual `await aTimeout(0)`. It's not clear why. But Menus opening
-  // in tests sometimes takes more than a tick when sub-Menus are present.
-  await waitUntil(() => {
-    return (
-      defaultSlots[0]?.checkVisibility() && defaultSlots[1]?.checkVisibility()
-    );
-  });
-
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[1]);
 
   // For whatever reason, there's a significant delay between hovering and
@@ -3110,7 +3052,7 @@ it('retains its active Option when a sub-Menu Option is hovered', async () => {
   const hosts = [host, ...host.querySelectorAll('glide-core-menu')];
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[3]);
   await hover(options[2]);
 
@@ -3145,7 +3087,7 @@ it('activates Options on hover when all or some are in a nested slot', async () 
     host.shadowRoot?.querySelector('glide-core-option'),
   ];
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[1]);
 
   expect(options[0]?.privateActive).to.be.false;
@@ -3191,7 +3133,7 @@ it('activates Options on hover when they are in Options Groups', async () => {
   `);
 
   const options = host.querySelectorAll('glide-core-option');
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[1]);
 
   expect(options[0]?.privateActive).to.be.false;
@@ -3273,7 +3215,7 @@ it('activates the next enabled Option on ArrowDown', async () => {
     </glide-core-menu>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' });
 
@@ -3439,20 +3381,7 @@ it('activates the next sub-Menu Option on ArrowDown after an Option of another M
   const hosts = [host, ...host.querySelectorAll('glide-core-menu')];
   const options = host.querySelectorAll('glide-core-option');
 
-  const defaultSlots = hosts.map((host) =>
-    host.shadowRoot?.querySelector<HTMLSlotElement>(
-      '[data-test="default-slot"]',
-    ),
-  );
-
-  // Replaces the usual `await aTimeout(0)`. It's not clear why. But Menus opening
-  // in tests sometimes takes more than a tick when sub-Menus are present.
-  await waitUntil(() => {
-    return (
-      defaultSlots[0]?.checkVisibility() && defaultSlots[1]?.checkVisibility()
-    );
-  });
-
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[3]); // Four
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // Three
@@ -3544,7 +3473,7 @@ it('activates the next enabled Option on ArrowUp', async () => {
     .map((option) => option.shadowRoot?.querySelector('[data-test="tooltip"]'))
     .filter((element): element is Tooltip => element instanceof Tooltip);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' });
   await sendKeys({ press: 'ArrowUp' });
@@ -3728,7 +3657,7 @@ it('activates the first enabled Option on Home', async () => {
     .map((option) => option.shadowRoot?.querySelector('[data-test="tooltip"]'))
     .filter((element): element is Tooltip => element instanceof Tooltip);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'End' });
   await sendKeys({ press: 'Home' });
@@ -3912,7 +3841,7 @@ it('activates the first enabled Option on PageUp', async () => {
     .map((option) => option.shadowRoot?.querySelector('[data-test="tooltip"]'))
     .filter((element): element is Tooltip => element instanceof Tooltip);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'PageDown' });
   await sendKeys({ press: 'PageUp' });
@@ -4096,7 +4025,7 @@ it('activates the first enabled Option on Meta + ArrowUp', async () => {
     .map((option) => option.shadowRoot?.querySelector('[data-test="tooltip"]'))
     .filter((element): element is Tooltip => element instanceof Tooltip);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'End' });
   await sendKeys({ down: 'Meta' });
@@ -4291,7 +4220,7 @@ it('activates the last enabled Option on End', async () => {
     .map((option) => option.shadowRoot?.querySelector('[data-test="tooltip"]'))
     .filter((element): element is Tooltip => element instanceof Tooltip);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'End' });
 
@@ -4477,7 +4406,7 @@ it('activates the last enabled Option on PageDown', async () => {
     .map((option) => option.shadowRoot?.querySelector('[data-test="tooltip"]'))
     .filter((element): element is Tooltip => element instanceof Tooltip);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'PageDown' });
 
@@ -4663,7 +4592,7 @@ it('activates the last enabled Option on Meta + ArrowDown', async () => {
     .map((option) => option.shadowRoot?.querySelector('[data-test="tooltip"]'))
     .filter((element): element is Tooltip => element instanceof Tooltip);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ down: 'Meta' });
   await sendKeys({ press: 'ArrowDown' });
@@ -4808,7 +4737,7 @@ it('does not wrap on ArrowUp', async () => {
 
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowUp' });
 
@@ -4836,7 +4765,7 @@ it('does not wrap on ArrowDown', async () => {
 
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // Two
   await sendKeys({ press: 'ArrowDown' }); // Two
@@ -4873,7 +4802,7 @@ it('sets the first enabled Option as active when Optionless and Options are adde
   host.querySelector('glide-core-options')?.append(secondOption);
   host.querySelector('glide-core-options')?.append(thirdOption);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await host.updateComplete;
   await secondOption.updateComplete;
 
@@ -4903,7 +4832,7 @@ it('sets the next enabled Option as active when the active Option is disabled pr
 
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   assert(options[0]);
   options[0].disabled = true;
@@ -4935,7 +4864,7 @@ it('sets the previously enabled Option as active when current Option is disabled
 
   const options = host.querySelectorAll('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[2]);
 
   assert(options[2]);
@@ -4965,7 +4894,7 @@ it('retains its active Option when an Option is programmatically added', async (
     </glide-core-menu>
   `);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(host.querySelector('glide-core-option:last-of-type'));
 
   const button = document.createElement('glide-core-option');
@@ -5025,7 +4954,7 @@ it('has limited keyboard functionality when loading', async () => {
   assert(hosts[1]);
   assert(hosts[2]);
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Escape' });
 
@@ -5108,7 +5037,7 @@ it('shows loading feedback', async () => {
     </glide-core-menu>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.loading = true;
   await host.updateComplete;
@@ -5134,7 +5063,7 @@ it('hides loading feedback', async () => {
     </glide-core-menu>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.loading = false;
   await host.updateComplete;


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> 
> Menu no longer activates the wrong Option on open when Menu's [containing block](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Containing_block#identifying_the_containing_block) isn't the document.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to Menu 's Overview page in Storybook.
2. Place your mouse just above Menu's target.
4. Tab to Menu's target.
5. Press Space to open Menu.
6. Verify the first Option is active.

As an aside, the reason the issue was reproducible in Storybook is because Storybook wraps our components in a `<div>` that's styled with `transform: scale(1)`—giving Menu a containing block that's something other than the document.

You'll no longer be able to reproduce the issue on [`main`](https://glide-core.crowdstrike-ux.workers.dev/main?path=/docs/menu--overview) if remove `transform: scale(1)` from that `<div>`.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
