### PR TITLE
Accordion: Prevent prefix icon from shrinking at narrow widths

### DIFF
--- a/.changeset/seven-teachers-repair.md
+++ b/.changeset/seven-teachers-repair.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+SVGs placed in the `prefix-icon` slot of an Accordion will no longer shrink at narrow widths.

--- a/src/accordion.styles.ts
+++ b/src/accordion.styles.ts
@@ -95,6 +95,13 @@ export default [
       }
     }
 
+    .prefix-icon-slot {
+      &.slotted-content {
+        align-items: center;
+        display: flex;
+      }
+    }
+
     .suffix-icons-slot {
       align-items: center;
       color: var(--glide-core-color-interactive-icon-link);

--- a/src/accordion.ts
+++ b/src/accordion.ts
@@ -184,7 +184,10 @@ export default class Accordion extends LitElement {
 
         <div class="label-container">
           <slot
-            class="prefix-icon-slot"
+            class=${classMap({
+              'prefix-icon-slot': true,
+              'slotted-content': this.hasPrefixIcon,
+            })}
             name="prefix-icon"
             @slotchange=${this.#onPrefixIconSlotChange}
             ${ref(this.#prefixIconSlotElementRef)}


### PR DESCRIPTION
## 🚀 Description

Wraps the Accordion prefix icon slot in a flex container, to prevent slotted SVGs from shrinking at narrow widths.

## Before

<img width="762" height="118" alt="image" src="https://github.com/user-attachments/assets/8145188f-37a1-4b52-8283-d1da3549efa5" />

## After

<img width="776" height="122" alt="image" src="https://github.com/user-attachments/assets/c0278f37-ace4-48a0-923b-f9232139b2ac" />


## 🔬 How to Test

- Visit Accordion Icons story: https://glide-core.crowdstrike-ux.workers.dev/prevent-accordion-svg-shrinking?path=/story/accordion--with-icons.
- Add a bunch of text to the `label` and narrow the viewport until the text starts to truncate.
- Change the `prefix-icon` slot's slotted `<glide-core-example-icon>` to `display: contents;` (effectively simulates putting the `<svg>` directly into the slot).
- Validate that the icon does not shrink.
- To test the failing case, remove `display: flex;` from the parent `.prefix-icon-slot` slot element.