### PR TITLE
Increase workflow timeouts

### DIFF
--- a/.github/workflows/on-merge-branch-changeset-release-main.yml
+++ b/.github/workflows/on-merge-branch-changeset-release-main.yml
@@ -45,7 +45,7 @@ jobs:
   release:
     name: Release
     if: github.event.pull_request.merged == true && github.head_ref == 'changeset-release/main'
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     needs:
       - install-dependencies

--- a/.github/workflows/on-pull-request-opened-and-synchronize.yml
+++ b/.github/workflows/on-pull-request-opened-and-synchronize.yml
@@ -95,7 +95,7 @@ jobs:
   test-lint-rules:
     name: Test (Lint Rules)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs:
       - install-dependencies
     steps:
@@ -123,7 +123,7 @@ jobs:
     name: Test (Functionality)
     runs-on: ubuntu-latest
 
-    timeout-minutes: 5 # Increase sharding if the job takes longer than this
+    timeout-minutes: 10 # Increase sharding if the job takes longer than this
     needs:
       - install-dependencies
       - build
@@ -270,7 +270,7 @@ jobs:
   test-visuals:
     name: Test (Visuals)
     runs-on: ubuntu-latest
-    timeout-minutes: 5 # Increase sharding if the job takes longer this
+    timeout-minutes: 10 # Increase sharding if the job takes longer this
     needs:
       - install-dependencies
       - fetch-baseline-screenshots

--- a/.github/workflows/on-push-branch-main.yml
+++ b/.github/workflows/on-push-branch-main.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     needs:
       - install-dependencies


### PR DESCRIPTION
## 🚀 Description


We've been seeing quite a few CI failures. At least [some](https://github.com/CrowdStrike/glide-core/actions/runs/16811286734/job/47617081628) appear to be because we're hitting our pretty low timeouts when downloading Ubuntu packages. So I figured increasing our timeouts is worth a try.
<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

N/A

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
