### PR TITLE
Support preventing Popover from opening

### DIFF
--- a/.changeset/great-cobras-notice.md
+++ b/.changeset/great-cobras-notice.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Popover can now be stopped from opening and closing by canceling "click" events on its target.

--- a/src/popover.test.interactions.ts
+++ b/src/popover.test.interactions.ts
@@ -3,6 +3,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import { styleMap } from 'lit/directives/style-map.js';
 import { click } from './library/mouse.js';
 import Popover from './popover.js';
+import requestIdleCallback from './library/request-idle-callback.js';
 
 it('opens when opened programmatically', async () => {
   const host = await fixture<Popover>(
@@ -231,6 +232,56 @@ it('remains closed on click when disabled', async () => {
     '[data-test="popover"]',
   );
 
+  expect(popover?.checkVisibility()).to.be.false;
+});
+
+it('remains open when its target is clicked and the event is canceled', async () => {
+  const host = await fixture<Popover>(
+    html`<glide-core-popover open>
+      Popover
+      <button slot="target">Target</button>
+    </glide-core-popover>`,
+  );
+
+  const target = host.querySelector('button');
+
+  target?.addEventListener('click', (event: MouseEvent) => {
+    event.preventDefault();
+  });
+
+  await requestIdleCallback(); // Wait for Floating UI
+  await click(target);
+
+  const popover = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="popover"]',
+  );
+
+  expect(host.open).to.be.true;
+  expect(popover?.checkVisibility()).to.be.true;
+});
+
+it('remains closed when its target is clicked and the event is canceled', async () => {
+  const host = await fixture<Popover>(
+    html`<glide-core-popover>
+      Popover
+      <button slot="target">Target</button>
+    </glide-core-popover>`,
+  );
+
+  const target = host.querySelector('button');
+
+  target?.addEventListener('click', (event: MouseEvent) => {
+    event.preventDefault();
+  });
+
+  await click(target);
+  await requestIdleCallback(); // Wait for Floating UI
+
+  const popover = host.shadowRoot?.querySelector<HTMLElement>(
+    '[data-test="popover"]',
+  );
+
+  expect(host.open).to.be.false;
   expect(popover?.checkVisibility()).to.be.false;
 });
 

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -299,9 +299,16 @@ export default class Popover extends LitElement {
     this.#isDefaultSlotClick = true;
   }
 
-  #onTargetSlotClick() {
+  #onTargetSlotClick(event: MouseEvent) {
     this.#isTargetSlotClick = true;
-    this.open = !this.open;
+
+    // The timeout gives consumers a chance to cancel the event to prevent Popover
+    // from opening or closing.
+    setTimeout(() => {
+      if (!event.defaultPrevented) {
+        this.open = !this.open;
+      }
+    });
   }
 
   #onTargetSlotKeydown(event: KeyboardEvent) {


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

For its use in Menu, I [recently](https://github.com/CrowdStrike/glide-core/pull/963#issue-3219607864) added support to Tooltip for preventing Tooltip from opening and closing when consumers cancel "mouseover" and "mouseout" events on its target. 

Not every component needs to have this feature. But Tooltip and Popover are very similar. So I thought I would bring the feature to Popover.



## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

1. Navigate to Popover in Storybook.
2. Add an event listener to Popover's target that cancels "click" events.
4. Click Popover's target.
5. Verify Popover remains closed.
6. Set Popover's `open` attribute to `true`.
7. Click Popover's target.
8. Verify Popover remains open.
<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
