### PR TITLE
Remove Popover support for setting `open` in a certain case

### DIFF
--- a/.changeset/afraid-buckets-crash.md
+++ b/.changeset/afraid-buckets-crash.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Popover can no longer be opened by setting its `open` attribute via the "click" handler of an element outside Popover. If you need Popover to open this way, you can call `click()` on Popover's target in that handler.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 ### Minor Changes
 
 - [#986](https://github.com/CrowdStrike/glide-core/pull/986) [`9ab18b1`](https://github.com/CrowdStrike/glide-core/commit/9ab18b116fec75f55f5d50eda624e5c72b59e0cf) Thanks [@clintcs](https://github.com/clintcs)! - Menu can no longer be opened by setting its `open` attribute via the "click" handler of an element outside Menu.
-  If you need to open this way, you can call `click()` on Menu's target in your handler.
+  If you need Menu to open this way, you can call `click()` on Menu's target in that handler.
   This change was made to support the ability to open sub-Menu targets programmatically by calling `click()`.
 
 ### Patch Changes

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -4715,6 +4715,7 @@
                 "text": "| 'bottom'\n    | 'left'\n    | 'right'\n    | 'top'\n    | 'bottom-start'\n    | 'bottom-end'\n    | 'left-start'\n    | 'left-end'\n    | 'right-start'\n    | 'right-end'\n    | 'top-start'\n    | 'top-end'"
               },
               "default": "'bottom-start'",
+              "description": "Menu will try to move itself to the opposite of this value if not doing so would result in overflow.\nFor example, if \"bottom\" results in overflow Menu will try \"top\" but not \"right\" or \"left\".",
               "attribute": "placement",
               "reflects": true
             },
@@ -4777,6 +4778,7 @@
                 "text": "| 'bottom'\n    | 'left'\n    | 'right'\n    | 'top'\n    | 'bottom-start'\n    | 'bottom-end'\n    | 'left-start'\n    | 'left-end'\n    | 'right-start'\n    | 'right-end'\n    | 'top-start'\n    | 'top-end'"
               },
               "default": "'bottom-start'",
+              "description": "Menu will try to move itself to the opposite of this value if not doing so would result in overflow.\nFor example, if \"bottom\" results in overflow Menu will try \"top\" but not \"right\" or \"left\".",
               "fieldName": "placement"
             },
             {
@@ -5863,7 +5865,7 @@
           "slots": [
             {
               "name": "target",
-              "description": "The element to which the popover will anchor. Can be any focusable element.",
+              "description": "The element to which Popover will anchor. Can be any focusable element.",
               "type": {
                 "text": "Element"
               }
@@ -5922,6 +5924,7 @@
               "type": {
                 "text": "'bottom' | 'left' | 'right' | 'top' | undefined"
               },
+              "description": "Popover will try to move itself to the opposite of this value if not doing so would result in overflow.\nFor example, if \"bottom\" results in overflow Popover will try \"top\" but not \"right\" or \"left\".",
               "attribute": "placement"
             },
             {
@@ -5973,6 +5976,7 @@
               "type": {
                 "text": "'bottom' | 'left' | 'right' | 'top' | undefined"
               },
+              "description": "Popover will try to move itself to the opposite of this value if not doing so would result in overflow.\nFor example, if \"bottom\" results in overflow Popover will try \"top\" but not \"right\" or \"left\".",
               "fieldName": "placement"
             },
             {
@@ -9769,7 +9773,7 @@
           "slots": [
             {
               "name": "target",
-              "description": "The element to which the tooltip will anchor. Can be any element with an implicit or explicit ARIA role.",
+              "description": "The element to which Tooltip will anchor. Can be any interactive element with an implicit or explicit ARIA role.",
               "required": {
                 "tag": "required",
                 "name": "",
@@ -9876,7 +9880,7 @@
               "type": {
                 "text": "'bottom' | 'left' | 'right' | 'top' | undefined"
               },
-              "description": "The placement of the tooltip relative to its target. Automatic placement will\ntake over if the tooltip is cut off by the viewport.",
+              "description": "Tooltip will try to move itself to the opposite of this value if not doing so would result in overflow.\nFor example, if \"bottom\" results in overflow Tooltip will try \"top\" but not \"right\" or \"left\".",
               "attribute": "placement",
               "reflects": true
             },
@@ -9966,7 +9970,7 @@
               "type": {
                 "text": "'bottom' | 'left' | 'right' | 'top' | undefined"
               },
-              "description": "The placement of the tooltip relative to its target. Automatic placement will\ntake over if the tooltip is cut off by the viewport.",
+              "description": "Tooltip will try to move itself to the opposite of this value if not doing so would result in overflow.\nFor example, if \"bottom\" results in overflow Tooltip will try \"top\" but not \"right\" or \"left\".",
               "fieldName": "placement"
             },
             {

--- a/src/link.ts
+++ b/src/link.ts
@@ -60,6 +60,9 @@ export default class Link extends LitElement {
   }
 
   override render() {
+    // Lit-a11y also wants a keyboard listener on anything with a "click" listener and
+    // doesn't account for `role="link"`.
+    //
     /* eslint-disable lit-a11y/click-events-have-key-events */
     return this.disabled
       ? html`<span

--- a/src/menu.stories.ts
+++ b/src/menu.stories.ts
@@ -124,7 +124,7 @@ const meta: Meta = {
         defaultValue: { summary: '"bottom-start"' },
         type: {
           summary:
-            '"bottom" | "left" | "right" | "top" | "bottom-start" | "bottom-end" | "left-start" | "left-end" | "right-start" | "right-end" | "top-start"| "top-end"',
+            '"bottom" | "left" | "right" | "top" | "bottom-start" | "bottom-end" | "left-start" | "left-end" | "right-start" | "right-end" | "top-start" | "top-end"',
         },
       },
     },

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -24,7 +24,7 @@ declare global {
  * @attr {boolean} [loading=false]
  * @attr {number} [offset=4]
  * @attr {boolean} [open=false]
- * @attr {'bottom'|'left'|'right'|'top'|'bottom-start'|'bottom-end'|'left-start'|'left-end'|'right-start'|'right-end'|'top-start'|'top-end'} [placement='bottom-start']
+ * @attr {'bottom'|'left'|'right'|'top'|'bottom-start'|'bottom-end'|'left-start'|'left-end'|'right-start'|'right-end'|'top-start'|'top-end'} [placement='bottom-start'] - Menu will try to move itself to the opposite of this value if not doing so would result in overflow. For example, if "bottom" results in overflow Menu will try "top" but not "right" or "left".
  *
  * @readonly
  * @attr {string} [version]
@@ -113,6 +113,10 @@ export default class Menu extends LitElement {
     }
   }
 
+  /**
+   * Menu will try to move itself to the opposite of this value if not doing so would result in overflow.
+   * For example, if "bottom" results in overflow Menu will try "top" but not "right" or "left".
+   */
   @property({ reflect: true, useDefault: true })
   placement:
     | 'bottom'
@@ -220,7 +224,7 @@ export default class Menu extends LitElement {
     }
 
     if (this.#defaultSlotElementRef.value) {
-      // `popover` so Options can break out of Modal or another container that has
+      // `popover` so Options can break out of Modal or another element that has
       // `overflow: hidden`. Elements with `popover` are positioned relative to the
       // viewport. Thus Floating UI in addition to `popover` until anchor positioning is
       // well supported.
@@ -323,7 +327,7 @@ export default class Menu extends LitElement {
   // `#onTargetAndDefaultSlotKeyDown()` to decide if we need to move focus.
   #hasVoiceOverMovedFocusToOptionsOrAnOption = false;
 
-  // Set in `#onDefaultSlotMouseUp()`. Used in `#onDocumentClick()` to guard against
+  // Set in `#onDefaultSlotClick()`. Used in `#onDocumentClick()` to guard against
   // Menu closing when any number of things that are not an Option are clicked. Those
   // "click" events will be retargeted to Menu's host the moment they bubble out of
   // Menu. So checking in `#onDocumentClick()` if the click's `event.target` came

--- a/src/popover.stories.ts
+++ b/src/popover.stories.ts
@@ -81,7 +81,7 @@ const meta: Meta = {
         type: {
           summary: 'Element',
           detail:
-            '// The element to which the popover will anchor. Can be any focusable element',
+            '// The element to which Popover will anchor. Can be any focusable element.',
         },
       },
       type: { name: 'function', required: true },
@@ -129,7 +129,7 @@ const meta: Meta = {
         type: {
           summary: '"top" | "right" | "bottom" | "left"',
           detail:
-            '// The popover will try to move itself to the opposite of this value if not doing so would result in\n// overflow. For example, if "bottom" results in overflow Popover will try "top" but not "right"\n// or "left".',
+            '// Popover will try to move itself to the opposite of this value if not doing so would result in\n// overflow. For example, if "bottom" results in overflow Popover will try "top" but not "right"\n// or "left".',
         },
       },
     },

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -452,6 +452,7 @@ export default class Slider extends LitElement implements FormControl {
     // input elements directly or via the handles. Exposing the
     // track via keyboard wouldn't bring any real value in this
     // instance.
+    //
     /*  eslint-disable lit-a11y/click-events-have-key-events */
     return html`
       <glide-core-private-label

--- a/src/tooltip.stories.ts
+++ b/src/tooltip.stories.ts
@@ -78,7 +78,7 @@ const meta: Meta = {
         type: {
           summary: 'Element',
           detail:
-            '// The element to which the tooltip will anchor. Can be any element with an implicit or explicit ARIA role.',
+            '// The element to which Tooltip will anchor. Can be any interactive element with an implicit or explicit\n// ARIA role.',
         },
       },
       type: { name: 'function', required: true },
@@ -132,7 +132,7 @@ const meta: Meta = {
         type: {
           summary: '"top" | "right" | "bottom" | "left"',
           detail:
-            '// The tooltip will try to move itself to the opposite of this value if not doing so would result in\n// overflow. For example, if "bottom" results in overflow Tooltip will try "top" but not "right"\n// or "left".',
+            '// Tooltip will try to move itself to the opposite of this value if not doing so would result in\n// overflow. For example, if "bottom" results in overflow Tooltip will try "top" but not "right"\n// or "left".',
         },
       },
     },

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -33,7 +33,7 @@ declare global {
  * @attr {boolean} [disabled=false]
  * @attr {number} [offset=4]
  * @attr {boolean} [open=false]
- * @attr {'bottom'|'left'|'right'|'top'} [placement] - The placement of the tooltip relative to its target. Automatic placement will take over if the tooltip is cut off by the viewport.
+ * @attr {'bottom'|'left'|'right'|'top'} [placement] - Tooltip will try to move itself to the opposite of this value if not doing so would result in overflow. For example, if "bottom" results in overflow Tooltip will try "top" but not "right" or "left".
  * @attr {boolean} [screenreader-hidden=false]
  * @attr {string[]} [shortcut=[]]
  *
@@ -41,7 +41,7 @@ declare global {
  * @attr {string} [version]
  *
  * @slot {TooltipContainer} [private]
- * @slot {Element} target - The element to which the tooltip will anchor. Can be any element with an implicit or explicit ARIA role.
+ * @slot {Element} target - The element to which Tooltip will anchor. Can be any interactive element with an implicit or explicit ARIA role.
  *
  * @fires {Event} toggle
  */
@@ -183,8 +183,8 @@ export default class Tooltip extends LitElement {
   }
 
   /**
-   * The placement of the tooltip relative to its target. Automatic placement will
-   * take over if the tooltip is cut off by the viewport.
+   * Tooltip will try to move itself to the opposite of this value if not doing so would result in overflow.
+   * For example, if "bottom" results in overflow Tooltip will try "top" but not "right" or "left".
    */
   @property({ reflect: true })
   placement?: 'bottom' | 'left' | 'right' | 'top';
@@ -249,18 +249,18 @@ export default class Tooltip extends LitElement {
 
   override firstUpdated() {
     if (this.#tooltipElementRef.value) {
-      // `popover` is used so the tooltip can break out of Modal or another container
-      // that has `overflow: hidden`. And elements with `popover` are positioned
-      // relative to the viewport. Thus Floating UI in addition to `popover`.
+      // `popover` so Tooltip can break out of Modal or another element that has
+      // `overflow: hidden`. Elements with `popover` are positioned relative to the
+      // viewport. Thus Floating UI in addition to `popover` until anchor positioning is
+      // well supported.
       //
-      // Set here instead of in the template to escape Lit Analyzer, which isn't aware
-      // of `popover` and doesn't have a way to disable its "no-unknown-attribute" rule.
+      // "manual" is set here instead of in the template to circumvent Lit Analyzer,
+      // which isn't aware of `popover` and doesn't provide a way to disable its
+      // "no-unknown-attribute" rule.
       //
-      // "auto" means only one popover can be open at a time. Consumers, however, may
-      // have popovers in own components that need to be open while this one is open.
-      //
-      // "auto" also automatically opens the popover when its target is clicked. We
-      // only want it to open on hover or focus.
+      // "manual" instead of "auto" because the latter only allows one popover to be open
+      // at a time. And consumers may have other popovers that need to remain open while
+      // this popover is open.
       this.#tooltipElementRef.value.popover = 'manual';
     }
 
@@ -307,8 +307,8 @@ export default class Tooltip extends LitElement {
             ${ref(this.#targetSlotElementRef)}
           >
             <!--
-              The element to which the tooltip will anchor.
-              Can be any element with an implicit or explicit ARIA role.
+              The element to which Tooltip will anchor.
+              Can be any interactive element with an implicit or explicit ARIA role.
 
               @required
               @type {Element}

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -124,7 +124,7 @@ export default {
 
   // If a test suite takes longer than this, it's almost certainly hanging and
   // won't finish. 2 minutes is the default.
-  testsFinishTimeout: process.env.CI ? 120_000 : 60_000,
+  testsFinishTimeout: process.env.CI ? 180_000 : 60_000,
 
   testRunnerHtml(testFramework) {
     return `<html>


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> 
> Popover can no longer be opened by setting its `open` attribute via the "click" handler of an element outside Popover. If you need Popover to open this way, you can call `click()` on Popover's target in that handler.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

Not much to test unless you want to verify that setting `open` in some handler no longer works.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
