### PR TITLE
Revert to old Chrome Headless in visual tests

### DIFF
--- a/.github/workflows/on-pull-request-opened-and-synchronize.yml
+++ b/.github/workflows/on-pull-request-opened-and-synchronize.yml
@@ -285,7 +285,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm
-      - run: pnpm dlx playwright@1.54.2 install --no-shell --with-deps chromium
+      - run: pnpm dlx playwright@1.54.2 install --only-shell --with-deps chromium
       - name: Download Baseline Screenshots
         uses: actions/download-artifact@v4
         with:

--- a/src/playwright/playwright.config.ts
+++ b/src/playwright/playwright.config.ts
@@ -100,12 +100,6 @@ export default defineConfig({
       // Something has gone wrong if one takes longer. So we fail fast to give
       // developers feedback quickly.
       timeout: 5000,
-
-      use: {
-        // - https://playwright.dev/docs/browsers#chromium-new-headless-mode
-        // - https://developer.chrome.com/blog/chrome-headless-shell
-        channel: 'chromium',
-      },
     },
   ],
   reporter: [


### PR DESCRIPTION
## 🚀 Description

N/A
<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

The full diff is expected. The old Chrome Headless renders most things slightly differently.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
