### PR TITLE
Add Select component

### DIFF
--- a/.changeset/nasty-pillows-heal.md
+++ b/.changeset/nasty-pillows-heal.md
@@ -1,0 +1,7 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Added a Select component. Select is like Menu but as a form control. Select has `name` and `value` attributes, and it supports form control methods like `reportValidity()` and `setValidity()`.
+
+Select does not support Form Controls Layout or multiselection. Multiselection support is coming soon.

--- a/.github/workflows/on-pull-request-opened-and-synchronize.yml
+++ b/.github/workflows/on-pull-request-opened-and-synchronize.yml
@@ -147,7 +147,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ matrix.shardIndex }}
-          path: dist/playwright/coverage-report
+          path: ./dist/playwright/coverage-report
       - name: Upload Test Report
         uses: actions/upload-artifact@v4
         with:

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -127,11 +127,11 @@ export default {
           }
 
           if (context.componentId === 'form-controls-layout') {
-            const isDropdownValueChanged =
+            const hasValueChanged =
               context.args['<glide-core-dropdown>.value'].toString() !==
               context.initialArgs['<glide-core-dropdown>.value'].toString();
 
-            if (isDropdownValueChanged) {
+            if (hasValueChanged) {
               $component
                 .querySelector('glide-core-dropdown')
                 .setAttribute(
@@ -173,11 +173,11 @@ export default {
           }
 
           if (context.componentId === 'dropdown') {
-            const isDropdownValueChanged =
+            const hasValueChanged =
               context.args.value.toString() !==
               context.initialArgs.value.toString();
 
-            if (isDropdownValueChanged) {
+            if (hasValueChanged) {
               $component.setAttribute(
                 'value',
                 JSON.stringify(context.args.value),
@@ -217,11 +217,11 @@ export default {
           }
 
           if (context.componentId === 'select') {
-            const isDropdownValueChanged =
+            const hasValueChanged =
               context.args.value.toString() !==
               context.initialArgs.value.toString();
 
-            if (isDropdownValueChanged) {
+            if (hasValueChanged) {
               $component.setAttribute(
                 'value',
                 JSON.stringify(context.args.value),

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -216,6 +216,32 @@ export default {
             }
           }
 
+          if (context.componentId === 'select') {
+            const isDropdownValueChanged =
+              context.args.value.toString() !==
+              context.initialArgs.value.toString();
+
+            if (isDropdownValueChanged) {
+              $component.setAttribute(
+                'value',
+                JSON.stringify(context.args.value),
+              );
+            }
+
+            for (const $option of $component.querySelectorAll(
+              'glide-core-options-group',
+            )) {
+              $option.removeAttribute('aria-label');
+            }
+
+            for (const $option of $component.querySelectorAll(
+              'glide-core-option',
+            )) {
+              $option.removeAttribute('aria-selected');
+              $option.removeAttribute('role');
+            }
+          }
+
           if (context.componentId === 'split-button') {
             for (const $option of $component.querySelectorAll(
               'glide-core-option',

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -6643,6 +6643,390 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/select.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "Select",
+          "slots": [
+            {
+              "name": "target",
+              "description": "The element to which Select will anchor. Can be any focusable element. If you want Select to be filterable, put an Input in this slot. Listen for Input's \"input\" event, then add and remove Option(s) from Select's default slot based on Input's value.",
+              "required": {
+                "tag": "required",
+                "name": "",
+                "type": "",
+                "optional": false,
+                "description": "",
+                "problems": [],
+                "source": [
+                  {
+                    "number": 8,
+                    "source": "          @required",
+                    "tokens": {
+                      "start": "          ",
+                      "delimiter": "",
+                      "postDelimiter": "",
+                      "tag": "@required",
+                      "postTag": "",
+                      "name": "",
+                      "postName": "",
+                      "type": "",
+                      "postType": "",
+                      "description": "",
+                      "end": "",
+                      "lineEnd": ""
+                    }
+                  }
+                ]
+              },
+              "type": {
+                "text": "Element"
+              }
+            },
+            {
+              "name": "",
+              "description": "",
+              "required": {
+                "tag": "required",
+                "name": "",
+                "type": "",
+                "optional": false,
+                "description": "",
+                "problems": [],
+                "source": [
+                  {
+                    "number": 2,
+                    "source": "          @required",
+                    "tokens": {
+                      "start": "          ",
+                      "delimiter": "",
+                      "postDelimiter": "",
+                      "tag": "@required",
+                      "postTag": "",
+                      "name": "",
+                      "postName": "",
+                      "type": "",
+                      "postType": "",
+                      "description": "",
+                      "end": "",
+                      "lineEnd": ""
+                    }
+                  }
+                ]
+              },
+              "type": {
+                "text": "Element"
+              }
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "formAssociated",
+              "type": {
+                "text": "boolean"
+              },
+              "static": true,
+              "default": "true"
+            },
+            {
+              "kind": "field",
+              "name": "shadowRootOptions",
+              "type": {
+                "text": "ShadowRootInit"
+              },
+              "static": true,
+              "default": "{ ...LitElement.shadowRootOptions, mode: shadowRootMode, }"
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "disabled",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "loading",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "loading",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "attribute": "name",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "offset",
+              "type": {
+                "text": "number"
+              },
+              "default": "4",
+              "attribute": "offset",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "open",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "open",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "placement",
+              "type": {
+                "text": "| 'bottom'\n    | 'left'\n    | 'right'\n    | 'top'\n    | 'bottom-start'\n    | 'bottom-end'\n    | 'left-start'\n    | 'left-end'\n    | 'right-start'\n    | 'right-end'\n    | 'top-start'\n    | 'top-end'"
+              },
+              "default": "'bottom-start'",
+              "description": "Select will try to move itself to the opposite of this value if not doing so would result in overflow.\nFor example, if \"bottom\" results in overflow Menu will try \"top\" but not \"right\" or \"left\".",
+              "attribute": "placement",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "attribute": "required",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string[]"
+              },
+              "default": "[]",
+              "attribute": "value"
+            },
+            {
+              "kind": "field",
+              "name": "version",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "version",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "form",
+              "type": {
+                "text": "HTMLFormElement | null"
+              },
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "targetLabelPrefix",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true
+            },
+            {
+              "kind": "method",
+              "name": "checkValidity",
+              "return": {
+                "type": {
+                  "text": "boolean"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "formAssociatedCallback",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "formResetCallback",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "reportValidity",
+              "return": {
+                "type": {
+                  "text": "boolean"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "setValidity",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "flags",
+                  "optional": true,
+                  "type": {
+                    "text": "ValidityStateFlags"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "field",
+              "name": "validity",
+              "type": {
+                "text": "ValidityState"
+              },
+              "readonly": true
+            }
+          ],
+          "events": [
+            {
+              "name": "input",
+              "type": {
+                "text": "Event"
+              }
+            },
+            {
+              "name": "change",
+              "type": {
+                "text": "Event"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "disabled"
+            },
+            {
+              "name": "loading",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "loading"
+            },
+            {
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "fieldName": "name"
+            },
+            {
+              "name": "offset",
+              "type": {
+                "text": "number"
+              },
+              "default": "4",
+              "fieldName": "offset"
+            },
+            {
+              "name": "open",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "open"
+            },
+            {
+              "name": "placement",
+              "type": {
+                "text": "| 'bottom'\n    | 'left'\n    | 'right'\n    | 'top'\n    | 'bottom-start'\n    | 'bottom-end'\n    | 'left-start'\n    | 'left-end'\n    | 'right-start'\n    | 'right-end'\n    | 'top-start'\n    | 'top-end'"
+              },
+              "default": "'bottom-start'",
+              "description": "Select will try to move itself to the opposite of this value if not doing so would result in overflow.\nFor example, if \"bottom\" results in overflow Menu will try \"top\" but not \"right\" or \"left\".",
+              "fieldName": "placement"
+            },
+            {
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "required"
+            },
+            {
+              "name": "value",
+              "type": {
+                "text": "string[]"
+              },
+              "default": "[]",
+              "fieldName": "value"
+            },
+            {
+              "name": "version",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "fieldName": "version"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "glide-core-select",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "default",
+          "declaration": {
+            "name": "Select",
+            "module": "src/select.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "glide-core-select",
+          "declaration": {
+            "name": "Select",
+            "module": "src/select.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/slider.styles.ts",
       "declarations": [],
       "exports": [

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -6839,14 +6839,6 @@
               "readonly": true
             },
             {
-              "kind": "field",
-              "name": "targetLabelPrefix",
-              "type": {
-                "text": "string"
-              },
-              "readonly": true
-            },
-            {
               "kind": "method",
               "name": "checkValidity",
               "return": {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -379,6 +379,7 @@ export default defineConfig([
       'src/stylelint/rules/*.test.ts',
       'src/accordion.test.*.ts',
       'src/button.test.*.ts',
+      'src/select.test.*.ts',
       'src/spinner.test.*.ts',
     ],
     rules: {

--- a/src/checkbox.test.forms.ts
+++ b/src/checkbox.test.forms.ts
@@ -2,11 +2,13 @@ import { html } from 'lit';
 import { expect, test } from './playwright/test.js';
 
 test('has a `form` property', { tag: '@forms' }, async ({ mount, page }) => {
-  await mount(() => html`
-    <form>
-      <glide-core-checkbox label="Label"></glide-core-checkbox>
-    </form>
-  `);
+  await mount(
+    () => html`
+      <form>
+        <glide-core-checkbox label="Label"></glide-core-checkbox>
+      </form>
+    `,
+  );
 
   const host = page.locator('glide-core-checkbox');
 
@@ -21,15 +23,17 @@ test(
   'can be reset',
   { tag: '@forms' },
   async ({ callMethod, mount, page, setProperty }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox
-          label="Label"
-          checked
-          indeterminate
-        ></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox
+            label="Label"
+            checked
+            indeterminate
+          ></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const host = page.locator('glide-core-checkbox');
     const form = page.locator('form');
@@ -47,16 +51,18 @@ test(
   'has form data when checked',
   { tag: '@forms' },
   async ({ mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox
-          label="Label"
-          name="name"
-          value="value"
-          checked
-        ></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox
+            label="Label"
+            name="name"
+            value="value"
+            checked
+          ></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const form = page.locator('form');
 
@@ -68,17 +74,19 @@ test(
   'has form data when checked and indeterminate',
   { tag: '@forms' },
   async ({ mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox
-          label="Label"
-          name="name"
-          value="value"
-          checked
-          indeterminate
-        ></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox
+            label="Label"
+            name="name"
+            value="value"
+            checked
+            indeterminate
+          ></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const form = page.locator('form');
 
@@ -90,15 +98,17 @@ test(
   'has no form data when unchecked',
   { tag: '@forms' },
   async ({ mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox
-          label="Label"
-          name="name"
-          value="value"
-        ></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox
+            label="Label"
+            name="name"
+            value="value"
+          ></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const form = page.locator('form');
 
@@ -110,16 +120,18 @@ test(
   'has no form data when unchecked and indeterminate',
   { tag: '@forms' },
   async ({ mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox
-          label="Label"
-          name="name"
-          value="value"
-          indeterminate
-        ></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox
+            label="Label"
+            name="name"
+            value="value"
+            indeterminate
+          ></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const form = page.locator('form');
 
@@ -131,17 +143,19 @@ test(
   'has no form data when checked and disabled',
   { tag: '@forms' },
   async ({ mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox
-          label="Label"
-          name="name"
-          value="value"
-          checked
-          disabled
-        ></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox
+            label="Label"
+            name="name"
+            value="value"
+            checked
+            disabled
+          ></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const form = page.locator('form');
 
@@ -153,15 +167,17 @@ test(
   'has no form data when checked and without a name',
   { tag: '@forms' },
   async ({ mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox
-          label="Label"
-          value="value"
-          checked
-        ></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox
+            label="Label"
+            value="value"
+            checked
+          ></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const form = page.locator('form');
 
@@ -170,18 +186,22 @@ test(
 );
 
 test(
-  'has no form data when checked and without a value',
+  'has no form data when disabled',
   { tag: '@forms' },
   async ({ mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox
-          label="Label"
-          name="name"
-          checked
-        ></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox
+            label="Label"
+            name="name"
+            value="value"
+            checked
+            disabled
+          ></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const form = page.locator('form');
 
@@ -193,11 +213,13 @@ test(
   'is valid when unchecked but not required',
   { tag: '@forms' },
   async ({ callMethod, mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox label="Label" checked></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox label="Label" checked></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const host = page.locator('glide-core-checkbox');
     const checkbox = page.getByRole('checkbox');
@@ -220,11 +242,13 @@ test(
   'is valid when required and unchecked but made not required programmatically',
   { tag: '@forms' },
   async ({ callMethod, mount, page, removeAttribute }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox label="Label" required></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox label="Label" required></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const host = page.locator('glide-core-checkbox');
     const checkbox = page.getByRole('checkbox');
@@ -249,15 +273,17 @@ test(
   'is both valid and invalid when unchecked and required but disabled',
   { tag: '@forms' },
   async ({ callMethod, mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox
-          label="Label"
-          disabled
-          required
-        ></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox
+            label="Label"
+            disabled
+            required
+          ></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const host = page.locator('glide-core-checkbox');
     const checkbox = page.getByRole('checkbox');
@@ -275,15 +301,17 @@ test(
   'is valid on submit when required and checked',
   { tag: '@forms' },
   async ({ addEventListener, mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox
-          label="Label"
-          checked
-          required
-        ></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox
+            label="Label"
+            checked
+            required
+          ></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const host = page.locator('glide-core-checkbox');
     const form = page.locator('form');
@@ -308,11 +336,13 @@ test(
   'is invalid when unchecked and required',
   { tag: '@forms' },
   async ({ callMethod, mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox label="Label" required></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox label="Label" required></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const host = page.locator('glide-core-checkbox');
     const checkbox = page.getByRole('checkbox');
@@ -335,15 +365,17 @@ test(
   'is invalid when required but unchecked via click',
   { tag: '@forms' },
   async ({ callMethod, mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox
-          label="Label"
-          checked
-          required
-        ></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox
+            label="Label"
+            checked
+            required
+          ></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const host = page.locator('glide-core-checkbox');
     const checkbox = page.getByRole('checkbox');
@@ -368,11 +400,13 @@ test(
   'is invalid on submit when required and unchecked',
   { tag: '@forms' },
   async ({ mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox label="Label" required></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox label="Label" required></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const host = page.locator('glide-core-checkbox');
     const checkbox = page.getByRole('checkbox');
@@ -397,11 +431,13 @@ test(
   'submits its form on Enter',
   { tag: '@forms' },
   async ({ addEventListener, mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox label="Label"></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox label="Label"></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const form = page.locator('form');
     const checkbox = page.getByRole('checkbox');
@@ -421,11 +457,13 @@ test(
   'updates its validity on blur',
   { tag: '@forms' },
   async ({ callMethod, mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox label="Label" required></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox label="Label" required></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const host = page.locator('glide-core-checkbox');
     const checkbox = page.getByRole('checkbox');
@@ -447,11 +485,13 @@ test(
   'supports `setCustomValidity()`',
   { tag: '@forms' },
   async ({ callMethod, mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox label="Label" required></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox label="Label" required></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const host = page.locator('glide-core-checkbox');
     const validityMessage = page.locator('[data-test="validity-message"]');
@@ -481,15 +521,17 @@ test(
   'supports `setValidity()`',
   { tag: '@forms' },
   async ({ callMethod, mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox
-          label="Label"
-          checked
-          required
-        ></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox
+            label="Label"
+            checked
+            required
+          ></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const host = page.locator('glide-core-checkbox');
     const validityMessage = page.locator('[data-test="validity-message"]');
@@ -510,11 +552,13 @@ test(
   'supports `resetValidityFeedback()`',
   { tag: '@forms' },
   async ({ callMethod, mount, page }) => {
-    await mount(() => html`
-      <form>
-        <glide-core-checkbox label="Label" required></glide-core-checkbox>
-      </form>
-    `);
+    await mount(
+      () => html`
+        <form>
+          <glide-core-checkbox label="Label" required></glide-core-checkbox>
+        </form>
+      `,
+    );
 
     const host = page.locator('glide-core-checkbox');
     const validityMessage = page.locator('[data-test="validity-message"]');

--- a/src/dropdown.stories.ts
+++ b/src/dropdown.stories.ts
@@ -68,12 +68,8 @@ const meta: Meta = {
     '<glide-core-dropdown-option>.disabled': false,
     '<glide-core-dropdown-option>.editable': false,
     '<glide-core-dropdown-option>.one.selected': false,
-    '<glide-core-dropdown-option>.two.selected': false,
-    '<glide-core-dropdown-option>.three.selected': false,
     '<glide-core-dropdown-option>[slot="icon"]': '',
     '<glide-core-dropdown-option>.one.value': 'one',
-    '<glide-core-dropdown-option>.two.value': 'two',
-    '<glide-core-dropdown-option>.three.value': 'three',
     '<glide-core-dropdown-option>.one.version': '',
   },
   argTypes: {

--- a/src/dropdown.test.accessibility.ts
+++ b/src/dropdown.test.accessibility.ts
@@ -369,6 +369,87 @@ test.describe('multiple=${false}', () => {
     `);
   });
 
+  test('placeholder', { tag: '@accessibility' }, async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        element.placeholder = 'Placeholder';
+      });
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+    - text: Label Placeholder
+    - button "Label"
+  `);
+  });
+
+  test('select-all', { tag: '@accessibility' }, async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        element.multiple = true;
+        element.open = true;
+        element.selectAll = true;
+      });
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+    - text: Label
+    - button "Label" [expanded]
+    - listbox:
+      - option "Select all":
+        - checkbox "Select all"
+      - option "One":
+        - checkbox "One"
+      - option "Two":
+        - checkbox "Two"
+      - option "Three":
+        - checkbox "Three"
+  `);
+  });
+
+  test('slot="description"', { tag: '@accessibility' }, async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        const div = document.createElement('div');
+
+        div.textContent = 'Description';
+        div.slot = 'description';
+
+        element.append(div);
+      });
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+    - text: Label
+    - button "Label"
+    - text: Description
+  `);
+  });
+
+  test('tooltip', { tag: '@accessibility' }, async ({ page }) => {
+    await page.goto('?id=dropdown--dropdown');
+
+    await page
+      .locator('glide-core-dropdown')
+      .evaluate<void, Dropdown>((element) => {
+        element.tooltip = 'Tooltip';
+      });
+
+    await page.locator('glide-core-tooltip').getByRole('button').focus();
+
+    await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
+    - button "Tooltip:"
+    - tooltip "Tooltip"
+    - text: Label
+    - button "Label"
+  `);
+  });
+
   test(
     '<glide-core-dropdown-option>.count',
     { tag: '@accessibility' },
@@ -459,85 +540,4 @@ test.describe('multiple=${false}', () => {
       `);
     },
   );
-});
-
-test('placeholder', { tag: '@accessibility' }, async ({ page }) => {
-  await page.goto('?id=dropdown--dropdown');
-
-  await page
-    .locator('glide-core-dropdown')
-    .evaluate<void, Dropdown>((element) => {
-      element.placeholder = 'Placeholder';
-    });
-
-  await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
-    - text: Label Placeholder
-    - button "Label"
-  `);
-});
-
-test('select-all', { tag: '@accessibility' }, async ({ page }) => {
-  await page.goto('?id=dropdown--dropdown');
-
-  await page
-    .locator('glide-core-dropdown')
-    .evaluate<void, Dropdown>((element) => {
-      element.multiple = true;
-      element.open = true;
-      element.selectAll = true;
-    });
-
-  await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
-    - text: Label
-    - button "Label" [expanded]
-    - listbox:
-      - option "Select all":
-        - checkbox "Select all"
-      - option "One":
-        - checkbox "One"
-      - option "Two":
-        - checkbox "Two"
-      - option "Three":
-        - checkbox "Three"
-  `);
-});
-
-test('slot="description"', { tag: '@accessibility' }, async ({ page }) => {
-  await page.goto('?id=dropdown--dropdown');
-
-  await page
-    .locator('glide-core-dropdown')
-    .evaluate<void, Dropdown>((element) => {
-      const div = document.createElement('div');
-
-      div.textContent = 'Description';
-      div.slot = 'description';
-
-      element.append(div);
-    });
-
-  await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
-    - text: Label
-    - button "Label"
-    - text: Description
-  `);
-});
-
-test('tooltip', { tag: '@accessibility' }, async ({ page }) => {
-  await page.goto('?id=dropdown--dropdown');
-
-  await page
-    .locator('glide-core-dropdown')
-    .evaluate<void, Dropdown>((element) => {
-      element.tooltip = 'Tooltip';
-    });
-
-  await page.locator('glide-core-tooltip').getByRole('button').focus();
-
-  await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
-    - button "Tooltip:"
-    - tooltip "Tooltip"
-    - text: Label
-    - button "Label"
-  `);
 });

--- a/src/playwright/fixtures/mount.ts
+++ b/src/playwright/fixtures/mount.ts
@@ -19,16 +19,16 @@ export default test.extend<{
       context?: Context<Type>,
     ): Promise<void> {
       return test.step('mount()', async () => {
-        await page.route('favicon.ico', (route) => {
-          // Stop the browser from attempting to fetch a favicon so a 404 doesn't show up
-          // in the console.
-          route.abort();
-        });
-
         let pageError: Error | undefined;
 
         page.on('pageerror', (error: Error) => {
           pageError = error;
+        });
+
+        await page.route('favicon.ico', (route) => {
+          // Stop the browser from attempting to fetch a favicon so a 404 doesn't show up
+          // in the console.
+          route.abort();
         });
 
         await page.goto('/playwright.html');

--- a/src/playwright/playwright.config.ts
+++ b/src/playwright/playwright.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
             'src/button.test.*.ts',
             'src/checkbox.test.*.ts',
             'src/icon-button.test.*.ts',
+            'src/select.test.*.ts',
             'src/spinner.test.*.ts',
           ],
           testIgnore: ['src/*.test.visuals.ts'],
@@ -115,6 +116,7 @@ export default defineConfig({
           'src/button.ts',
           'src/checkbox.ts',
           'src/icon-button.ts',
+          'src/select.ts',
           'src/spinner.ts',
         ],
 

--- a/src/select.stories.ts
+++ b/src/select.stories.ts
@@ -1,0 +1,747 @@
+import './icons/storybook.js';
+import './icon-button.js';
+import './option.js';
+import './options.js';
+import './options.group.js';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html, nothing } from 'lit';
+import { UPDATE_STORY_ARGS } from '@storybook/core-events';
+import { addons } from '@storybook/preview-api';
+import { withActions } from '@storybook/addon-actions/decorator';
+import MenuComponent from './menu.js';
+import SelectComponent from './select.js';
+
+const meta: Meta = {
+  title: 'Select',
+  decorators: [withActions],
+  parameters: {
+    actions: {
+      handles: ['change', 'input', 'toggle'],
+    },
+    docs: {
+      story: {
+        autoplay: true,
+      },
+    },
+  },
+  args: {
+    'slot="default"': '',
+    'slot="target"': '',
+    targetLabelPrefix: '',
+    'addEventListener(event, handler)': '',
+    'checkValidity()': '',
+    disabled: false,
+    loading: false,
+    name: '',
+    offset: 4,
+    open: false,
+    placement: 'bottom-start',
+    'reportValidity()': '',
+    required: false,
+    'setValidity(flags, message)': '',
+    value: [],
+    version: '',
+    '<glide-core-options>[slot="default"]': '',
+    '<glide-core-options>.version': '',
+    '<glide-core-options-group>.label': 'A',
+    '<glide-core-options-group>.hide-label': false,
+    '<glide-core-option>.label': 'One',
+    '<glide-core-option>.addEventListener(event, handler)': '',
+    '<glide-core-option>.description': '',
+    '<glide-core-option>.disabled': false,
+    '<glide-core-option>.one.selected': false,
+    '<glide-core-option>[slot="content"]': '',
+    '<glide-core-option>[slot="icon"]': '',
+    '<glide-core-option>[slot="submenu"]': '',
+    '<glide-core-option>[slot="submenu"].open': '',
+    '<glide-core-option>.value': 'one',
+    '<glide-core-option>.version': '',
+  },
+  argTypes: {
+    'slot="default"': {
+      table: {
+        type: { summary: 'Element' },
+      },
+      type: { name: 'function', required: true },
+    },
+    'slot="target"': {
+      table: {
+        type: {
+          summary: 'Element',
+          detail: `
+// The element to which Select will anchor. Can be any focusable element.
+//
+// If you want Select to be filterable, put an Input in this slot. Listen for Input's "input"
+// event, then add and remove Option(s) from Select's default slot based on Input's value.
+`,
+        },
+      },
+      type: { name: 'function', required: true },
+    },
+    targetLabelPrefix: {
+      table: {
+        defaultValue: { summary: '""' },
+        type: {
+          summary: 'getter',
+          detail: `
+// Returns a string containing the \`label\` of each selected Option.
+//
+// Update the label of your target to include this string whenever an Option is selected or deselected
+// so screenreaders know which Option(s) are selected.
+`,
+        },
+      },
+      type: { name: 'function', required: true },
+    },
+    'addEventListener(event, handler)': {
+      control: false,
+      table: {
+        type: {
+          summary: 'method',
+          detail:
+            '(event: "change" | "input" | "toggle", handler: (event: Event) => void): void',
+        },
+      },
+    },
+    'checkValidity()': {
+      control: false,
+      table: {
+        type: {
+          summary: 'method',
+          detail: '(): boolean',
+        },
+      },
+    },
+    disabled: {
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+          detail: `
+// This attribute only affects whether Select's \`value\` is included in a form submission. You
+// provide and manage Select's target. So it's up to you to also disable your target when you
+// disable Select.
+`,
+        },
+      },
+    },
+    loading: {
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+          detail: `
+// Add this attribute when asynchronously updating Options' default slot. Remove it after the slot
+// has been updated.
+`,
+        },
+      },
+    },
+    name: {
+      table: {
+        defaultValue: { summary: '""' },
+        type: { summary: 'string' },
+      },
+    },
+    offset: {
+      table: {
+        defaultValue: { summary: '4' },
+        type: { summary: 'number' },
+      },
+    },
+    open: {
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    placement: {
+      control: { type: 'select' },
+      options: [
+        'bottom',
+        'left',
+        'right',
+        'top',
+        'bottom-start',
+        'bottom-end',
+        'left-start',
+        'left-end',
+        'right-start',
+        'right-end',
+        'top-start',
+        'top-end',
+      ],
+      table: {
+        defaultValue: { summary: '"bottom-start"' },
+        type: {
+          summary:
+            '"bottom" | "left" | "right" | "top" | "bottom-start" | "bottom-end" | "left-start" | "left-end" | "right-start" | "right-end" | "top-start" | "top-end"',
+        },
+      },
+    },
+    'reportValidity()': {
+      control: false,
+      table: {
+        type: {
+          summary: 'method',
+          detail: '(): boolean',
+        },
+      },
+    },
+    required: {
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    'setValidity(flags, message)': {
+      control: false,
+      table: {
+        type: {
+          summary: 'method',
+          detail:
+            '((flags?: ValidityStateFlags, message?: string) => void): void',
+        },
+      },
+    },
+    value: {
+      table: {
+        defaultValue: { summary: '[]' },
+        type: {
+          summary: 'string[]',
+        },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_GLIDE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
+    '<glide-core-options>[slot="default"]': {
+      name: 'slot="default"',
+      control: false,
+      table: {
+        category: 'Options',
+        type: {
+          summary: 'Option',
+        },
+      },
+      type: { name: 'function' },
+    },
+    '<glide-core-options>.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Options',
+        defaultValue: {
+          summary: import.meta.env.VITE_GLIDE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
+    '<glide-core-options-group>.label': {
+      name: 'label',
+      table: {
+        category: 'Options Group',
+      },
+      type: { name: 'string', required: true },
+    },
+    '<glide-core-options-group>.hide-label': {
+      name: 'hide-label',
+      table: {
+        category: 'Options Group',
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    '<glide-core-options-group>.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Options Group',
+        defaultValue: {
+          summary: import.meta.env.VITE_GLIDE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
+    '<glide-core-option>.label': {
+      name: 'label',
+      table: {
+        category: 'Option',
+        type: { summary: 'string' },
+      },
+      type: { name: 'string', required: true },
+    },
+    '<glide-core-option>.addEventListener(event, handler)': {
+      name: 'addEventListener(event, handler)',
+      control: false,
+      table: {
+        category: 'Option',
+        type: {
+          summary: 'method',
+          detail: '(event: "click", handler: (event: Event) => void): void',
+        },
+      },
+    },
+    '<glide-core-option>.description': {
+      name: 'description',
+      table: {
+        category: 'Option',
+        type: { summary: 'string' },
+      },
+      type: { name: 'string' },
+    },
+    '<glide-core-option>.disabled': {
+      name: 'disabled',
+      table: {
+        category: 'Option',
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    '<glide-core-option>.one.selected': {
+      name: 'selected',
+      table: {
+        category: 'Option',
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    '<glide-core-option>.two.selected': {
+      table: {
+        disable: true,
+      },
+    },
+    '<glide-core-option>.three.selected': {
+      table: {
+        disable: true,
+      },
+    },
+    '<glide-core-option>[slot="content"]': {
+      name: 'slot="content"',
+      control: false,
+      table: {
+        category: 'Option',
+        type: {
+          summary: 'Element | Text',
+          detail: `
+// This is the unhappy path. It's the escape hatch where you can render arbitrary content and lay it out
+// however you need to.
+//
+// If you go this route, \`slot="icon"\` and \`slot="submenu"\` will become unavailable. And the \`label\`
+// and \`description\` attributes won't be rendered.
+//
+// The \`label\` attribute is still required. We'll show it in a tooltip when your content overflows. If you
+// need a second line of text in the tooltip, you can provide it via the \`description\` attribute.
+`,
+        },
+      },
+      type: { name: 'function' },
+    },
+    '<glide-core-option>[slot="icon"]': {
+      name: 'slot="icon"',
+      control: false,
+      table: {
+        category: 'Option',
+        type: {
+          summary: 'Element',
+        },
+      },
+      type: { name: 'function' },
+    },
+    '<glide-core-option>[slot="submenu"]': {
+      name: 'slot="submenu"',
+      control: false,
+      table: {
+        category: 'Option',
+        type: {
+          summary: 'Menu',
+        },
+      },
+      type: { name: 'function' },
+    },
+    '<glide-core-option>[slot="submenu"].open': {
+      table: {
+        disable: true,
+      },
+    },
+    '<glide-core-option>.value': {
+      name: 'value',
+      table: {
+        category: 'Option',
+        defaultValue: { summary: '""' },
+        type: { summary: 'string' },
+      },
+      type: { name: 'string' },
+    },
+    '<glide-core-option>.version': {
+      control: false,
+      name: 'version',
+      table: {
+        category: 'Option',
+        defaultValue: {
+          summary: import.meta.env.VITE_GLIDE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
+  },
+  play(context) {
+    const option = context.canvasElement.querySelector('glide-core-option');
+
+    context.canvasElement
+      .querySelector('glide-core-select')
+      ?.addEventListener('change', (event: Event) => {
+        if (option && event.target instanceof SelectComponent) {
+          addons.getChannel().emit(UPDATE_STORY_ARGS, {
+            storyId: context.id,
+            updatedArgs: {
+              targetLabelPrefix: event.target.targetLabelPrefix,
+              value: event.target.value,
+            },
+          });
+        }
+      });
+
+    context.canvasElement
+      .querySelector('glide-core-select')
+      ?.addEventListener('toggle', (event: Event) => {
+        const isFromSubMenu =
+          event.target instanceof Element &&
+          event.target.closest('glide-core-option');
+
+        if (event.target instanceof SelectComponent && !isFromSubMenu) {
+          addons.getChannel().emit(UPDATE_STORY_ARGS, {
+            storyId: context.id,
+            updatedArgs: {
+              open: event.target.open,
+              value: event.target.value,
+            },
+          });
+        }
+      });
+
+    context.canvasElement
+      .querySelector('glide-core-menu')
+      ?.addEventListener('toggle', (event: Event) => {
+        if (event.target instanceof MenuComponent) {
+          addons.getChannel().emit(UPDATE_STORY_ARGS, {
+            storyId: context.id,
+            updatedArgs: {
+              '<glide-core-option>[slot="submenu"].open': event.target.open,
+            },
+          });
+        }
+      });
+
+    context.canvasElement
+      .querySelector('form')
+      ?.addEventListener('submit', (event: Event) => {
+        event.preventDefault();
+
+        // We reload the page to give the impression of a submission while keeping
+        // the user on the same page.
+        window.location.reload();
+      });
+  },
+  render(arguments_) {
+    /* eslint-disable @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+    return html`<glide-core-select
+      name=${arguments_.name || nothing}
+      offset=${arguments_.offset === 4 ? nothing : arguments_.offset}
+      placement=${arguments_.placement === 'bottom-start'
+        ? nothing
+        : arguments_.placement}
+      .value=${arguments_.value}
+      ?disabled=${arguments_.disabled}
+      ?loading=${arguments_.loading}
+      ?open=${arguments_.open}
+      ?required=${arguments_.required}
+    >
+      <glide-core-icon-button
+        label=${arguments_.targetLabelPrefix
+          ? arguments_.targetLabelPrefix + ' Toggle'
+          : 'Toggle'}
+        slot="target"
+      >
+        <glide-core-example-icon name="chevron-down"></glide-core-example-icon>
+      </glide-core-icon-button>
+
+      <glide-core-options>
+        <glide-core-option
+          label=${arguments_['<glide-core-option>.label']}
+          description=${arguments_['<glide-core-option>.description'] ||
+          nothing}
+          value=${arguments_['<glide-core-option>.value'] || nothing}
+          ?disabled=${arguments_['<glide-core-option>.disabled']}
+          ?selected=${arguments_.value.includes(
+            arguments_['<glide-core-option>.value'],
+          )}
+        >
+          <glide-core-menu
+            slot="submenu"
+            ?open=${arguments_['<glide-core-option>[slot="submenu"].open']}
+          >
+            <glide-core-example-icon
+              slot="target"
+              name="three-dots"
+            ></glide-core-example-icon>
+
+            <glide-core-options>
+              <glide-core-option label="Four"></glide-core-option>
+              <glide-core-option label="Five"></glide-core-option>
+              <glide-core-option label="Six"></glide-core-option>
+            </glide-core-options>
+          </glide-core-menu>
+        </glide-core-option>
+
+        <glide-core-option
+          label="Two"
+          value="two"
+          ?selected=${arguments_.value.includes('two')}
+        ></glide-core-option>
+        <glide-core-option
+          label="Three"
+          value="three"
+          ?selected=${arguments_.value.includes('three')}
+        ></glide-core-option>
+      </glide-core-options>
+    </glide-core-select>`;
+  },
+};
+
+export default meta;
+
+export const Select: StoryObj = {
+  decorators: [
+    (story) => html`
+      <form action="/">
+        <script type="ignore">
+          import '@crowdstrike/glide-core/select.js';
+          import '@crowdstrike/glide-core/options.js';
+          import '@crowdstrike/glide-core/option.js';
+          import '@crowdstrike/glide-core/menu.js';
+        </script>
+
+        ${story()}
+      </form>
+    `,
+  ],
+};
+
+export const WithGroups: StoryObj = {
+  decorators: [
+    (story) => html`
+      <form action="/">
+        <script type="ignore">
+          import '@crowdstrike/glide-core/select.js';
+          import '@crowdstrike/glide-core/options.js';
+          import '@crowdstrike/glide-core/options.group.js';
+          import '@crowdstrike/glide-core/option.js';
+          import '@crowdstrike/glide-core/menu.js';
+        </script>
+
+        ${story()}
+      </form>
+    `,
+  ],
+  render(arguments_) {
+    return html`<glide-core-select
+      name=${arguments_.name || nothing}
+      offset=${arguments_.offset === 4 ? nothing : arguments_.offset}
+      placement=${arguments_.placement === 'bottom-start'
+        ? nothing
+        : arguments_.placement}
+      ?disabled=${arguments_.disabled}
+      ?loading=${arguments_.loading}
+      ?open=${arguments_.open}
+      ?required=${arguments_.required}
+      .value=${arguments_.value}
+    >
+      <glide-core-icon-button label="Toggle" slot="target">
+        <glide-core-example-icon name="chevron-down"></glide-core-example-icon>
+      </glide-core-icon-button>
+
+      <glide-core-options>
+        <glide-core-options-group
+          label=${arguments_['<glide-core-options-group>.label']}
+          ?hide-label=${arguments_['<glide-core-options-group>.hide-label']}
+        >
+          <glide-core-option
+            label=${arguments_['<glide-core-option>.label']}
+            description=${arguments_['<glide-core-option>.description'] ||
+            nothing}
+            value=${arguments_['<glide-core-option>.value'] || nothing}
+            ?disabled=${arguments_['<glide-core-option>.disabled']}
+            ?selected=${arguments_.value.includes(
+              arguments_['<glide-core-option>.value'],
+            )}
+          >
+            <glide-core-menu
+              slot="submenu"
+              ?open=${arguments_['<glide-core-option>[slot="submenu"].open']}
+            >
+              <glide-core-example-icon
+                slot="target"
+                name="three-dots"
+              ></glide-core-example-icon>
+
+              <glide-core-options>
+                <glide-core-option label="Ten"></glide-core-option>
+                <glide-core-option label="Eleven"></glide-core-option>
+                <glide-core-option label="Twelve"></glide-core-option>
+              </glide-core-options>
+            </glide-core-menu>
+          </glide-core-option>
+
+          <glide-core-option
+            label="Two"
+            value="two"
+            ?selected=${arguments_.value.includes('two')}
+          ></glide-core-option>
+          <glide-core-option
+            label="Three"
+            value="three"
+            ?selected=${arguments_.value.includes('three')}
+          ></glide-core-option>
+        </glide-core-options-group>
+
+        <glide-core-options-group
+          label="B"
+          ?hide-label=${arguments_['<glide-core-options-group>.hide-label']}
+        >
+          <glide-core-option
+            label="Four"
+            value="four"
+            ?selected=${arguments_.value.includes('four')}
+          ></glide-core-option>
+          <glide-core-option
+            label="Five"
+            value="five"
+            ?selected=${arguments_.value.includes('five')}
+          ></glide-core-option>
+          <glide-core-option
+            label="Six"
+            value="six"
+            ?selected=${arguments_.value.includes('six')}
+          ></glide-core-option>
+        </glide-core-options-group>
+
+        <glide-core-options-group
+          label="C"
+          ?hide-label=${arguments_['<glide-core-options-group>.hide-label']}
+        >
+          <glide-core-option
+            label="Seven"
+            value="seven"
+            ?selected=${arguments_.value.includes('seven')}
+          ></glide-core-option>
+          <glide-core-option
+            label="Eight"
+            value="eight"
+            ?selected=${arguments_.value.includes('eight')}
+          ></glide-core-option>
+          <glide-core-option
+            label="Nine"
+            value="nine"
+            ?selected=${arguments_.value.includes('nine')}
+          ></glide-core-option>
+        </glide-core-options-group>
+      </glide-core-options>
+    </glide-core-select>`;
+  },
+};
+
+export const WithIcons: StoryObj = {
+  decorators: [
+    (story) => html`
+      <script type="ignore">
+        import '@crowdstrike/glide-core/select.js';
+        import '@crowdstrike/glide-core/options.js';
+        import '@crowdstrike/glide-core/option.js';
+        import '@crowdstrike/glide-core/menu.js';
+      </script>
+
+      ${story()}
+    `,
+  ],
+  render(arguments_) {
+    return html`<glide-core-select
+      name=${arguments_.name || nothing}
+      offset=${arguments_.offset === 4 ? nothing : arguments_.offset}
+      placement=${arguments_.placement === 'bottom-start'
+        ? nothing
+        : arguments_.placement}
+      ?disabled=${arguments_.disabled}
+      ?loading=${arguments_.loading}
+      ?open=${arguments_.open}
+      ?required=${arguments_.required}
+      .value=${arguments_.value}
+    >
+      <glide-core-icon-button label="Toggle" slot="target">
+        <glide-core-example-icon name="chevron-down"></glide-core-example-icon>
+      </glide-core-icon-button>
+
+      <glide-core-options>
+        <glide-core-option
+          label=${arguments_['<glide-core-option>.label']}
+          description=${arguments_['<glide-core-option>.description'] ||
+          nothing}
+          value=${arguments_['<glide-core-option>.value'] || nothing}
+          ?disabled=${arguments_['<glide-core-option>.disabled']}
+          ?selected=${arguments_.value.includes(
+            arguments_['<glide-core-option>.value'],
+          )}
+        >
+          <glide-core-example-icon
+            slot="icon"
+            name="edit"
+          ></glide-core-example-icon>
+
+          <glide-core-menu
+            slot="submenu"
+            ?open=${arguments_['<glide-core-option>[slot="submenu"].open']}
+          >
+            <glide-core-example-icon
+              slot="target"
+              name="three-dots"
+            ></glide-core-example-icon>
+
+            <glide-core-options>
+              <glide-core-option label="Four"></glide-core-option>
+              <glide-core-option label="Five"></glide-core-option>
+              <glide-core-option label="Six"></glide-core-option>
+            </glide-core-options>
+          </glide-core-menu>
+        </glide-core-option>
+
+        <glide-core-option
+          label="Two"
+          value="two"
+          ?selected=${arguments_.value.includes('two')}
+        >
+          <glide-core-example-icon
+            slot="icon"
+            name="move"
+          ></glide-core-example-icon>
+        </glide-core-option>
+
+        <glide-core-option
+          label="Three"
+          value="three"
+          ?selected=${arguments_.value.includes('three')}
+        >
+          <glide-core-example-icon
+            slot="icon"
+            name="share"
+          ></glide-core-example-icon>
+        </glide-core-option>
+      </glide-core-options>
+    </glide-core-select>`;
+  },
+};

--- a/src/select.stories.ts
+++ b/src/select.stories.ts
@@ -27,7 +27,6 @@ const meta: Meta = {
   args: {
     'slot="default"': '',
     'slot="target"': '',
-    targetLabelPrefix: '',
     'addEventListener(event, handler)': '',
     'checkValidity()': '',
     disabled: false,
@@ -73,21 +72,6 @@ const meta: Meta = {
 //
 // If you want Select to be filterable, put an Input in this slot. Listen for Input's "input"
 // event, then add and remove Option(s) from Select's default slot based on Input's value.
-`,
-        },
-      },
-      type: { name: 'function', required: true },
-    },
-    targetLabelPrefix: {
-      table: {
-        defaultValue: { summary: '""' },
-        type: {
-          summary: 'getter',
-          detail: `
-// Returns a string containing the \`label\` of each selected Option.
-//
-// Update the label of your target to include this string whenever an Option is selected or deselected
-// so screenreaders know which Option(s) are selected.
 `,
         },
       },
@@ -401,7 +385,6 @@ const meta: Meta = {
           addons.getChannel().emit(UPDATE_STORY_ARGS, {
             storyId: context.id,
             updatedArgs: {
-              targetLabelPrefix: event.target.targetLabelPrefix,
               value: event.target.value,
             },
           });
@@ -463,12 +446,7 @@ const meta: Meta = {
       ?open=${arguments_.open}
       ?required=${arguments_.required}
     >
-      <glide-core-icon-button
-        label=${arguments_.targetLabelPrefix
-          ? arguments_.targetLabelPrefix + ' Toggle'
-          : 'Toggle'}
-        slot="target"
-      >
+      <glide-core-icon-button label="Toggle" slot="target">
         <glide-core-example-icon name="chevron-down"></glide-core-example-icon>
       </glide-core-icon-button>
 

--- a/src/select.test.accessibility.ts
+++ b/src/select.test.accessibility.ts
@@ -1,0 +1,242 @@
+import { html } from 'lit';
+import { expect, test } from './playwright/test.js';
+import type Select from './select.js';
+import type Menu from './menu.js';
+import Option from './option.js';
+
+test('is accessible', { tag: '@accessibility' }, async ({ mount, page }) => {
+  await mount(
+    () =>
+      html`<glide-core-select open>
+        <button slot="target">Target</button>
+
+        <glide-core-options>
+          <glide-core-options-group label="A">
+            <glide-core-option label="One" selected>
+              <glide-core-menu slot="submenu">
+                <span slot="target">☀</span>
+
+                <glide-core-options>
+                  <glide-core-option label="Five"></glide-core-option>
+                  <glide-core-option label="Six"></glide-core-option>
+                </glide-core-options>
+              </glide-core-menu>
+            </glide-core-option>
+
+            <glide-core-option label="Two"></glide-core-option>
+          </glide-core-options-group>
+
+          <glide-core-options-group label="B">
+            <glide-core-option label="Three"></glide-core-option>
+            <glide-core-option label="Four"></glide-core-option>
+          </glide-core-options-group>
+        </glide-core-options>
+      </glide-core-select>`,
+  );
+
+  await expect(page).toBeAccessible('glide-core-select', [
+    // Menu has a similar test and it passes. The difference is that Select changes
+    // the role of Options to "listbox" and the role of Option(s) to "option". This
+    // test passes without whitelisting violations if you remove the sub-Menu.
+    //
+    // My suspicion, which I had while building Select, is that a "listbox" with a
+    // nested "menu" isn't a strictly valid pattern. But what to do if a design calls
+    // for a Menu-like thing that's a form control and has a sub-Menu?
+    'aria-allowed-attr',
+    'nested-interactive',
+  ]);
+
+  await mount(
+    () =>
+      html`<glide-core-select loading open>
+        <button slot="target">Target</button>
+        <glide-core-options></glide-core-options>
+      </glide-core-select>`,
+  );
+
+  await expect(page).toBeAccessible('glide-core-select');
+});
+
+test('loading', { tag: '@accessibility' }, async ({ page }) => {
+  await page.goto('?id=select--select');
+
+  await page.locator('glide-core-select').evaluate<void, Select>((element) => {
+    element.loading = true;
+    element.open = true;
+  });
+
+  await expect(page.locator('glide-core-select')).toMatchAriaSnapshot(`
+    - button "Toggle"
+    - listbox "Toggle"
+  `);
+});
+
+test('open=${true}', { tag: '@accessibility' }, async ({ page }) => {
+  await page.goto('?id=select--select');
+
+  await page.locator('glide-core-select').evaluate<void, Select>((element) => {
+    element.value = ['one'];
+    element.open = true;
+  });
+
+  await page
+    .locator('glide-core-option glide-core-menu')
+    .evaluate<void, Menu>((element) => {
+      element.open = true;
+    });
+
+  await expect(page.locator('glide-core-select')).toMatchAriaSnapshot(`
+    - button "Toggle" [expanded]
+    - listbox "Toggle":
+      - option "One" [selected]:
+        - menu:
+          - menuitem "Four"
+          - menuitem "Five"
+          - menuitem "Six"
+      - option "Two"
+      - option "Three"
+  `);
+});
+
+test('open=${false}', { tag: '@accessibility' }, async ({ page }) => {
+  await page.goto('?id=select--select');
+
+  await expect(page.locator('glide-core-select')).toMatchAriaSnapshot(`
+    - button "Toggle"
+  `);
+});
+
+test(
+  '<glide-core-options-group>',
+  { tag: '@accessibility' },
+  async ({ page }) => {
+    await page.goto('?id=select--with-groups');
+
+    await page
+      .locator('glide-core-select')
+      .evaluate<void, Select>((element) => {
+        element.value = ['one'];
+        element.open = true;
+      });
+
+    await page
+      .locator('glide-core-option glide-core-menu')
+      .evaluate<void, Select>((element) => {
+        element.open = true;
+      });
+
+    await expect(page.locator('glide-core-select')).toMatchAriaSnapshot(`
+      - button "Toggle"
+      - listbox "Toggle":
+        - group "A":
+          - option "One" [selected]:
+            - menu:
+              - menuitem "Ten"
+              - menuitem "Eleven"
+              - menuitem "Twelve"
+          - option "Two"
+          - option "Three"
+        - group "B":
+          - option "Four"
+          - option "Five"
+          - option "Six"
+        - group "C":
+          - option "Seven"
+          - option "Eight"
+          - option "Nine"
+    `);
+  },
+);
+
+test(
+  '<glide-core-option>.description',
+  { tag: '@accessibility' },
+  async ({ page }) => {
+    await page.goto('?id=select--select');
+
+    await page
+      .locator('glide-core-select')
+      .evaluate<void, Select>((element) => {
+        element.open = true;
+      });
+
+    await page
+      .locator('glide-core-option')
+      .first()
+      .evaluate<void, Option>((element) => {
+        element.description = 'Description';
+      });
+
+    await expect(page.locator('glide-core-select')).toMatchAriaSnapshot(`
+      - button "Toggle"
+      - listbox "Toggle":
+        - option "One Description"
+        - option "Two"
+        - option "Three"
+    `);
+  },
+);
+
+test(
+  '<glide-core-option>.disabled',
+  { tag: '@accessibility' },
+  async ({ page }) => {
+    await page.goto('?id=select--select');
+
+    await page
+      .locator('glide-core-select')
+      .evaluate<void, Select>((element) => {
+        element.open = true;
+      });
+
+    await page
+      .locator('glide-core-option')
+      .first()
+      .evaluate<void, Option>((element) => {
+        element.disabled = true;
+      });
+
+    await expect(page.locator('glide-core-select')).toMatchAriaSnapshot(`
+      - button "Toggle"
+      - listbox "Toggle":
+        - option "One" [disabled]
+        - option "Two"
+        - option "Three"
+    `);
+  },
+);
+
+test(
+  '<glide-core-option>[slot="content"]',
+  { tag: '@accessibility' },
+  async ({ page }) => {
+    await page.goto('?id=select--select');
+
+    await page
+      .locator('glide-core-select')
+      .evaluate<void, Select>((element) => {
+        element.value = ['one'];
+        element.open = true;
+      });
+
+    await page
+      .locator('glide-core-option')
+      .first()
+      .evaluate<void, Option>((element) => {
+        const content = document.createElement('div');
+
+        content.slot = 'content';
+        content.textContent = 'One';
+
+        element.append(content);
+      });
+
+    await expect(page.locator('glide-core-select')).toMatchAriaSnapshot(`
+      - button "Toggle" [expanded]
+      - listbox "Toggle":
+        - option "One" [selected]
+        - option "Two"
+        - option "Three"
+    `);
+  },
+);

--- a/src/select.test.forms.ts
+++ b/src/select.test.forms.ts
@@ -1,0 +1,609 @@
+import { html } from 'lit';
+import { expect, test } from './playwright/test.js';
+
+test('has a `form` property', { tag: '@forms' }, async ({ mount, page }) => {
+  await mount(
+    () => html`
+      <form>
+        <glide-core-select>
+          <button slot="target">Target</button>
+          <glide-core-options></glide-core-options>
+        </glide-core-select>
+      </form>
+    `,
+  );
+
+  const host = page.locator('glide-core-select');
+
+  const hasform = await host.evaluate((element) => {
+    return 'form' in element && element.form instanceof HTMLFormElement;
+  });
+
+  expect(hasform).toBe(true);
+});
+
+test(
+  'can be reset',
+  { tag: '@forms' },
+  async ({ callMethod, mount, page, setProperty }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select open>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option
+                label="One"
+                value="one"
+                selected
+              ></glide-core-option>
+
+              <glide-core-option label="Two" value="two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const form = page.locator('form');
+    const options = page.getByRole('option');
+
+    await setProperty(options.nth(0), 'selected', false);
+    await setProperty(options.nth(1), 'selected', true);
+    await callMethod(form, 'reset');
+
+    await expect(options.nth(0)).toHaveJSProperty('selected', true);
+    await expect(options.nth(1)).toHaveJSProperty('selected', false);
+    await expect(host).toHaveJSProperty('value', ['one']);
+  },
+);
+
+test(
+  'has form data when an option is selected',
+  { tag: '@forms' },
+  async ({ mount, page }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select name="name">
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option
+                label="One"
+                value="one"
+                selected
+              ></glide-core-option>
+
+              <glide-core-option label="Two" value="two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const form = page.locator('form');
+
+    await expect(form).toHaveFormData('name', JSON.stringify(['one']));
+  },
+);
+
+test(
+  'has no form data when no option is selected',
+  { tag: '@forms' },
+  async ({ mount, page }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select name="name">
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One" value="one"></glide-core-option>
+              <glide-core-option label="Two" value="two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const form = page.locator('form');
+
+    await expect(form).toHaveFormData('name', null);
+  },
+);
+
+test(
+  'has no form data when without a name',
+  { tag: '@forms' },
+  async ({ mount, page }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One" value="one"></glide-core-option>
+              <glide-core-option label="Two" value="two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const form = page.locator('form');
+
+    await expect(form).toHaveFormData('name', null);
+  },
+);
+
+test(
+  'has no form data when disabled',
+  { tag: '@forms' },
+  async ({ mount, page }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select name="name" disabled>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option
+                label="One"
+                value="one"
+                selected
+              ></glide-core-option>
+
+              <glide-core-option label="Two" value="two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const form = page.locator('form');
+
+    await expect(form).toHaveFormData('name', null);
+  },
+);
+
+test(
+  'is valid when not required and no option is selected',
+  { tag: '@forms' },
+  async ({ callMethod, mount, page }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One"></glide-core-option>
+              <glide-core-option label="Two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+
+    await expect(host).not.toDispatchEvents(async () => {
+      await callMethod(host, 'checkValidity');
+      await callMethod(host, 'reportValidity');
+    }, [{ type: 'invalid' }]);
+
+    await expect(host).toHaveJSProperty('validity.valid', true);
+    await expect(host).toHaveJSProperty('validity.valueMissing', false);
+    await expect(target).toHaveJSProperty('ariaInvalid', 'false');
+
+    expect(await callMethod(host, 'checkValidity')).toBe(true);
+    expect(await callMethod(host, 'reportValidity')).toBe(true);
+  },
+);
+
+test(
+  'is valid when required and no option is selected but made not required programmatically',
+  { tag: '@forms' },
+  async ({ callMethod, mount, page, removeAttribute }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select required>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One"></glide-core-option>
+              <glide-core-option label="Two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+
+    await removeAttribute(host, 'required');
+
+    await expect(host).not.toDispatchEvents(async () => {
+      await callMethod(host, 'checkValidity');
+      await callMethod(host, 'reportValidity');
+    }, [{ type: 'invalid' }]);
+
+    await expect(host).toHaveJSProperty('validity.valid', true);
+    await expect(host).toHaveJSProperty('validity.valueMissing', false);
+    await expect(target).toHaveJSProperty('ariaInvalid', 'false');
+
+    expect(await callMethod(host, 'checkValidity')).toBe(true);
+    expect(await callMethod(host, 'reportValidity')).toBe(true);
+  },
+);
+
+test(
+  'is valid when required and an option is selected programmatically',
+  { tag: '@forms' },
+  async ({ callMethod, mount, page, setProperty }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select open>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One"></glide-core-option>
+              <glide-core-option label="Two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+    const options = page.getByRole('option');
+
+    await setProperty(options.nth(0), 'selected', true);
+
+    await expect(host).not.toDispatchEvents(async () => {
+      await callMethod(host, 'checkValidity');
+      await callMethod(host, 'reportValidity');
+    }, [{ type: 'invalid' }]);
+
+    await expect(host).toHaveJSProperty('validity.valid', true);
+    await expect(host).toHaveJSProperty('validity.valueMissing', false);
+    await expect(target).toHaveJSProperty('ariaInvalid', 'false');
+
+    expect(await callMethod(host, 'checkValidity')).toBe(true);
+    expect(await callMethod(host, 'reportValidity')).toBe(true);
+  },
+);
+
+test(
+  'is valid when required and `value` is set programmatically',
+  { tag: '@forms' },
+  async ({ callMethod, mount, page, setProperty }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select required open>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One"></glide-core-option>
+              <glide-core-option label="Two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+
+    await setProperty(host, 'value', ['one']);
+
+    await expect(host).not.toDispatchEvents(async () => {
+      await callMethod(host, 'checkValidity');
+      await callMethod(host, 'reportValidity');
+    }, [{ type: 'invalid' }]);
+
+    await expect(host).toHaveJSProperty('validity.valid', true);
+    await expect(host).toHaveJSProperty('validity.valueMissing', false);
+    await expect(target).toHaveJSProperty('ariaInvalid', 'false');
+
+    expect(await callMethod(host, 'checkValidity')).toBe(true);
+    expect(await callMethod(host, 'reportValidity')).toBe(true);
+  },
+);
+
+test(
+  'is both valid and invalid when no option is selected and required but disabled',
+  { tag: '@forms' },
+  async ({ callMethod, mount, page }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select disabled required>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One"></glide-core-option>
+              <glide-core-option label="Two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+
+    await expect(host).toHaveJSProperty('validity.valid', false);
+    await expect(host).toHaveJSProperty('validity.valueMissing', true);
+    await expect(target).toHaveJSProperty('ariaInvalid', 'false');
+
+    expect(await callMethod(host, 'checkValidity')).toBe(true);
+    expect(await callMethod(host, 'reportValidity')).toBe(true);
+  },
+);
+
+test(
+  'is valid on submit when required and an option is selected',
+  { tag: '@forms' },
+  async ({ addEventListener, mount, page }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select required>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option
+                label="One"
+                value="one"
+                selected
+              ></glide-core-option>
+              <glide-core-option label="Two" value="two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const form = page.locator('form');
+    const target = page.getByRole('button');
+
+    await addEventListener(form, 'submit', {
+      preventDefault: true,
+    });
+
+    await expect(host).not.toDispatchEvents(
+      async () => target.press('Enter'),
+      [{ type: 'invalid' }],
+    );
+
+    await expect(host).toHaveJSProperty('validity.valid', true);
+    await expect(host).toHaveJSProperty('validity.valueMissing', false);
+    await expect(target).toHaveJSProperty('ariaInvalid', 'false');
+  },
+);
+
+test(
+  'is invalid when required and no option is selected',
+  { tag: '@forms' },
+  async ({ callMethod, mount, page }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select required>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One"></glide-core-option>
+              <glide-core-option label="Two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+
+    await expect(host).toDispatchEvents(
+      () => callMethod(host, 'reportValidity'),
+      [{ type: 'invalid' }],
+    );
+
+    await expect(host).toHaveJSProperty('validity.valid', false);
+    await expect(host).toHaveJSProperty('validity.valueMissing', true);
+    await expect(target).toHaveJSProperty('ariaInvalid', 'true');
+
+    expect(await callMethod(host, 'checkValidity')).toBe(false);
+    expect(await callMethod(host, 'reportValidity')).toBe(false);
+  },
+);
+
+test(
+  'is invalid on submit when required and no option is selected',
+  { tag: '@forms' },
+  async ({ mount, page }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select required>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One"></glide-core-option>
+              <glide-core-option label="Two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+
+    await expect(host).toDispatchEvents(
+      () => target.press('Enter'),
+      [
+        {
+          type: 'invalid',
+        },
+      ],
+    );
+
+    await expect(target).toBeFocused();
+    await expect(host).toHaveJSProperty('validity.valid', false);
+    await expect(host).toHaveJSProperty('validity.valueMissing', true);
+    await expect(target).toHaveJSProperty('ariaInvalid', 'true');
+  },
+);
+
+test(
+  'is invalid when required and its selected option is disabled programmatically',
+  { tag: '@forms' },
+  async ({ callMethod, mount, page, setProperty }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select open required>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One" selected></glide-core-option>
+              <glide-core-option label="Two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+    const options = page.getByRole('option');
+
+    await setProperty(options.nth(0), 'disabled', true);
+
+    await expect(host).toDispatchEvents(async () => {
+      await callMethod(host, 'checkValidity');
+      await callMethod(host, 'reportValidity');
+    }, [{ type: 'invalid' }, { type: 'invalid' }]);
+
+    await expect(host).toHaveJSProperty('validity.valid', false);
+    await expect(host).toHaveJSProperty('validity.valueMissing', true);
+    await expect(target).toHaveJSProperty('ariaInvalid', 'true');
+
+    expect(await callMethod(host, 'checkValidity')).toBe(false);
+    expect(await callMethod(host, 'reportValidity')).toBe(false);
+  },
+);
+
+test(
+  'submits its form on Enter when closed',
+  { tag: '@forms' },
+  async ({ addEventListener, mount, page }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One"></glide-core-option>
+              <glide-core-option label="Two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const form = page.locator('form');
+    const target = page.getByRole('button');
+
+    await addEventListener(form, 'submit', {
+      preventDefault: true,
+    });
+
+    await expect(form).toDispatchEvents(
+      () => target.press('Enter'),
+      [{ type: 'submit' }],
+    );
+  },
+);
+
+test(
+  'does not submit its form on Enter when open',
+  { tag: '@forms' },
+  async ({ addEventListener, mount, page }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select open>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One"></glide-core-option>
+              <glide-core-option label="Two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const form = page.locator('form');
+    const target = page.getByRole('button');
+
+    await addEventListener(form, 'submit', {
+      preventDefault: true,
+    });
+
+    await expect(form).not.toDispatchEvents(
+      () => target.press('Enter'),
+      [{ type: 'submit' }],
+    );
+  },
+);
+
+test(
+  'supports `setValidity()`',
+  { tag: '@forms' },
+  async ({ callMethod, mount, page }) => {
+    await mount(
+      () => html`
+        <form>
+          <glide-core-select open required>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One" selected></glide-core-option>
+              <glide-core-option label="Two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        </form>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+
+    await callMethod(host, 'setValidity', { customError: true }, 'message');
+
+    await expect(host).toDispatchEvents(async () => {
+      await callMethod(host, 'checkValidity');
+      await callMethod(host, 'reportValidity');
+    }, [{ type: 'invalid' }, { type: 'invalid' }]);
+
+    await expect(host).toHaveJSProperty('validity.valid', false);
+    await expect(host).toHaveJSProperty('validity.customError', true);
+    await expect(target).toHaveJSProperty('ariaInvalid', 'true');
+  },
+);

--- a/src/select.test.keyboard.ts
+++ b/src/select.test.keyboard.ts
@@ -1,0 +1,130 @@
+import { html } from 'lit';
+import { expect, test } from './playwright/test.js';
+
+test(
+  'opens when clicked via Space',
+  { tag: '@keyboard' },
+  async ({ mount, page }) => {
+    await mount(
+      () => html`
+        <glide-core-select>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option label="Label"></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+    const listbox = page.getByRole('listbox');
+
+    await target.press('Space');
+
+    await expect(host).toHaveAttribute('open');
+    await expect(listbox).toBeVisible();
+  },
+);
+
+test(
+  'does not open when clicked via Enter',
+  { tag: '@keyboard' },
+  async ({ mount, page }) => {
+    await mount(
+      () => html`
+        <glide-core-select>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option label="Label"></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+    const listbox = page.getByRole('listbox');
+
+    await target.press('Enter');
+
+    await expect(host).not.toHaveAttribute('open');
+    await expect(listbox).toBeHidden();
+  },
+);
+
+test(
+  'can select an option via Space',
+  { tag: '@keyboard' },
+  async ({ mount, page }) => {
+    await mount(
+      () => html`
+        <glide-core-select open>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option label="One" value="one"></glide-core-option>
+            <glide-core-option label="Two" value="two"></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+
+    await expect(host).toDispatchEvents(
+      () => target.press('Space'),
+      [
+        { bubbles: true, composed: true, type: 'input' },
+        { bubbles: true, composed: true, type: 'change' },
+      ],
+    );
+
+    await expect(host).toHaveJSProperty('value', ['one']);
+    await expect(host).not.toHaveAttribute('open');
+
+    await expect(
+      page.getByRole('option', { includeHidden: true }).nth(0),
+    ).toHaveJSProperty('selected', true);
+  },
+);
+
+test(
+  'can select an option via Enter',
+  { tag: '@keyboard' },
+  async ({ mount, page }) => {
+    await mount(
+      () => html`
+        <glide-core-select open>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option label="One" value="one"></glide-core-option>
+            <glide-core-option label="Two" value="two"></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+
+    await expect(host).toDispatchEvents(
+      () => target.press('Enter'),
+      [
+        { bubbles: true, composed: true, type: 'input' },
+        { bubbles: true, composed: true, type: 'change' },
+      ],
+    );
+
+    await expect(host).toHaveJSProperty('value', ['one']);
+    await expect(host).not.toHaveAttribute('open');
+
+    await expect(
+      page.getByRole('option', { includeHidden: true }).nth(0),
+    ).toHaveJSProperty('selected', true);
+  },
+);

--- a/src/select.test.miscellaneous.ts
+++ b/src/select.test.miscellaneous.ts
@@ -1,0 +1,362 @@
+import { html } from 'lit';
+import { expect, test } from './playwright/test.js';
+
+test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
+  await mount(
+    () => html`
+      <glide-core-select>
+        <button slot="target">Target</button>
+        <glide-core-options></glide-core-options>
+      </glide-core-select>
+    `,
+  );
+
+  const host = page.locator('glide-core-select');
+
+  await expect(host).toBeRegistered('glide-core-select');
+});
+
+test(
+  'sets `value` when an option is selected initially',
+  { tag: '@miscellaneous' },
+  async ({ mount, page }) => {
+    await mount(
+      () => html`
+        <glide-core-select>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option label="One" value="one"></glide-core-option>
+
+            <glide-core-option
+              label="Two"
+              value="two"
+              selected
+            ></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+
+    await expect(host).toHaveJSProperty('value', ['two']);
+  },
+);
+
+test(
+  'is opened when when open initially',
+  { tag: '@miscellaneous' },
+  async ({ mount, page }) => {
+    await mount(
+      () => html`
+        <glide-core-select open>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option label="Label"></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const listbox = page.getByRole('listbox');
+
+    await expect(host).toHaveAttribute('open');
+    await expect(listbox).toBeVisible();
+  },
+);
+
+test(
+  'is closed when closed initially',
+  { tag: '@miscellaneous' },
+  async ({ mount, page }) => {
+    await mount(
+      () => html`
+        <glide-core-select>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option label="Label"></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const listbox = page.getByRole('listbox');
+
+    await expect(host).not.toHaveAttribute('open');
+    await expect(listbox).toBeHidden();
+  },
+);
+
+test(
+  'is opened when opened programmatically',
+  { tag: '@miscellaneous' },
+  async ({ mount, page, setProperty }) => {
+    await mount(
+      () => html`
+        <glide-core-select>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option label="Label"></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const listbox = page.getByRole('listbox');
+
+    await setProperty(host, 'open', true);
+
+    await expect(host).toHaveAttribute('open');
+    await expect(listbox).toBeVisible();
+  },
+);
+
+test(
+  'is closed when closed programmatically',
+  { tag: '@miscellaneous' },
+  async ({ mount, page, setProperty }) => {
+    await mount(
+      () => html`
+        <glide-core-select open>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option label="Label"></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const listbox = page.getByRole('listbox');
+
+    await setProperty(host, 'open', false);
+
+    await expect(host).not.toHaveAttribute('open');
+    await expect(listbox).toBeHidden();
+  },
+);
+
+test(
+  'selects an option when `value` is set initially',
+  { tag: '@miscellaneous' },
+  async ({ mount, page, setProperty }) => {
+    await mount(
+      () => html`
+        <glide-core-select .value=${['one']} open>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option label="One" value="one"></glide-core-option>
+            <glide-core-option label="Two" value="two"></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const options = page.getByRole('option');
+
+    await setProperty(options.nth(1), 'selected', true);
+
+    await expect(host).toHaveJSProperty('value', ['two']);
+  },
+);
+
+test(
+  'changes its initial `value` when an option is selected initially',
+  { tag: '@miscellaneous' },
+  async ({ mount, page, setProperty }) => {
+    await mount(
+      () => html`
+        <glide-core-select .value=${['one']} open>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option label="One" value="one"></glide-core-option>
+            <glide-core-option
+              label="Two"
+              value="two"
+              selected
+            ></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const options = page.getByRole('option');
+
+    await setProperty(options.nth(1), 'selected', true);
+
+    await expect(host).toHaveJSProperty('value', ['two']);
+  },
+);
+
+test(
+  'changes its `value` when an option is selected programmatically',
+  { tag: '@miscellaneous' },
+  async ({ mount, page, setProperty }) => {
+    await mount(
+      () => html`
+        <glide-core-select open>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option
+              label="One"
+              value="one"
+              selected
+            ></glide-core-option>
+
+            <glide-core-option label="Two" value="two"></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const options = page.getByRole('option');
+
+    await setProperty(options.nth(1), 'selected', true);
+
+    await expect(host).toHaveJSProperty('value', ['two']);
+  },
+);
+
+test(
+  'changes its `value` and selected option when its selected option is disabled programmatically',
+  { tag: '@miscellaneous' },
+  async ({ mount, page, setProperty }) => {
+    await mount(
+      () => html`
+        <glide-core-select open>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option
+              label="One"
+              value="one"
+              selected
+            ></glide-core-option>
+
+            <glide-core-option label="Two" value="two"></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+    const options = page.getByRole('option');
+
+    await setProperty(options.nth(0), 'disabled', true);
+
+    await expect(options.nth(0)).toHaveJSProperty('selected', false);
+    await expect(host).toHaveJSProperty('value', []);
+  },
+);
+
+test(
+  'throws when more than one option is selected initially',
+  { tag: '@miscellaneous' },
+  async ({ mount }) => {
+    await expect(
+      mount(
+        () => html`
+          <glide-core-select>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One" selected></glide-core-option>
+              <glide-core-option label="Two" selected></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        `,
+      ),
+    ).rejects.toThrow();
+  },
+);
+
+test(
+  'throws when `value` contains more than one value initially',
+  { tag: '@miscellaneous' },
+  async ({ mount }) => {
+    await expect(
+      mount(
+        (value) => html`
+          <glide-core-select .value=${value}>
+            <button slot="target">Target</button>
+
+            <glide-core-options>
+              <glide-core-option label="One" value="one"></glide-core-option>
+              <glide-core-option label="Two" value="two"></glide-core-option>
+            </glide-core-options>
+          </glide-core-select>
+        `,
+        ['one', 'two'],
+      ),
+    ).rejects.toThrow();
+  },
+);
+
+test(
+  'throws when `value` is set programmatically and has more then one value',
+  { tag: '@miscellaneous' },
+  async ({ mount, page, setProperty }) => {
+    await mount(
+      () => html`
+        <glide-core-select>
+          <button slot="target">Target</button>
+
+          <glide-core-options>
+            <glide-core-option label="One"></glide-core-option>
+            <glide-core-option label="Two"></glide-core-option>
+          </glide-core-options>
+        </glide-core-select>
+      `,
+    );
+
+    const host = page.locator('glide-core-select');
+
+    await expect(setProperty(host, 'value', ['one', 'two'])).rejects.toThrow();
+  },
+);
+
+test(
+  'throws when its default slot is empty',
+  { tag: '@miscellaneous' },
+  async ({ mount }) => {
+    await expect(
+      mount(
+        () => html`
+          <glide-core-select>
+            <button slot="target">Target</button>
+          </glide-core-select>
+        `,
+      ),
+    ).rejects.toThrow();
+  },
+);
+
+test(
+  'throws when its "target" slot is empty',
+  { tag: '@miscellaneous' },
+  async ({ mount }) => {
+    await expect(
+      mount(
+        () => html`
+          <glide-core-select>
+            <glide-core-options></glide-core-options>
+          </glide-core-select>
+        `,
+      ),
+    ).rejects.toThrow();
+  },
+);

--- a/src/select.test.mouse.ts
+++ b/src/select.test.mouse.ts
@@ -1,0 +1,308 @@
+import { html } from 'lit';
+import { expect, test } from './playwright/test.js';
+
+test(
+  'opens when its target is clicked',
+  { tag: '@mouse' },
+  async ({ mount, page }) => {
+    await mount(() => html`
+      <glide-core-select>
+        <button slot="target">Target</button>
+
+        <glide-core-options>
+          <glide-core-option label="Label"></glide-core-option>
+        </glide-core-options>
+      </glide-core-select>
+    `);
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+    const listbox = page.getByRole('listbox');
+
+    await target.click();
+
+    await expect(host).toHaveAttribute('open');
+    await expect(listbox).toBeVisible();
+  },
+);
+
+test(
+  'closes when its target is clicked',
+  { tag: '@mouse' },
+  async ({ mount, page }) => {
+    await mount(() => html`
+      <glide-core-select open>
+        <button slot="target">Target</button>
+
+        <glide-core-options>
+          <glide-core-option label="Label"></glide-core-option>
+        </glide-core-options>
+      </glide-core-select>
+    `);
+
+    const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
+    const listbox = page.getByRole('listbox');
+
+    await target.click();
+
+    await expect(host).not.toHaveAttribute('open');
+    await expect(listbox).toBeHidden();
+  },
+);
+
+test(
+  'remains open when a disabled option is clicked',
+  { tag: '@mouse' },
+  async ({ mount, page }) => {
+    await mount(() => html`
+      <glide-core-select open>
+        <button slot="target">Target</button>
+
+        <glide-core-options>
+          <glide-core-option label="One" disabled></glide-core-option>
+          <glide-core-option label="Two"></glide-core-option>
+        </glide-core-options>
+      </glide-core-select>
+    `);
+
+    const host = page.locator('glide-core-select');
+    const listbox = page.getByRole('listbox');
+    const options = page.getByRole('option');
+
+    // eslint-disable-next-line playwright/no-force-option
+    await options.first().click({ force: true });
+
+    await expect(host).toHaveAttribute('open');
+    await expect(listbox).toBeVisible();
+  },
+);
+
+test(
+  'can select an option via mouse',
+  { tag: '@mouse' },
+  async ({ mount, page }) => {
+    await mount(() => html`
+      <glide-core-select open>
+        <button slot="target">Target</button>
+
+        <glide-core-options>
+          <glide-core-option label="One" value="one"></glide-core-option>
+          <glide-core-option label="Two" value="two"></glide-core-option>
+        </glide-core-options>
+      </glide-core-select>
+    `);
+
+    const host = page.locator('glide-core-select');
+
+    await expect(host).toDispatchEvents(
+      () => page.getByRole('option').nth(0).click(),
+      [
+        { bubbles: true, composed: true, type: 'input' },
+        { bubbles: true, composed: true, type: 'change' },
+      ],
+    );
+
+    await expect(host).toHaveJSProperty('value', ['one']);
+    await expect(host).not.toHaveAttribute('open');
+
+    await expect(
+      page.getByRole('option', { includeHidden: true }).nth(0),
+    ).toHaveJSProperty('selected', true);
+  },
+);
+
+test(
+  'can select an option via `click()`',
+  { tag: '@mouse' },
+  async ({ callMethod, mount, page }) => {
+    await mount(() => html`
+      <glide-core-select open>
+        <button slot="target">Target</button>
+
+        <glide-core-options>
+          <glide-core-option label="One" value="one"></glide-core-option>
+          <glide-core-option label="Two" value="two"></glide-core-option>
+        </glide-core-options>
+      </glide-core-select>
+    `);
+
+    const host = page.locator('glide-core-select');
+
+    await expect(host).toDispatchEvents(async () => {
+      const option = page.getByRole('option').nth(0);
+
+      await callMethod(option, 'click');
+    }, [
+      { bubbles: true, composed: true, type: 'input' },
+      { bubbles: true, composed: true, type: 'change' },
+    ]);
+
+    await expect(host).toHaveJSProperty('value', ['one']);
+    await expect(host).not.toHaveAttribute('open');
+
+    await expect(
+      page.getByRole('option', { includeHidden: true }).nth(0),
+    ).toHaveJSProperty('selected', true);
+  },
+);
+
+test(
+  'can select a grouped option via mouse',
+  { tag: '@mouse' },
+  async ({ mount, page }) => {
+    await mount(() => html`
+      <glide-core-select open>
+        <button slot="target">Target</button>
+
+        <glide-core-options>
+          <glide-core-options-group label="A">
+            <glide-core-option label="One" value="one"></glide-core-option>
+            <glide-core-option label="Two" value="two"></glide-core-option>
+          </glide-core-options-group>
+
+          <glide-core-options-group label="B">
+            <glide-core-option label="Three" value="three"></glide-core-option>
+            <glide-core-option label="Four" value="four"></glide-core-option>
+          </glide-core-options-group>
+        </glide-core-options>
+      </glide-core-select>
+    `);
+
+    const host = page.locator('glide-core-select');
+
+    await expect(host).toDispatchEvents(
+      () => page.getByRole('option').nth(0).click(),
+      [
+        { bubbles: true, composed: true, type: 'input' },
+        { bubbles: true, composed: true, type: 'change' },
+      ],
+    );
+
+    await expect(host).toHaveJSProperty('value', ['one']);
+    await expect(host).not.toHaveAttribute('open');
+
+    await expect(
+      page.getByRole('option', { includeHidden: true }).nth(0),
+    ).toHaveJSProperty('selected', true);
+  },
+);
+
+test(
+  'can select a grouped option via `click()`',
+  { tag: '@mouse' },
+  async ({ callMethod, mount, page }) => {
+    await mount(() => html`
+      <glide-core-select open>
+        <button slot="target">Target</button>
+
+        <glide-core-options>
+          <glide-core-options-group label="A">
+            <glide-core-option label="One" value="one"></glide-core-option>
+            <glide-core-option label="Two" value="two"></glide-core-option>
+          </glide-core-options-group>
+
+          <glide-core-options-group label="B">
+            <glide-core-option label="Three" value="three"></glide-core-option>
+            <glide-core-option label="Four" value="four"></glide-core-option>
+          </glide-core-options-group>
+        </glide-core-options>
+      </glide-core-select>
+    `);
+
+    const host = page.locator('glide-core-select');
+
+    await expect(host).toDispatchEvents(async () => {
+      const option = page.getByRole('option').nth(0);
+
+      await callMethod(option, 'click');
+    }, [
+      { bubbles: true, composed: true, type: 'input' },
+      { bubbles: true, composed: true, type: 'change' },
+    ]);
+
+    await expect(host).toHaveJSProperty('value', ['one']);
+    await expect(host).not.toHaveAttribute('open');
+
+    await expect(
+      page.getByRole('option', { includeHidden: true }).nth(0),
+    ).toHaveJSProperty('selected', true);
+  },
+);
+
+test(
+  'deselects its selected option when another is selected via mouse',
+  { tag: '@mouse' },
+  async ({ mount, page }) => {
+    await mount(() => html`
+      <glide-core-select open>
+        <button slot="target">Target</button>
+
+        <glide-core-options>
+          <glide-core-option
+            label="One"
+            value="one"
+            selected
+          ></glide-core-option>
+
+          <glide-core-option label="Two" value="two"></glide-core-option>
+        </glide-core-options>
+      </glide-core-select>
+    `);
+
+    const host = page.locator('glide-core-select');
+
+    await expect(host).toDispatchEvents(
+      () => page.getByRole('option').nth(1).click(),
+      [
+        { bubbles: true, composed: true, type: 'input' },
+        { bubbles: true, composed: true, type: 'change' },
+      ],
+    );
+
+    await expect(host).toHaveJSProperty('value', ['two']);
+    await expect(host).not.toHaveAttribute('open');
+
+    await expect(
+      page.getByRole('option', { includeHidden: true }).nth(0),
+    ).toHaveJSProperty('selected', false);
+  },
+);
+
+test(
+  'retains its selected option when a sub-Menu option is selected via mouse',
+  { tag: '@mouse' },
+  async ({ mount, page }) => {
+    await mount(() => html`
+      <glide-core-select open>
+        <button slot="target">Target</button>
+
+        <glide-core-options>
+          <glide-core-option label="One" value="one" selected>
+            <glide-core-menu slot="submenu" open>
+              <span slot="target">☀</span>
+
+              <glide-core-options>
+                <glide-core-option label="Three"></glide-core-option>
+                <glide-core-option label="Four"></glide-core-option>
+              </glide-core-options>
+            </glide-core-menu>
+          </glide-core-option>
+
+          <glide-core-option label="Two" value="two"></glide-core-option>
+        </glide-core-options>
+      </glide-core-select>
+    `);
+
+    const host = page.locator('glide-core-select');
+    const menuitems = page.getByRole('menuitem');
+
+    await menuitems.nth(0).click();
+
+    await expect(host).toHaveJSProperty('value', ['one']);
+
+    await expect(
+      page.getByRole('option', { includeHidden: true }).nth(0),
+    ).toHaveJSProperty('selected', true);
+  },
+);

--- a/src/select.test.visuals.ts
+++ b/src/select.test.visuals.ts
@@ -1,0 +1,191 @@
+import { expect, test } from './playwright/test.js';
+import type Select from './select.js';
+import fetchStories from './playwright/fetch-stories.js';
+import type Menu from './menu.js';
+import type Option from './option.js';
+import type OptionsGroup from './options.group.js';
+
+const stories = await fetchStories('Select');
+
+for (const story of stories) {
+  test.describe(story.id, () => {
+    for (const theme of story.themes) {
+      test.describe(theme, () => {
+        test('loading', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-select')
+            .evaluate<void, Select>((element) => {
+              element.loading = true;
+              element.open = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('offset', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-select')
+            .evaluate<void, Select>((element) => {
+              element.offset = 50;
+              element.open = true;
+            });
+
+          await page
+            .locator('glide-core-option glide-core-menu')
+            .evaluate<void, Menu>((element) => {
+              element.open = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('open=${true}', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-select')
+            .evaluate<void, Select>((element) => {
+              element.open = true;
+            });
+
+          await page
+            .locator('glide-core-option glide-core-menu')
+            .evaluate<void, Menu>((element) => {
+              element.open = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('open=${false}', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+          await page.locator('glide-core-select').waitFor();
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('placement="right-end"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-select')
+            .evaluate<void, Select>((element) => {
+              element.placement = 'right-end';
+              element.open = true;
+            });
+
+          await page
+            .locator('glide-core-option glide-core-menu')
+            .evaluate<void, Menu>((element) => {
+              element.open = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('<glide-core-options-group>.hide-label', async ({
+          page,
+        }, test) => {
+          // eslint-disable-next-line playwright/no-skipped-test
+          test.skip(story.id !== 'select--with-groups');
+
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-select')
+            .evaluate<void, Menu>((element) => {
+              element.open = true;
+            });
+
+          await page
+            .locator('glide-core-options-group')
+            .first()
+            .evaluate<void, OptionsGroup>((element) => {
+              element.hideLabel = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('<glide-core-option>.description', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-select')
+            .evaluate<void, Select>((element) => {
+              element.open = true;
+            });
+
+          await page
+            .locator('glide-core-option')
+            .first()
+            .evaluate<void, Option>((element) => {
+              element.description = 'Description';
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('<glide-core-option>.disabled', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-select')
+            .evaluate<void, Select>((element) => {
+              element.open = true;
+            });
+
+          await page
+            .locator('glide-core-option')
+            .first()
+            .evaluate<void, Option>((element) => {
+              element.disabled = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('<glide-core-option>.selected', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-select')
+            .evaluate<void, Select>((element) => {
+              element.open = true;
+            });
+
+          await page
+            .locator('glide-core-option')
+            .first()
+            .evaluate<void, Option>((element) => {
+              element.selected = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+      });
+    }
+  });
+}

--- a/src/select.ts
+++ b/src/select.ts
@@ -1,0 +1,642 @@
+import { html, LitElement } from 'lit';
+import { createRef, ref } from 'lit/directives/ref.js';
+import { customElement, property, state } from 'lit/decorators.js';
+import packageJson from '../package.json' with { type: 'json' };
+import assertSlot from './library/assert-slot.js';
+import styles from './menu.styles.js';
+import shadowRootMode from './library/shadow-root-mode.js';
+import final from './library/final.js';
+import Menu from './menu.js';
+import Option from './option.js';
+import Options from './options.js';
+import OptionsGroup from './options.group.js';
+import type FormControl from './library/form-control.js';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'glide-core-select': Select;
+  }
+}
+
+/**
+ * @attr {boolean} [disabled=false]
+ * @attr {boolean} [loading=false]
+ * @attr {string} [name='']
+ * @attr {number} [offset=4]
+ * @attr {boolean} [open=false]
+ * @attr {'bottom'|'left'|'right'|'top'|'bottom-start'|'bottom-end'|'left-start'|'left-end'|'right-start'|'right-end'|'top-start'|'top-end'} [placement='bottom-start'] - Select will try to move itself to the opposite of this value if not doing so would result in overflow. For example, if "bottom" results in overflow Menu will try "top" but not "right" or "left".
+ * @attr {boolean} [required=false]
+ * @attr {string[]} [value=[]]
+ *
+ * @readonly
+ * @attr {string} [version]
+ *
+ * @slot {Element}
+ * @slot {Element} target - The element to which Select will anchor. Can be any focusable element. If you want Select to be filterable, put an Input in this slot. Listen for Input's "input" event, then add and remove Option(s) from Select's default slot based on Input's value.
+ *
+ * @fires {Event} change
+ * @fires {Event} input
+ *
+ * @readonly
+ * @prop {HTMLFormElement | null} form
+ *
+ * @readonly
+ * @prop {string} targetLabelPrefix
+ *
+ * @readonly
+ * @prop {ValidityState} validity
+ *
+ * @method checkValidity
+ * @returns boolean
+ *
+ * @method formAssociatedCallback
+ * @method formResetCallback
+ *
+ * @method reportValidity
+ * @returns boolean
+ *
+ * @method setValidity
+ * @param {ValidityStateFlags} [flags]
+ */
+@customElement('glide-core-select')
+@final
+export default class Select
+  extends LitElement
+  implements
+    Omit<
+      FormControl,
+      | 'hideLabel'
+      | 'orientation'
+      | 'resetValidityFeedback'
+      | 'setCustomValidity'
+    >
+{
+  static formAssociated = true;
+
+  static override shadowRootOptions: ShadowRootInit = {
+    ...LitElement.shadowRootOptions,
+    mode: shadowRootMode,
+  };
+
+  static override styles = styles;
+
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
+
+  @property({ reflect: true, type: Boolean })
+  loading = false;
+
+  @property({ reflect: true, useDefault: true })
+  name = '';
+
+  /**
+   * @default 4
+   */
+  @property({ reflect: true, type: Number })
+  get offset(): number {
+    return (
+      this.#offset ??
+      Number.parseFloat(
+        window
+          .getComputedStyle(document.body)
+          .getPropertyValue('--glide-core-spacing-base-xxs'),
+      ) *
+        Number.parseFloat(
+          window.getComputedStyle(document.documentElement).fontSize,
+        )
+    );
+  }
+
+  /* v8 ignore start */
+  set offset(offset: number) {
+    this.#offset = offset;
+  }
+  /* v8 ignore end */
+
+  /**
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true })
+  get open(): boolean {
+    return this.#isOpen;
+  }
+
+  set open(isOpen: boolean) {
+    this.#isOpen = isOpen;
+
+    if (this.#menuElementRef.value) {
+      this.#menuElementRef.value.open = isOpen;
+    }
+  }
+
+  /**
+   * Select will try to move itself to the opposite of this value if not doing so would result in overflow.
+   * For example, if "bottom" results in overflow Menu will try "top" but not "right" or "left".
+   */
+  @property({ reflect: true, useDefault: true })
+  placement:
+    | 'bottom'
+    | 'left'
+    | 'right'
+    | 'top'
+    | 'bottom-start'
+    | 'bottom-end'
+    | 'left-start'
+    | 'left-end'
+    | 'right-start'
+    | 'right-end'
+    | 'top-start'
+    | 'top-end' = 'bottom-start';
+
+  /**
+   * @default false
+   */
+  @property({ reflect: true, type: Boolean })
+  get required(): boolean {
+    return this.#isRequired;
+  }
+
+  set required(isRequired: boolean) {
+    this.#isRequired = isRequired;
+    this.#setValidity();
+  }
+
+  /**
+   * @default []
+   */
+  @property({ type: Array })
+  get value(): string[] {
+    return this.#value;
+  }
+
+  set value(value: string[]) {
+    if (value.length > 1) {
+      throw this.#tooManySelectedOptionsError;
+    }
+
+    this.#value = value;
+
+    if (this.#optionElements) {
+      for (const option of this.#optionElements) {
+        this.#isSelectionFromValueSetter = true;
+        option.selected = false;
+        this.#isSelectionFromValueSetter = false;
+      }
+    }
+
+    for (const value$ of value) {
+      const option = this.#optionElements?.find(
+        (option) => option.value === value$,
+      );
+
+      if (option) {
+        this.#isSelectionFromValueSetter = true;
+        option.selected = true;
+        this.#isSelectionFromValueSetter = false;
+      }
+    }
+
+    this.#setValidity();
+  }
+
+  @property({ reflect: true })
+  readonly version: string = packageJson.version;
+
+  get form(): HTMLFormElement | null {
+    return this.#internals.form;
+  }
+
+  get targetLabelPrefix(): string {
+    return this.#optionElements
+      ? this.#optionElements
+          .filter(({ selected }) => selected)
+          .map(({ label }) => label)
+          .join(',')
+          .concat(',')
+      : '';
+  }
+
+  checkValidity(): boolean {
+    this.isCheckingValidity = true;
+    const isValid = this.#internals.checkValidity();
+    this.isCheckingValidity = false;
+
+    return isValid;
+  }
+
+  override firstUpdated() {
+    const options = this.querySelector('glide-core-options');
+
+    if (options) {
+      options.role = 'listbox';
+    }
+
+    const hasNoSelectedOptions = this.#optionElements?.every(
+      ({ selected }) => !selected,
+    );
+
+    // When `value` is set on initial render, its setter is called before
+    // `connectedCallback()` and thus before the default slot has any assigned
+    // elements. So we select options here after the initial render is complete
+    // and `this.#optionElements` isn't empty.
+    //
+    // Additionally, `#onDefaultSlotSlotChange()` is called after `firstUpdated()`
+    // and sets `value` based on which options are selected. And the initial `value`
+    // may conflict with the one derived from which options are selected.
+    //
+    // So we have a decision to make. On first render, do we defer to the initial
+    // `value` and select and deselect options below? Or do we defer to
+    // `#onDefaultSlotSlotChange()` and let that method change `value` from its initial
+    // value?
+    //
+    // It's largely a toss-up. But the latter seems like the logical choice given
+    // `#onDefaultSlotSlotChange()` is called after `firstUpdated()`. In other words,
+    // we defer to the lifecycle. `#onDefaultSlotSlotChange()` is called second. So
+    // it gets to override what `value` was initially.
+    //
+    // If no options are selected, then it's obvious that the consumer's intention is
+    // to select options based on the initial `value`. So we proceed.
+    if (hasNoSelectedOptions) {
+      if (this.value.length > 1) {
+        throw this.#tooManySelectedOptionsError;
+      }
+
+      for (const value of this.value) {
+        const option = this.#optionElements?.find(
+          (option) => option.value === value,
+        );
+
+        if (option) {
+          option.selected = true;
+        }
+      }
+    }
+
+    if (this.open && this.#menuElementRef.value) {
+      // Simply passing `this.open` to Menu in the template below would be more
+      // convenient. But, when an attribute's value is an expression, Lit will set the
+      // attribute on a slight delay, and that's a problem when a sub-Menu is also
+      // initially open because it means the sub-Menu wil be opened before the top-level
+      // Menu. So the top-level Menu below will be positioned underneath the sub-Menu.
+      this.#menuElementRef.value.open = true;
+    }
+  }
+
+  formAssociatedCallback(): void {
+    this.form?.addEventListener('formdata', this.#onFormdata);
+  }
+
+  formResetCallback(): void {
+    if (this.#optionElements) {
+      for (const option of this.#optionElements) {
+        option.selected = option.hasAttribute('selected');
+
+        if (option.selected) {
+          this.#value = [option.value];
+        }
+      }
+    }
+  }
+
+  override render() {
+    // Lit-a11y doesn't know that we're not interested in certain keys being pressed.
+    //
+    /* eslint-disable lit-a11y/click-events-have-key-events */
+    return html`<glide-core-menu
+      offset=${this.offset}
+      placement=${this.placement}
+      ?loading=${this.loading}
+      @toggle=${this.#onMenuToggle}
+      ${ref(this.#menuElementRef)}
+    >
+      <slot
+        name="target"
+        slot="target"
+        @click=${this.#onTargetSlotClick}
+        @keydown=${this.#onTargetSlotKeyDown}
+        @slotchange=${this.#onTargetSlotChange}
+        ${assertSlot([Element])}
+        ${ref(this.#targetSlotElementRef)}
+      >
+        <!--
+          The element to which Select will anchor. Can be any focusable element.
+
+          If you want Select to be filterable, put an Input in this slot. Listen for Input's
+          "input" event, then add and remove Option(s) from Select's default slot based on
+          Input's value.
+
+          @required
+          @type {Element}
+        -->
+      </slot>
+
+      <slot
+        @click=${this.#onDefaultSlotClick}
+        @deselected=${this.#onDefaultSlotDeselected}
+        @disabled=${this.#onDefaultSlotDisabled}
+        @selected=${this.#onDefaultSlotSelected}
+        @slotchange=${this.#onDefaultSlotSlotChange}
+        ${ref(this.#defaultSlotElementRef)}
+      >
+        <!--
+          @required
+          @type {Element}
+        -->
+      </slot>
+    </glide-core-menu>`;
+  }
+
+  reportValidity(): boolean {
+    return this.#internals.reportValidity();
+  }
+
+  setValidity(flags?: ValidityStateFlags): void {
+    this.#hasCustomValidity = true;
+
+    this.#internals.setValidity(
+      flags,
+      ' ',
+
+      // `setValidity()` isn't typed for an SVG. But an SVG is valid as long as it's
+      // focusable. Thus the cast.
+      this.#targetElement as HTMLElement | undefined,
+    );
+  }
+
+  get validity(): ValidityState {
+    return this.#internals.validity;
+  }
+
+  constructor() {
+    super();
+    this.#internals = this.attachInternals();
+
+    // Event handlers on the host aren't great because consumers can remove them.
+    // Unfortunately, the host is the only thing on which this event is dispatched
+    // because it's the host that is form-associated.
+    this.addEventListener('invalid', (event) => {
+      // Canceled so the native validation message isn't shown.
+      event.preventDefault();
+
+      if (this.isCheckingValidity) {
+        return;
+      }
+
+      this.#hasEmittedAnInvalidEvent = true;
+
+      const isFirstInvalidFormElement =
+        this.form?.querySelector(':invalid') === this;
+
+      if (isFirstInvalidFormElement) {
+        // Canceling the event means the target won't get focus, even if we were to use
+        // `delegatesFocus`. So we have to it focus manually.
+        this.#targetElement?.focus();
+      }
+
+      if (this.#targetElement) {
+        this.#targetElement.ariaInvalid = this.validity.valid
+          ? 'false'
+          : 'true';
+      }
+    });
+  }
+
+  @state()
+  private isCheckingValidity = false;
+
+  #defaultSlotElementRef = createRef<HTMLSlotElement>();
+
+  #hasCustomValidity = false;
+
+  #hasEmittedAnInvalidEvent = false;
+
+  #internals: ElementInternals;
+
+  #isOpen = false;
+
+  #isRequired = false;
+
+  #isSelectionFromValueSetter = false;
+
+  #isTargetClickViaEnter = false;
+
+  #menuElementRef = createRef<Menu>();
+
+  #offset: number | undefined;
+
+  #targetSlotElementRef = createRef<HTMLSlotElement>();
+
+  #tooManySelectedOptionsError = new Error(
+    'Only one option may be selected at a time.',
+  );
+
+  #value: string[] = [];
+
+  get #optionElements() {
+    if (this.#optionsElement) {
+      return [...this.#optionsElement.children]
+        .filter((element) => {
+          return element instanceof Option || element instanceof OptionsGroup;
+        })
+        .flatMap((element) => {
+          return element instanceof OptionsGroup
+            ? [
+                ...element.querySelectorAll<Option>(
+                  ':scope > glide-core-option',
+                ),
+              ]
+            : element;
+        });
+    }
+  }
+
+  get #optionsElement() {
+    const firstAssignedElement = this.#defaultSlotElementRef.value
+      ?.assignedElements({ flatten: true })
+      .at(0);
+
+    return firstAssignedElement instanceof Options
+      ? firstAssignedElement
+      : null;
+  }
+
+  #onFormdata = ({ formData }: FormDataEvent) => {
+    if (this.name && this.value.length > 0 && !this.disabled) {
+      formData.append(this.name, JSON.stringify(this.value));
+    }
+  };
+
+  // An arrow function field instead of a method so `this` is closed over and
+  // set to the component instead of the form.
+  #onDefaultSlotClick(event: Event) {
+    const isSubMenuOption = this.#optionElements?.every(
+      (option) => option !== event.target,
+    );
+
+    if (isSubMenuOption) {
+      return;
+    }
+
+    if (event.target instanceof Option && !event.target.selected) {
+      if (this.#optionElements) {
+        for (const option of this.#optionElements) {
+          if (option.selected) {
+            option.selected = false;
+          }
+        }
+      }
+
+      if (this.#menuElementRef.value) {
+        // Menu waits a tick or so before closing after an Option is clicked to give its
+        // consumers a chance to cancel the event and prevent Menu from closing.
+        //
+        // When `selected` is set below, the Option will rerender to include a checkmark.
+        // If the Option has a sub-Menu, the Option will also move its sub-Menu target so
+        // it's to the left of the checkmark.
+        //
+        // Because Menu doesn't close immediately, the user will see the checkmark suddenly
+        // appear and the sub-Menu's target move moments before Menu closes.
+        //
+        // To avoid all that, we close Menu ourselves before setting `selected`.
+        this.#menuElementRef.value.open = false;
+      }
+
+      event.target.selected = true;
+      this.#value = [event.target.value];
+
+      this.dispatchEvent(
+        new Event('input', {
+          bubbles: true,
+          composed: true,
+        }),
+      );
+
+      this.dispatchEvent(
+        new Event('change', {
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+  }
+
+  #onDefaultSlotDeselected() {
+    if (this.#isSelectionFromValueSetter) {
+      return;
+    }
+
+    this.#value = [];
+    this.#setValidity();
+  }
+
+  #onDefaultSlotDisabled(event: Event) {
+    if (event.target instanceof Option && event.target.selected) {
+      event.target.selected = false;
+    }
+  }
+
+  #onDefaultSlotSelected(event: Event) {
+    if (this.#isSelectionFromValueSetter) {
+      return;
+    }
+
+    if (event.target instanceof Option && this.#optionElements) {
+      for (const option of this.#optionElements) {
+        if (option !== event.target) {
+          option.selected = false;
+        }
+      }
+
+      this.#value = [event.target.value];
+    }
+
+    this.#setValidity();
+  }
+
+  #onDefaultSlotSlotChange() {
+    const selectedOptions =
+      this.#optionElements &&
+      this.#optionElements.filter(({ selected }) => selected);
+
+    if (selectedOptions && selectedOptions.length > 1) {
+      throw this.#tooManySelectedOptionsError;
+    }
+
+    const selectedOption = selectedOptions?.at(0);
+
+    if (selectedOption) {
+      this.#value = [selectedOption.value];
+    }
+
+    if (this.#optionElements) {
+      for (const option of this.#optionElements) {
+        option.role = 'option';
+      }
+    }
+
+    this.#setValidity();
+  }
+
+  #onMenuToggle(event: Event) {
+    if (
+      event.target instanceof Menu &&
+      event.target === this.#menuElementRef.value
+    ) {
+      this.open = event.target.open;
+    }
+  }
+
+  #onTargetSlotChange() {
+    if (this.#targetElement) {
+      this.#targetElement.ariaInvalid =
+        !this.#hasEmittedAnInvalidEvent || this.validity.valid
+          ? 'false'
+          : 'true';
+    }
+  }
+
+  #onTargetSlotClick(event: PointerEvent) {
+    if (this.#isTargetClickViaEnter) {
+      this.#isTargetClickViaEnter = false;
+      event.preventDefault(); // Prevent Menu from opening.
+    }
+  }
+
+  #onTargetSlotKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && !this.open) {
+      this.#isTargetClickViaEnter = true;
+      this.form?.requestSubmit();
+    }
+  }
+
+  #setValidity() {
+    if (this.#hasCustomValidity) {
+      return;
+    }
+
+    if (this.required && this.value.length === 0) {
+      this.#internals.setValidity(
+        { valueMissing: true },
+        ' ',
+
+        // `setValidity()` isn't typed for an SVG. But an SVG is valid as long as it's
+        // focusable. Thus the cast.
+        this.#targetElement as HTMLElement | undefined,
+      );
+
+      return;
+    }
+
+    this.#internals.setValidity({});
+  }
+
+  get #targetElement() {
+    const element = this.#targetSlotElementRef.value
+      ?.assignedElements({ flatten: true })
+      .at(0);
+
+    if (element instanceof HTMLElement || element instanceof SVGElement) {
+      return element;
+    }
+  }
+}

--- a/src/select.ts
+++ b/src/select.ts
@@ -41,9 +41,6 @@ declare global {
  * @prop {HTMLFormElement | null} form
  *
  * @readonly
- * @prop {string} targetLabelPrefix
- *
- * @readonly
  * @prop {ValidityState} validity
  *
  * @method checkValidity
@@ -204,16 +201,6 @@ export default class Select
 
   get form(): HTMLFormElement | null {
     return this.#internals.form;
-  }
-
-  get targetLabelPrefix(): string {
-    return this.#optionElements
-      ? this.#optionElements
-          .filter(({ selected }) => selected)
-          .map(({ label }) => label)
-          .join(',')
-          .concat(',')
-      : '';
   }
 
   checkValidity(): boolean {
@@ -536,6 +523,24 @@ export default class Select
   }
 
   #onDefaultSlotSelected(event: Event) {
+    if (this.#targetElement) {
+      // The `label` of the selected Option(s) should actually be read before the label
+      // or text content of the target. But we don't always know what the target's label
+      // is because the target is an arbitrary element.
+      //
+      // For example, it could be a custom element without `textContent`. Button is like
+      // this. Button doesn't have any `textContent` because nothing gets slotted into
+      // it. Yet it is labeled.
+      //
+      // So the best we can do is set `ariaDescription`.
+      this.#targetElement.ariaDescription = this.#optionElements
+        ? this.#optionElements
+            .filter(({ selected }) => selected)
+            .map(({ label }) => label)
+            .join(',')
+        : '';
+    }
+
     if (this.#isSelectionFromValueSetter) {
       return;
     }

--- a/src/select.ts
+++ b/src/select.ts
@@ -460,14 +460,14 @@ export default class Select
       : null;
   }
 
+  // An arrow function field instead of a method so `this` is closed over and
+  // set to the component instead of the form.
   #onFormdata = ({ formData }: FormDataEvent) => {
     if (this.name && this.value.length > 0 && !this.disabled) {
       formData.append(this.name, JSON.stringify(this.value));
     }
   };
 
-  // An arrow function field instead of a method so `this` is closed over and
-  // set to the component instead of the form.
   #onDefaultSlotClick(event: Event) {
     const isSubMenuOption = this.#optionElements?.every(
       (option) => option !== event.target,

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -33,6 +33,7 @@ export default {
       'src/checkbox.ts',
       'src/icon-button.ts',
       'src/spinner.ts',
+      'src/select.ts',
     ],
     reportDir: 'dist/web-test-runner-coverage',
     threshold: {
@@ -58,6 +59,7 @@ export default {
     '!src/button.test.*.ts',
     '!src/checkbox.test.*.ts',
     '!src/icon-button.test.*.ts',
+    '!src/select.test.*.ts',
     '!src/spinner.test.*.ts',
   ],
   nodeResolve: {


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> Added a Select component. Select doesn't support Form Controls Layout or multiselection. But multiselection is coming soon.

Select builds upon Menu by adding form control functionality to it. Like Menu, Select is highly flexible. It's meant to support every use case under the sun.

#### Up Next


1. Add multiselection support to Select.
3. Migrate Dropdown to Select.
4. Move Dropdown out of Glide Core. 

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

1. Navigate to Select in Storybook.
2. Select an option.
3. Verify the option appears selected.
4. Verify `value` includes the `value` of the option.
5. Play around with the sub-Menu and verify it works like it does with Menu.
6. What else?

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
