### PR TITLE
Install Chromium shell when updating baseline screenshots

### DIFF
--- a/.github/workflows/on-push-branch-main.yml
+++ b/.github/workflows/on-push-branch-main.yml
@@ -69,7 +69,7 @@ jobs:
           aws configure set aws_secret_access_key $CLOUDFLARE_R2_SECRET_ACCESS_KEY
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm
-      - run: pnpm dlx playwright@1.54.2 install --no-shell --with-deps chromium
+      - run: pnpm dlx playwright@1.54.2 install --only-shell --with-deps chromium
       - run: PLAYWRIGHT_SKIP_COVERAGE=true pnpm exec playwright test --config ./src/playwright/playwright.config.ts --project visuals --update-snapshots
       - run: aws s3 sync ./dist/playwright-baseline-screenshots s3://${{ vars.CLOUDFLARE_R2_BUCKET_NAME }}/playwright-baseline-screenshots --delete --endpoint-url ${{ vars.CLOUDFLARE_R2_ENDPOINT }}
 


### PR DESCRIPTION
## 🚀 Description

Updated our `on-push-branch-main.yml` workflow to install Chromium's shell before updating screenshots. Chromium's old Headless [doesn't work](https://github.com/CrowdStrike/glide-core/actions/runs/16886103311/job/47834175056) with `--no-shell`.



<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Testing

The visual diffs are expected. They're because that `on-push-branch-main.yml` run failed.

<!--

  Tell us how to reproduce and verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

-->
