### PR TITLE
Replace `aTimeout()` with `requestIdleCallback()`

### DIFF
--- a/src/dropdown.option.test.events.ts
+++ b/src/dropdown.option.test.events.ts
@@ -1,7 +1,8 @@
-import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import sinon from 'sinon';
 import DropdownOption from './dropdown.option.js';
 import { hover } from './library/mouse.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('dispatches a "private-label-change" event', async () => {
   const host = await fixture<DropdownOption>(
@@ -64,8 +65,7 @@ it('does not allow its "toggle" event to propagate', async () => {
   await hover(host);
   host.privateIsTooltipOpen = true;
 
-  // Wait for the Resize Observer to do its thing.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for the Resize Observer
 
   expect(spy.callCount).to.equal(0);
 });

--- a/src/dropdown.test.basics.multiple.ts
+++ b/src/dropdown.test.basics.multiple.ts
@@ -3,6 +3,7 @@ import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
 import Dropdown from './dropdown.js';
 import Tag from './tag.js';
 import type DropdownOption from './dropdown.option.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('is accessible', async () => {
   const host = await fixture<Dropdown>(
@@ -89,7 +90,7 @@ it('shows Select All', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const selectAll = host.shadowRoot?.querySelector<DropdownOption>(
     '[data-test="select-all"]',

--- a/src/dropdown.test.basics.single.ts
+++ b/src/dropdown.test.basics.single.ts
@@ -1,6 +1,7 @@
-import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import Dropdown from './dropdown.js';
 import type DropdownOption from './dropdown.option.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('is accessible ', async () => {
   const host = await fixture<Dropdown>(
@@ -251,7 +252,7 @@ it('only shows the last selected option as selected when multiple are selected i
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 

--- a/src/dropdown.test.basics.ts
+++ b/src/dropdown.test.basics.ts
@@ -1,10 +1,11 @@
-import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import sinon from 'sinon';
 import { customElement } from 'lit/decorators.js';
 import Dropdown from './dropdown.js';
 import './dropdown.option.js';
 import expectWindowError from './library/expect-window-error.js';
 import type Tooltip from './tooltip.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 // You'll notice quite a few duplicated tests among the "*.single.ts",
 // "*.multiple.ts", and "*.filterable.ts" test suites. The thinking is that
@@ -38,7 +39,7 @@ it('can be open', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
   expect(options?.checkVisibility()).to.be.true;
@@ -49,7 +50,7 @@ it('shows a fallback when open and there are no options', async () => {
     html`<glide-core-dropdown label="Label" open></glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const feedback = host.shadowRoot?.querySelector(
     '[data-test="optionless-feedback"]',
@@ -66,7 +67,7 @@ it('shows loading feedback', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const feedback = host.shadowRoot?.querySelector(
     '[data-test="loading-feedback"]',
@@ -159,7 +160,7 @@ it('activates the first enabled option when no options are selected', async () =
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -184,7 +185,7 @@ it('is scrollable', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
   assert(options);
@@ -207,7 +208,7 @@ it('is not scrollable', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
   assert(options);
@@ -228,7 +229,7 @@ it('hides the tooltip of the active option when open', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const tooltip = host
     .querySelector('glide-core-dropdown-option')

--- a/src/dropdown.test.events.multiple.ts
+++ b/src/dropdown.test.events.multiple.ts
@@ -12,6 +12,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import { click } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import './dropdown.option.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('dispatches one "change" event when an option is selected via click', async () => {
   const host = await fixture<Dropdown>(
@@ -25,8 +26,7 @@ it('dispatches one "change" event when an option is selected via click', async (
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   click(
     host
@@ -57,8 +57,7 @@ it('dispatches a "change" event after "input"', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   click(
     host
@@ -89,8 +88,7 @@ it('dispatches one "change" event when an option is selected via Enter', async (
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const spy = sinon.spy();
   host.addEventListener('change', spy);
@@ -122,8 +120,7 @@ it('dispatches one "change" event when an option is selected via Space', async (
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const spy = sinon.spy();
   host.addEventListener('change', spy);
@@ -155,8 +152,7 @@ it('dispatches one "input" event when an option is selected via click', async ()
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const spy = sinon.spy();
   host.addEventListener('input', spy);
@@ -187,8 +183,7 @@ it('dispatches one "input" event when an option is selected via Enter', async ()
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const spy = sinon.spy();
   host.addEventListener('input', spy);
@@ -221,8 +216,7 @@ it('dispatches one "input" event when an option is selected via Space', async ()
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const spy = sinon.spy();
   host.addEventListener('input', spy);
@@ -255,8 +249,7 @@ it('dispatches one "change" event when Select All is clicked', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const spy = sinon.spy();
   host.addEventListener('change', spy);
@@ -278,8 +271,7 @@ it('dispatches one "input" event when Select All is clicked', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const spy = sinon.spy();
   host.addEventListener('input', spy);
@@ -331,8 +323,7 @@ it('continues to dispatch "change" events upon selection after `value` is set pr
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.value = ['one', 'two'];
   click(host.querySelector('glide-core-dropdown-option:last-of-type'));
@@ -386,8 +377,7 @@ it('continues to dispatch "input" events upon selection after `value` is set pro
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.value = ['one', 'two'];
   click(host.querySelector('glide-core-dropdown-option:last-of-type'));
@@ -408,8 +398,7 @@ it('dispatches one "change" event when an option is selected after Select All is
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   await click(host.shadowRoot?.querySelector('[data-test="select-all"]'));
 
@@ -433,8 +422,7 @@ it('dispatches one "input" event when an option is selected after Select All is 
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   await click(host.shadowRoot?.querySelector('[data-test="select-all"]'));
 

--- a/src/dropdown.test.events.single.ts
+++ b/src/dropdown.test.events.single.ts
@@ -11,6 +11,7 @@ import {
 import { sendKeys } from '@web/test-runner-commands';
 import { click } from './library/mouse.js';
 import Dropdown from './dropdown.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('dispatches one "change" event when an option is selected via click', async () => {
   const host = await fixture<Dropdown>(
@@ -24,8 +25,7 @@ it('dispatches one "change" event when an option is selected via click', async (
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   click(host.querySelector('glide-core-dropdown-option'));
 
@@ -52,8 +52,7 @@ it('dispatches one "change" event when an option is selected via Enter', async (
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const spy = sinon.spy();
   host.addEventListener('change', spy);
@@ -86,8 +85,7 @@ it('dispatches one "change" event when an option is selected via Space', async (
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const spy = sinon.spy();
   host.addEventListener('change', spy);
@@ -120,8 +118,7 @@ it('dispatches a "change" event after "input"', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   click(host.querySelector('glide-core-dropdown-option'));
 
@@ -259,8 +256,7 @@ it('dispatches one "input" event when an option is selected via click', async ()
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   click(host.querySelector('glide-core-dropdown-option'));
 
@@ -287,8 +283,7 @@ it('dispatches one "input" event when an option is selected via Enter', async ()
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const spy = sinon.spy();
   host.addEventListener('input', spy);
@@ -321,8 +316,7 @@ it('dispatches one "input" event when an option is selected via Space', async ()
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const spy = sinon.spy();
   host.addEventListener('input', spy);
@@ -355,8 +349,7 @@ it('does not dispatch a "change" event when an already selected option is clicke
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const spy = sinon.spy();
   host.addEventListener('change', spy);
@@ -401,8 +394,7 @@ it('continues to dispatch "change" events upon selection after `value` is set pr
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.value = ['two'];
   click(host.querySelector('glide-core-dropdown-option'));
@@ -446,8 +438,7 @@ it('does not dispatch a "change" event when an already selected option is select
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   click(host.querySelector('glide-core-dropdown-option'));
 
@@ -469,8 +460,7 @@ it('does not dispatch an "input" event when an already selected option is select
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   click(host.querySelector('glide-core-dropdown-option'));
 
@@ -495,8 +485,7 @@ it('continues to dispatch "input" events upon selection after `value` is set pro
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.value = ['two'];
   click(host.querySelector('glide-core-dropdown-option'));

--- a/src/dropdown.test.events.ts
+++ b/src/dropdown.test.events.ts
@@ -11,6 +11,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import './dropdown.option.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('dispatches an "edit" event on click', async () => {
   const host = await fixture<Dropdown>(
@@ -22,8 +23,7 @@ it('dispatches an "edit" event on click', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
 
@@ -59,8 +59,7 @@ it('dispatches an "edit" event on Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' });
@@ -88,8 +87,7 @@ it('dispatches an "edit" event on Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' });

--- a/src/dropdown.test.focus.filterable.ts
+++ b/src/dropdown.test.focus.filterable.ts
@@ -1,8 +1,9 @@
-import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import './dropdown.option.js';
 import { click } from './library/mouse.js';
 import Dropdown from './dropdown.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('focuses the input when `focus()` is called', async () => {
   const host = await fixture<Dropdown>(
@@ -26,7 +27,7 @@ it('retains focus on the input when an option is selected via click', async () =
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await click(host.querySelector('glide-core-dropdown-option'));
 
@@ -44,7 +45,7 @@ it('retains focus on the the input when an option is selected via Enter', async 
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
 
   host
@@ -134,7 +135,7 @@ it('sets the `value` of its `<input> to the selected option when focus is lost',
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
   assert(option);

--- a/src/dropdown.test.focus.ts
+++ b/src/dropdown.test.focus.ts
@@ -1,8 +1,9 @@
-import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import './dropdown.option.js';
 import { click } from './library/mouse.js';
 import Dropdown from './dropdown.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('closes and reports validity when it loses focus', async () => {
   const div = document.createElement('div');
@@ -64,7 +65,7 @@ it('shows a fallback on focus when there are no options', async () => {
 
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const feedback = host.shadowRoot?.querySelector(
     '[data-test="optionless-feedback"]',

--- a/src/dropdown.test.forms.multiple.ts
+++ b/src/dropdown.test.forms.multiple.ts
@@ -1,10 +1,11 @@
-import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import './dropdown.option.js';
 import sinon from 'sinon';
 import { sendKeys } from '@web/test-runner-commands';
 import Dropdown from './dropdown.js';
 import Tag from './tag.js';
 import { click } from './library/mouse.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('can be reset after options are selected via click', async () => {
   const form = document.createElement('form');
@@ -33,7 +34,7 @@ it('can be reset after options are selected via click', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
   await click(options[1]);
 
@@ -125,7 +126,7 @@ it('can be reset after options are deselected via click', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[1]);
 
   form.reset();

--- a/src/dropdown.test.forms.single.ts
+++ b/src/dropdown.test.forms.single.ts
@@ -1,7 +1,8 @@
-import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import './dropdown.option.js';
 import Dropdown from './dropdown.js';
 import { click } from './library/mouse.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('can be reset after an option is selected via click', async () => {
   const form = document.createElement('form');
@@ -25,7 +26,7 @@ it('can be reset after an option is selected via click', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
 
   form.reset();
@@ -106,7 +107,7 @@ it('can be reset after an option is deselected via click', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
 
   form.reset();

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -13,6 +13,7 @@ import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import './dropdown.option.js';
 import type Tooltip from './tooltip.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('opens on click', async () => {
   const host = await fixture<Dropdown>(
@@ -38,7 +39,7 @@ it('closes on click', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('[data-test="primary-button"]'));
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
@@ -55,7 +56,7 @@ it('does not close when its input field is clicked', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('[data-test="input"]'));
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
@@ -72,7 +73,7 @@ it('closes when single-select and its Add button is clicked via mouse', async ()
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host);
   await sendKeys({ type: 'o' });
 
@@ -93,7 +94,7 @@ it('does not close when multiselect and its Add button is clicked via mouse', as
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host);
   await sendKeys({ type: 'o' });
 
@@ -248,7 +249,7 @@ it('unfilters when an option is selected via click', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'one' });
 
@@ -401,7 +402,7 @@ it('hides its magnifying glass icon when single-select and an option is selected
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'one' });
 
@@ -427,7 +428,7 @@ it('hides its magnifying glass icon when single-select and closed programmatical
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
   assert(option);
@@ -492,7 +493,7 @@ it('clears its filter on close when single-select and no option is selected', as
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'o' });
   await click(document.body);
@@ -512,7 +513,7 @@ it('clears its filter on close when multiselect and no option is selected', asyn
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'o' });
   await click(document.body);
@@ -536,7 +537,7 @@ it('clears its filter on close when multiselect and an option is selected', asyn
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'o' });
   await click(document.body);
@@ -648,14 +649,14 @@ it('unhides every option after filtering when one is selected and Dropdown is re
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'two' });
   await sendKeys({ press: 'Tab' });
 
   host.open = true;
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = [
     ...host.querySelectorAll('glide-core-dropdown-option'),
@@ -845,7 +846,7 @@ it('deselects the last selected option on Backspace when the insertion point is 
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await click(options[0]);
   await click(options[1]);
@@ -902,7 +903,7 @@ it('updates its input field when single-select and an option is selected`', asyn
     '[data-test="input"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
 
   expect(input?.value).to.equal(options[0]?.label);
@@ -991,7 +992,7 @@ it('clears its input field when multiselect and an option is selected via mouse'
     '[data-test="input"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'one' });
   await click(options[0]);
@@ -1085,7 +1086,7 @@ it('activates options on hover', async () => {
   const options = host.querySelectorAll('glide-core-dropdown-option');
   const input = host.shadowRoot?.querySelector('[data-test="input"]');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'o' });
 
@@ -1130,7 +1131,7 @@ it('activates options on ArrowDown', async () => {
     '[data-test="input"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // Two
 
@@ -1242,7 +1243,7 @@ it('activates the first option on Home', async () => {
     '[data-test="input"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'End' });
   await sendKeys({ press: 'Home' });
@@ -1289,7 +1290,7 @@ it('activates the first option on PageUp', async () => {
     '[data-test="input"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'PageDown' });
   await sendKeys({ press: 'PageUp' });
@@ -1336,7 +1337,7 @@ it('activates the first option on Meta + ArrowUp', async () => {
     '[data-test="input"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'End' });
   await sendKeys({ down: 'Meta' });
@@ -1389,7 +1390,7 @@ it('activates the last option on End', async () => {
     '[data-test="input"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'End' });
 
@@ -1431,7 +1432,7 @@ it('activates the last option on PageDown', async () => {
     '[data-test="input"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'PageDown' });
 
@@ -1473,7 +1474,7 @@ it('activates the last option on Meta + ArrowDown', async () => {
 
   const options = [...host.querySelectorAll('glide-core-dropdown-option')];
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ down: 'Meta' });
   await sendKeys({ press: 'ArrowDown' });
@@ -1698,7 +1699,7 @@ it('activates the first option when the previously active option is filtered out
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // ABC
   await sendKeys({ press: 'ArrowDown' }); // AB
@@ -1728,7 +1729,7 @@ it('deactivates the active option when closed', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   await click(
     host.shadowRoot?.querySelector<HTMLButtonElement>(
@@ -1791,7 +1792,7 @@ it('sets its input field back to the `label` of the selected option when somethi
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
 
@@ -1824,7 +1825,7 @@ it('sets its input field to the `label` of the selected option when `label` is a
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
   await click(options[1]);
@@ -2022,8 +2023,7 @@ it('shows an ellipsis when the label of its selected option is set programmatica
   option.label = 'x'.repeat(500);
   await host.updateComplete;
 
-  // Wait for the Resize Observer to do its thing.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for the Resize Observer
 
   const ellipsis = host.shadowRoot?.querySelector('[data-test="ellipsis"]');
   expect(ellipsis?.checkVisibility()).to.be.true;
@@ -2075,7 +2075,7 @@ it('hides its ellipsis when previously overflowing and an option with a shorter 
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[1]);
 
   await waitUntil(() => {
@@ -2102,7 +2102,7 @@ it('hides its ellipsis when previously overflowing and an option with a shorter 
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' });
   await sendKeys({ press: 'Enter' });
@@ -2135,7 +2135,7 @@ it('does not show its input tooltip on close when an option is selected via clic
   );
 
   await click(host);
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(option);
   await tooltip?.updateComplete;
 
@@ -2191,7 +2191,7 @@ it('does not show its input tooltip on close when an option is added via the Add
 
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ type: 'x'.repeat(500) });
   await sendKeys({ press: 'Enter' });
   await tooltip?.updateComplete;
@@ -2211,7 +2211,7 @@ it('does not allow its "toggle" event to propagate', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const tooltip = host.shadowRoot
     ?.querySelector('[data-test="input-tooltip"]')
@@ -2235,7 +2235,7 @@ it('retains its filter query when multiselect and its default slot changes', asy
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'one' });
 
@@ -2260,7 +2260,7 @@ it('retains its filter query when single-select` and its default slot changes', 
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'one' });
 
@@ -2285,7 +2285,7 @@ it('shows a fallback when every option has been filtered out', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'two' });
 
@@ -2309,7 +2309,7 @@ it('shows a fallback when every option has been removed via filtering', async ()
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.filter = async () => {
     const options = host.querySelectorAll('glide-core-dropdown-option');
@@ -2342,7 +2342,7 @@ it('does not show a fallback when every option has been filtered out and the Add
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ type: 'two' });
 
@@ -2360,7 +2360,7 @@ it('does not show a fallback when every option has been removed via filtering an
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.filter = async () => {
     const options = host.querySelectorAll('glide-core-dropdown-option');

--- a/src/dropdown.test.interactions.multiple.ts
+++ b/src/dropdown.test.interactions.multiple.ts
@@ -14,6 +14,7 @@ import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import DropdownOption from './dropdown.option.js';
 import Tag from './tag.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 @customElement('glide-core-dropdown-in-another-component')
 class DropdownInAnotherComponent extends LitElement {
@@ -76,7 +77,7 @@ it('selects an option on click via mouse', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
 
   const labels = host.shadowRoot?.querySelectorAll(
@@ -201,7 +202,7 @@ it('deselects an option on click via mouse', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
 
   const labels = host.shadowRoot?.querySelectorAll(
@@ -347,7 +348,7 @@ it('selects an option on Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -392,7 +393,7 @@ it('deselects an option on Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -434,7 +435,7 @@ it('selects an option on Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -477,7 +478,7 @@ it('deselects an option on Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -533,7 +534,7 @@ it('deactivates all other options when an option is hovered', async () => {
     host.shadowRoot?.querySelector<DropdownOption>('[data-test="select-all"]'),
   ];
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[0]);
   await hover(options[1]);
 
@@ -547,7 +548,7 @@ it('remains open when an option is selected via click', async () => {
     html`<glide-core-dropdown-in-another-component></glide-core-dropdown-in-another-component>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('glide-core-dropdown-option'));
 
   const dropdown = host.shadowRoot?.querySelector('glide-core-dropdown');
@@ -566,7 +567,7 @@ it('remains open when an option is selected via Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.querySelector('glide-core-dropdown-option')?.focus();
   await sendKeys({ press: 'Enter' });
@@ -586,7 +587,7 @@ it('remains open when an option is selected via Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
 
@@ -607,7 +608,7 @@ it('activates Select All on hover', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[0]);
 
   expect(options[0]?.privateActive).to.be.true;
@@ -629,7 +630,7 @@ it('does not activate the next option on ArrowDown when a tag is focused', async
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -776,7 +777,7 @@ it('does not update `value` when a disabled option is selected via click', async
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.querySelector('glide-core-dropdown-option'));
 
   expect(host.value).to.deep.equal([]);
@@ -939,7 +940,7 @@ it('has no internal label when an option is newly selected', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   await click(host.querySelector('glide-core-dropdown-option:last-of-type'));
 
@@ -970,12 +971,12 @@ it('updates its tags and overflow count when options are selected', async () => 
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
   await click(options[1]);
   await click(options[2]);
   await click(options[3]);
-  await aTimeout(0); // Wait for the Resize Observer to do its thing
+  await requestIdleCallback(); // Wait for the Resize Observer
 
   const tagContainers = [
     ...(host.shadowRoot?.querySelectorAll<HTMLElement>(
@@ -1013,7 +1014,7 @@ it('updates its tags and overflow count when options are selected programmatical
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for the Resize Observer to do its thing
+  await requestIdleCallback(); // Wait for the Resize Observer
 
   const thirdOption = document.createElement('glide-core-dropdown-option');
 
@@ -1084,7 +1085,7 @@ it('selects all enabled options when none are selected and Select All is selecte
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('[data-test="select-all"]'));
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
@@ -1117,7 +1118,7 @@ it('selects all enabled options when some are selected and Select All is selecte
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('[data-test="select-all"]'));
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
@@ -1158,7 +1159,7 @@ it('deselects all options when all are selected and Select All is selected via c
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   await click(
     host.shadowRoot?.querySelector<DropdownOption>('[data-test="select-all"]'),
@@ -1202,7 +1203,7 @@ it('selects all enabled options when none are selected and Select All is selecte
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
 
@@ -1251,7 +1252,7 @@ it('selects all enabled options when some are selected and Select All is selecte
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' }); // Two's tag
   await sendKeys({ press: 'Tab' }); // Dropdown
   await sendKeys({ press: 'ArrowUp' });
@@ -1297,7 +1298,7 @@ it('deselects all options when all are selected and Select All is selected via S
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' }); // One's tag
   await sendKeys({ press: 'Tab' }); // Two's tag
   await sendKeys({ press: 'Tab' }); // Dropdown
@@ -1342,7 +1343,7 @@ it('selects all enabled options when none are selected and Select All is selecte
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Enter' });
 
@@ -1391,7 +1392,7 @@ it('selects all enabled options when some are selected and Select All is selecte
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' }); // Two's tag
   await sendKeys({ press: 'Tab' }); // Dropdown
   await sendKeys({ press: 'ArrowUp' });
@@ -1437,7 +1438,7 @@ it('deselects all options when all are selected and Select All is selected via E
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' }); // One's tag
   await sendKeys({ press: 'Tab' }); // Twos' tag
   await sendKeys({ press: 'Tab' }); // Dropdown
@@ -1473,7 +1474,7 @@ it('shows Select All when is enabled programmatically', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.selectAll = true;
   await host.updateComplete;
@@ -1500,7 +1501,7 @@ it('sets Select All as selected when all enabled options are selected', async ()
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[1]);
   await click(options[2]);
 
@@ -1521,7 +1522,7 @@ it('sets Select All as deselected when no options are selected', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
   await click(options[1]);
   await click(options[0]);
@@ -1542,7 +1543,7 @@ it('sets Select All as indeterminate when not all options are selected', async (
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.querySelector('glide-core-dropdown-option'));
 
   const selectAll = host.shadowRoot?.querySelector<DropdownOption>(
@@ -1569,7 +1570,7 @@ it('does not set Select All as indeterminate when no options are selected', asyn
     '[data-test="select-all"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
 
   expect(selectAll?.privateIndeterminate).to.be.false;
@@ -1589,7 +1590,7 @@ it('does not set Select All as indeterminate when all options are selected', asy
     '[data-test="select-all"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
   await click(options[1]);
 
@@ -1627,7 +1628,7 @@ it('closes when a tag is edited via click', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   await click(
     host.shadowRoot
@@ -1739,7 +1740,7 @@ it('updates itself when a selected option is disabled programmatically', async (
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -1812,7 +1813,7 @@ it('updates itself when a selected option is enabled programmatically', async ()
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -1820,7 +1821,7 @@ it('updates itself when a selected option is enabled programmatically', async ()
 
   options[1].disabled = false;
   await host.updateComplete;
-  await aTimeout(0); // Wait for the Resize Observer to do its thing
+  await requestIdleCallback(); // Wait for the Resize Observer
 
   const input = host.shadowRoot?.querySelector<HTMLInputElement>(
     '[data-test="input"]',
@@ -1930,7 +1931,7 @@ it('sets `aria-selected` when made multiselect programmatically', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.multiple = true;
   await host.updateComplete;

--- a/src/dropdown.test.interactions.single.ts
+++ b/src/dropdown.test.interactions.single.ts
@@ -13,6 +13,7 @@ import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import DropdownOption from './dropdown.option.js';
 import type Tooltip from './tooltip.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('opens on click', async () => {
   const host = await fixture<Dropdown>(
@@ -61,7 +62,7 @@ it('selects an option on click via mouse', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
 
   const labels = host.shadowRoot?.querySelectorAll(
@@ -203,7 +204,7 @@ it('does not select a disabled option on click', async () => {
     '[data-test="selected-option-label"]',
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[0]);
 
   expect(options[0]?.selected).to.be.false;
@@ -229,7 +230,7 @@ it('selects an option on Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -294,8 +295,7 @@ it('selects an option when its icon is clicked', async () => {
     </glide-core-dropdown>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -330,7 +330,7 @@ it('does not deselect options on Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
 
@@ -364,7 +364,7 @@ it('selects an option on Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
   options[0]?.focus();
@@ -393,7 +393,7 @@ it('deactivates all other options when an option is hovered', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[0]);
   await hover(options[1]);
 
@@ -408,7 +408,7 @@ it('closes when an option is selected via click', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.querySelector('glide-core-dropdown-option'));
 
   expect(host.open).to.be.false;
@@ -421,7 +421,7 @@ it('closes when an option is selected via Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: ' ' });
 
@@ -435,7 +435,7 @@ it('closes when an option is selected via Enter', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Enter' });
 
@@ -449,7 +449,7 @@ it('closes when an option is selected via Space', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const option = host.querySelector('glide-core-dropdown-option');
 
@@ -469,7 +469,7 @@ it('closes when an already selected option is clicked', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.querySelector('glide-core-dropdown-option'));
 
   expect(host.open).to.be.false;
@@ -486,7 +486,7 @@ it('closes on edit via click', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.shadowRoot?.querySelector('[data-test="edit-button"]'));
 
   expect(host.open).to.be.false;
@@ -515,7 +515,7 @@ it('deselects all other options when one is newly selected', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(options[1]);
 
   expect(options[0]?.selected).to.be.false;
@@ -689,7 +689,7 @@ it('does not update `value` when a disabled option is selected via click', async
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(host.querySelector('glide-core-dropdown-option'));
 
   expect(host.value).to.deep.equal([]);
@@ -909,7 +909,7 @@ it('updates itself when an option is newly selected', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const option = host.querySelector<DropdownOption>(
     'glide-core-dropdown-option:last-of-type',
@@ -1200,7 +1200,7 @@ it('only shows the last selected option as selected when single-select and a sel
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const firstOption = host.querySelector('glide-core-dropdown-option');
   const secondOption = document.createElement('glide-core-dropdown-option');
@@ -1264,7 +1264,7 @@ it('sets `aria-selected` when an option is selected programmatically', async () 
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -1288,7 +1288,7 @@ it('sets `aria-selected` when an option is deselected programmatically', async (
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -1315,7 +1315,7 @@ it('sets `aria-selected` when an option is disabled programmatically', async () 
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -1343,7 +1343,7 @@ it('sets `aria-selected` when an option is enabled programmatically', async () =
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -1370,7 +1370,7 @@ it('sets `aria-selected` when made single-select programmatically', async () => 
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.multiple = false;
   await host.updateComplete;

--- a/src/dropdown.test.interactions.ts
+++ b/src/dropdown.test.interactions.ts
@@ -5,6 +5,7 @@ import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import './dropdown.option.js';
 import type Tooltip from './tooltip.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('opens when opened programmatically', async () => {
   const host = await fixture<Dropdown>(
@@ -14,7 +15,7 @@ it('opens when opened programmatically', async () => {
   );
 
   host.open = true;
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
   expect(options?.checkVisibility()).to.be.true;
@@ -26,7 +27,7 @@ it('shows a fallback when opened programmatically and there are no options', asy
   );
 
   host.open = true;
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const feedback = host.shadowRoot?.querySelector(
     '[data-test="optionless-feedback"]',
@@ -42,7 +43,7 @@ it('does not open when opened programmatically and there are no options', async 
   );
 
   host.open = true;
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.shadowRoot?.querySelector('[data-test="options"]');
   expect(options?.checkVisibility()).to.be.false;
@@ -232,7 +233,7 @@ it('closes when something outside of it is clicked', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(document.body);
   expect(host.open).to.be.false;
 });
@@ -249,7 +250,7 @@ it('closes on Escape', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'Escape' });
 
@@ -291,7 +292,7 @@ it('opens when open and enabled programmatically', async () => {
   );
 
   host.disabled = false;
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host?.shadowRoot?.querySelector('[data-test="options"]');
   expect(options?.checkVisibility()).to.be.true;
@@ -309,7 +310,7 @@ it('closes when open and disabled programmatically', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   host.disabled = true;
 
   const options = host?.shadowRoot?.querySelector('[data-test="options"]');
@@ -326,7 +327,7 @@ it('activates an option on hover', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[1]);
 
   expect(options[0]?.privateActive).to.be.false;
@@ -344,7 +345,7 @@ it('hides option tooltips on close', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' });
   await sendKeys({ press: 'Tab' });
@@ -367,7 +368,7 @@ it('does not activate a disabled option on hover', async () => {
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await hover(options[1]);
 
   expect(options[0]?.privateActive).to.be.true;
@@ -435,7 +436,7 @@ it('activates the next enabled option on ArrowDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // Three
 
@@ -458,7 +459,7 @@ it('activates the Edit button on ArrowDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // One's edit button
 
@@ -487,7 +488,7 @@ it('activates the next enabled option on ArrowDown when the Edit button is activ
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // One's edit button
   await sendKeys({ press: 'ArrowDown' }); // Three
@@ -517,7 +518,7 @@ it('activates the previous enabled option on ArrowUp', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // Three
   await sendKeys({ press: 'ArrowUp' }); // Two
@@ -544,7 +545,7 @@ it('activates the Edit button on on ArrowUp', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // One's Edit button
   await sendKeys({ press: 'ArrowDown' }); // Two
@@ -575,7 +576,7 @@ it('activates the first enabled option on Home', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'End' });
   await sendKeys({ press: 'Home' });
@@ -606,7 +607,7 @@ it('activates the first enabled option on PageUp', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'PageDown' });
   await sendKeys({ press: 'PageUp' });
@@ -637,7 +638,7 @@ it('activates the first enabled option on ArrowUp + Meta', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'End' });
   await sendKeys({ down: 'Meta' });
@@ -670,7 +671,7 @@ it('activates the last enabled option on End', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'End' });
 
@@ -700,7 +701,7 @@ it('activates the last option on PageDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'PageDown' });
 
@@ -730,7 +731,7 @@ it('activates the last option on Meta + ArrowDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ down: 'Meta' });
   await sendKeys({ press: 'ArrowDown' });
@@ -780,7 +781,7 @@ it('does not wrap on ArrowUp', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowUp' });
 
@@ -798,7 +799,7 @@ it('does not wrap on ArrowDown', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await sendKeys({ press: 'Tab' });
   await sendKeys({ press: 'ArrowDown' }); // Two
   await sendKeys({ press: 'ArrowDown' }); // Two
@@ -885,7 +886,7 @@ it('shows a fallback when open and its options are removed', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host.querySelectorAll('glide-core-dropdown-option');
 
@@ -937,7 +938,7 @@ it('does not allow its "toggle" event to propagate', async () => {
     </glide-core-dropdown>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const tooltip = host.shadowRoot
     ?.querySelector('[data-test="internal-label-tooltip"]')

--- a/src/option.test.events.ts
+++ b/src/option.test.events.ts
@@ -5,6 +5,7 @@ import './options.js';
 import './menu.js';
 import { click, hover } from './library/mouse.js';
 import pencilIcon from './icons/pencil.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('dispatches a "click" event when clicked via mouse', async () => {
   const host = await fixture<Option>(
@@ -101,7 +102,7 @@ it('does not allow its "toggle" event to propagate', async () => {
   await hover(host);
   host.privateTooltipOpen = true;
 
-  await aTimeout(0); // Wait for the Resize Observer to do its thing
+  await requestIdleCallback(); // Wait for the Resize Observer
 
   expect(spy.callCount).to.equal(0);
 });
@@ -126,7 +127,7 @@ it('cancels navigation on click when disabled', async () => {
     event.preventDefault();
   });
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   await click(tooltip);
 
   expect(wasNavigationCanceled).to.be.true;
@@ -162,7 +163,7 @@ it('does not retarget nested option "click" events to itself', async () => {
 
   const nestedOption = host.querySelector('glide-core-option');
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   click(nestedOption);
 

--- a/src/popover.test.basics.ts
+++ b/src/popover.test.basics.ts
@@ -1,8 +1,9 @@
-import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import Popover from './popover.js';
 import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends Popover {}
@@ -34,8 +35,7 @@ it('opens', async () => {
     '[data-test="popover"]',
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(popover?.checkVisibility()).to.be.true;
 });
@@ -52,8 +52,7 @@ it('is not open when disabled', async () => {
     '[data-test="popover"]',
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(popover?.checkVisibility()).to.be.false;
 });

--- a/src/popover.test.interactions.ts
+++ b/src/popover.test.interactions.ts
@@ -1,8 +1,9 @@
-import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { assert, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import { styleMap } from 'lit/directives/style-map.js';
 import { click } from './library/mouse.js';
 import Popover from './popover.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('opens when opened programmatically', async () => {
   const host = await fixture<Popover>(
@@ -14,8 +15,7 @@ it('opens when opened programmatically', async () => {
 
   host.open = true;
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const popover = host.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="popover"]',
@@ -34,8 +34,7 @@ it('opens when open and enabled programmatically', async () => {
 
   host.disabled = false;
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const popover = host.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="popover"]',
@@ -52,13 +51,11 @@ it('closes when open and disabled programmatically', async () => {
     </glide-core-popover>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.disabled = true;
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const popover = host.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="popover"]',
@@ -77,8 +74,7 @@ it('does not open when opened programmatically and disabled', async () => {
 
   host.open = true;
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const popover = host.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="popover"]',
@@ -95,8 +91,7 @@ it('closes on Escape', async () => {
     </glide-core-popover>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   host.querySelector('button')?.focus();
   await sendKeys({ press: 'Escape' });
@@ -116,8 +111,7 @@ it('opens on click', async () => {
 
   await click(host.querySelector('button'));
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const popover = host.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="popover"]',
@@ -137,8 +131,7 @@ it('opens on Enter', async () => {
   host.querySelector('button')?.focus();
   await sendKeys({ press: 'Enter' });
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const popover = host.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="popover"]',
@@ -158,8 +151,7 @@ it('opens on Space', async () => {
   host.querySelector('button')?.focus();
   await sendKeys({ press: ' ' });
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const popover = host.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="popover"]',
@@ -176,8 +168,7 @@ it('remains open when its popover is clicked', async () => {
     </glide-core-popover>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const popover = host.shadowRoot?.querySelector('[data-test="popover"]');
   const defaultSlot = host.shadowRoot?.querySelector('slot:not([name])');
@@ -201,8 +192,7 @@ it('remains open when its arrow is clicked', async () => {
     </glide-core-popover>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const arrow = host.shadowRoot?.querySelector('[data-test="arrow"]');
 
@@ -242,8 +232,7 @@ it('closes when something outside of it is clicked', async () => {
     </glide-core-popover>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   await click(document.body);
 
@@ -263,8 +252,7 @@ it('does not close when a slotted `<label>` is clicked', async () => {
     </glide-core-popover>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   const label = host.querySelector('label');
   await click(label);
@@ -280,15 +268,12 @@ it('has `this.#cleanUpFloatingUi?.()` coverage', async () => {
     </glide-core-popover>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
   host.open = true;
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
   host.open = true;
 });
 
@@ -321,8 +306,7 @@ it('has `middlewareData.arrow.y` coverage', async () => {
     </glide-core-popover>`,
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 });
 
 it('has `#show()` coverage', async () => {

--- a/src/tab.group.test.basics.ts
+++ b/src/tab.group.test.basics.ts
@@ -1,11 +1,4 @@
-import {
-  assert,
-  aTimeout,
-  expect,
-  fixture,
-  html,
-  waitUntil,
-} from '@open-wc/testing';
+import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
 import { emulateMedia } from '@web/test-runner-commands';
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
@@ -13,6 +6,7 @@ import TabGroup from './tab.group.js';
 import './tab.js';
 import TabPanel from './tab.panel.js';
 import expectWindowError from './library/expect-window-error.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends TabGroup {}
@@ -70,11 +64,7 @@ it('sets the width of its selected tab indicator to that of the selected tab', a
   assert(firstTab);
   assert(selectedTabIndicator);
 
-  // Wait for the Resize Observer
-  await waitUntil(() => {
-    return selectedTabIndicator.clientWidth === firstTab.clientWidth;
-  });
-
+  await requestIdleCallback(); // Wait for the Resize Observer
   await emulateMedia({ reducedMotion: 'no-preference' });
 });
 
@@ -95,7 +85,7 @@ it('offsets the width of its tab indicator when its first tab is selected', asyn
     </glide-core-tab-group>
   `);
 
-  await aTimeout(0); // Wait for the Resize Observer
+  await requestIdleCallback(); // Wait for the Resize Observer
 
   const firstTab = host
     .querySelector('glide-core-tab')
@@ -108,11 +98,7 @@ it('offsets the width of its tab indicator when its first tab is selected', asyn
   assert(firstTab);
   assert(selectedTabIndicator);
 
-  // Wait for the Resize Observer
-  await waitUntil(() => {
-    return selectedTabIndicator.clientWidth === firstTab.clientWidth;
-  });
-
+  await requestIdleCallback(); // Wait for the Resize Observer
   await emulateMedia({ reducedMotion: 'no-preference' });
 });
 
@@ -133,7 +119,7 @@ it('offsets the width of its tab indicator when its middle tab is selected', asy
     </glide-core-tab-group>
   `);
 
-  await aTimeout(0); // Wait for the Resize Observer
+  await requestIdleCallback(); // Wait for the Resize Observer
 
   const middleTab = host
     .querySelector('glide-core-tab:nth-of-type(2)')
@@ -146,11 +132,7 @@ it('offsets the width of its tab indicator when its middle tab is selected', asy
   assert(middleTab);
   assert(selectedTabIndicator);
 
-  // Wait for the Resize Observer
-  await waitUntil(() => {
-    return selectedTabIndicator.clientWidth === middleTab.clientWidth;
-  });
-
+  await requestIdleCallback(); // Wait for the Resize Observer
   await emulateMedia({ reducedMotion: 'no-preference' });
 });
 
@@ -184,11 +166,7 @@ it('offsets the width of its tab indicator when its last tab is selected', async
   assert(lastTab);
   assert(selectedTabIndicator);
 
-  // Wait for the Resize Observer
-  await waitUntil(() => {
-    return selectedTabIndicator.clientWidth === lastTab.clientWidth;
-  });
-
+  await requestIdleCallback(); // Wait for the Resize Observer
   await emulateMedia({ reducedMotion: 'no-preference' });
 });
 

--- a/src/tab.group.test.interactions.ts
+++ b/src/tab.group.test.interactions.ts
@@ -11,6 +11,7 @@ import './tab.js';
 import { click } from './library/mouse.js';
 import TabGroup from './tab.group.js';
 import './tab.panel.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('sets the selected tab using the `selected` attribute', async () => {
   const host = await fixture<TabGroup>(html`
@@ -540,8 +541,6 @@ it('updates the width of its selected tab indicator when the label of a tab chan
     .querySelector('glide-core-tab')
     ?.shadowRoot?.querySelector('[data-test="component"]');
 
-  const firstTabInitialWidth = firstTab?.clientWidth;
-
   const selectedTabIndicator = host.shadowRoot?.querySelector(
     '[data-test="selected-tab-indicator"]',
   );
@@ -549,18 +548,10 @@ it('updates the width of its selected tab indicator when the label of a tab chan
   assert(firstTab);
   assert(selectedTabIndicator);
 
-  // Wait for the Resize Observer
-  await waitUntil(() => {
-    return selectedTabIndicator?.clientWidth === firstTabInitialWidth;
-  });
-
+  await requestIdleCallback(); // Wait for the Resize Observer
   firstTab.innerHTML = 'One (But Longer)';
 
-  // Wait for the Resize Observer
-  await waitUntil(() => {
-    return selectedTabIndicator?.clientWidth !== firstTabInitialWidth;
-  });
-
+  await requestIdleCallback(); // Wait for the Resize Observer
   expect(selectedTabIndicator?.clientWidth).to.equal(firstTab.clientWidth);
 
   await emulateMedia({ reducedMotion: 'no-preference' });

--- a/src/tooltip.test.basics.ts
+++ b/src/tooltip.test.basics.ts
@@ -1,9 +1,10 @@
-import { aTimeout, expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
 import sinon from 'sinon';
 import { customElement } from 'lit/decorators.js';
 import Tooltip from './tooltip.js';
 import TooltipContainer from './tooltip.container.js';
 import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends Tooltip {}
@@ -33,8 +34,7 @@ it('can be open', async () => {
     '[data-test="tooltip"]',
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(tooltip?.checkVisibility()).to.be.true;
 });
@@ -78,8 +78,7 @@ it('is not open when disabled', async () => {
     '[data-test="tooltip"]',
   );
 
-  // Wait for Floating UI.
-  await aTimeout(0);
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(tooltip?.checkVisibility()).to.be.false;
 });

--- a/src/tooltip.test.interactions.ts
+++ b/src/tooltip.test.interactions.ts
@@ -11,6 +11,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { hover } from './library/mouse.js';
 import Tooltip from './tooltip.js';
 import TooltipContainer from './tooltip.container.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('passes down certain properties to its container', async () => {
   const host = await fixture<Tooltip>(
@@ -47,7 +48,7 @@ it('is open when opened programmatically', async () => {
   );
 
   host.open = true;
-  await aTimeout(0); // Wait for Floating UI.
+  await requestIdleCallback(); // Wait for Floating UI
 
   const tooltip = host.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="tooltip"]',
@@ -64,7 +65,7 @@ it('is open when open and enabled programmatically', async () => {
   );
 
   host.disabled = false;
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const tooltip = host.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="tooltip"]',
@@ -80,9 +81,9 @@ it('is not open when open and disabled programmatically', async () => {
     </glide-core-tooltip>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
   host.disabled = true;
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const tooltip = host.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="tooltip"]',
@@ -99,7 +100,7 @@ it('is not open when opened programmatically and disabled', async () => {
   );
 
   host.open = true;
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   const tooltip = host.shadowRoot?.querySelector<HTMLElement>(
     '[data-test="tooltip"]',
@@ -116,7 +117,7 @@ it('opens when tabbed to', async () => {
   );
 
   await sendKeys({ press: 'Tab' });
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 
   expect(
     host.shadowRoot?.querySelector('[data-test="tooltip"]')?.checkVisibility(),
@@ -140,7 +141,7 @@ it('opens on hover', async () => {
   tooltip.dataset.openDelay = '0';
 
   await hover(target);
-  await aTimeout(0); // Wait for Floating UI and `#onComponentMouseOver()`
+  await requestIdleCallback(); // Wait for Floating UI and `#onComponentMouseOver()`
 
   expect(tooltip.checkVisibility()).to.be.true;
 });
@@ -168,7 +169,7 @@ it('remains open when hovered away from and the event is canceled', async () => 
   tooltip.dataset.closeDelay = '0';
 
   await hover(target);
-  await aTimeout(0); // Wait for Floating UI and `#onComponentMouseOver()`
+  await requestIdleCallback(); // Wait for Floating UI and `#onComponentMouseOver()`
 
   await hover(document.body);
   await aTimeout(0); // Wait for `#onComponentMouseOut()`
@@ -231,7 +232,7 @@ it('closes when hovered away from', async () => {
   tooltip.dataset.closeDelay = '0';
 
   await hover(target);
-  await aTimeout(0); // Wait for Floating UI and `#onComponentMouseOver()`
+  await requestIdleCallback(); // Wait for Floating UI and `#onComponentMouseOver()`
 
   await hover(document.body);
   await aTimeout(0); // Wait for `#onComponentMouseOut()`
@@ -296,7 +297,7 @@ it('remains closed when hovered to and the event is canceled', async () => {
   tooltip.dataset.closeDelay = '0';
 
   await hover(target);
-  await aTimeout(0); // Wait for Floating UI and `#onComponentMouseOver()`
+  await requestIdleCallback(); // Wait for Floating UI and `#onComponentMouseOver()`
 
   expect(tooltip.checkVisibility()).to.be.false;
 });
@@ -375,7 +376,7 @@ it('has `middlewareData.arrow.y` coverage', async () => {
     </glide-core-tooltip>`,
   );
 
-  await aTimeout(0); // Wait for Floating UI
+  await requestIdleCallback(); // Wait for Floating UI
 });
 
 it('has `set open(isOpen: boolean)` coverage', async () => {


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Replaced instances of `aTimeout(0)` in tests with `requestIdleCallback()` so tests, especially in CI, are less flaky. Also see https://github.com/CrowdStrike/glide-core/pull/1001#discussion_r2231177804.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

If the tests pass we're good.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
