### PR TITLE
Add `toBeExtensible()` matcher

### DIFF
--- a/src/accordion.test.miscellaneous.ts
+++ b/src/accordion.test.miscellaneous.ts
@@ -131,6 +131,20 @@ test(
 );
 
 test(
+  'cannot be extended',
+  { tag: '@miscellaneous' },
+  async ({ mount, page }) => {
+    await mount(
+      html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
+    );
+
+    const host = page.locator('glide-core-accordion');
+
+    await expect(host).not.toBeExtensible();
+  },
+);
+
+test(
   'throws when `label` is undefined',
   { tag: '@miscellaneous' },
   async ({ mount }) => {

--- a/src/button.test.miscellaneous.ts
+++ b/src/button.test.miscellaneous.ts
@@ -24,6 +24,18 @@ test(
 );
 
 test(
+  'cannot be extended',
+  { tag: '@miscellaneous' },
+  async ({ mount, page }) => {
+    await mount(html`<glide-core-button label="Label"></glide-core-button>`);
+
+    const host = page.locator('glide-core-button');
+
+    await expect(host).not.toBeExtensible();
+  },
+);
+
+test(
   'throws when `label` is undefined',
   { tag: '@miscellaneous' },
   async ({ mount }) => {

--- a/src/checkbox.test.miscellaneous.ts
+++ b/src/checkbox.test.miscellaneous.ts
@@ -103,6 +103,20 @@ test(
 );
 
 test(
+  'cannot be extended',
+  { tag: '@miscellaneous' },
+  async ({ mount, page }) => {
+    await mount(
+      html`<glide-core-checkbox label="Label"></glide-core-checkbox>`,
+    );
+
+    const host = page.locator('glide-core-checkbox');
+
+    await expect(host).not.toBeExtensible();
+  },
+);
+
+test(
   'throws when `label` is undefined',
   { tag: '@miscellaneous' },
   async ({ mount }) => {

--- a/src/icon-button.test.miscellaneous.ts
+++ b/src/icon-button.test.miscellaneous.ts
@@ -32,6 +32,22 @@ test(
 );
 
 test(
+  'cannot be extended',
+  { tag: '@miscellaneous' },
+  async ({ mount, page }) => {
+    await mount(
+      html`<glide-core-icon-button label="Label">
+        <div>Icon</div>
+      </glide-core-icon-button>`,
+    );
+
+    const host = page.locator('glide-core-icon-button');
+
+    await expect(host).not.toBeExtensible();
+  },
+);
+
+test(
   'throws when `label` is undefined',
   { tag: '@miscellaneous' },
   async ({ mount }) => {

--- a/src/playwright/matchers/to-be-extensible.ts
+++ b/src/playwright/matchers/to-be-extensible.ts
@@ -1,0 +1,58 @@
+import { type Locator, expect } from '@playwright/test';
+
+export default expect.extend({
+  async toBeExtensible(locator: Locator) {
+    const isExtensible = await locator.evaluate((node) => {
+      const tag = node.tagName.toLowerCase();
+      const Constructor = window.customElements.get(tag);
+
+      if (Constructor) {
+        class Component extends Constructor {}
+        window.customElements.define('glide-core-component', Component);
+
+        try {
+          new Component();
+        } catch {
+          return false;
+        }
+
+        return true;
+      } else {
+        return null;
+      }
+    });
+
+    const message =
+      isExtensible === null
+        ? () =>
+            this.utils.matcherHint('toBeExtensible', null, true) +
+            '\n\n' +
+            // Locators have a `toString()` implementation that serializes nicely.
+            //
+            // eslint-disable-next-line @typescript-eslint/no-base-to-string
+            `Locator: ${locator.toString()}\n` +
+            `Expected: Locator to be a custom element.\n`
+        : (this.isNot && isExtensible) || (!this.isNot && !isExtensible)
+          ? () =>
+              this.utils.matcherHint('toBeExtensible', true, false, {
+                isNot: this.isNot,
+              }) +
+              '\n\n' +
+              // Locators have a `toString()` implementation that serializes nicely.
+              //
+              // eslint-disable-next-line @typescript-eslint/no-base-to-string
+              `Locator: ${locator.toString()}\n` +
+              `Expected: ${this.utils.printExpected(false)}\n` +
+              `Received: ${this.utils.printReceived(true)}`
+          : () => '';
+
+    return {
+      message,
+      pass:
+        this.isNot && isExtensible === null ? true : (isExtensible ?? false),
+      name: 'toBeExtensible',
+      actual: isExtensible,
+      expected: !this.isNot,
+    };
+  },
+});

--- a/src/playwright/test.ts
+++ b/src/playwright/test.ts
@@ -12,12 +12,14 @@ import removeAttribute from './fixtures/remove-attribute.js';
 import setAttribute from './fixtures/set-attribute.js';
 import setProperty from './fixtures/set-property.js';
 import toBeAccessible from './matchers/to-be-accessible.js';
+import toBeExtensible from './matchers/to-be-extensible.js';
 import toBeRegistered from './matchers/to-be-registered.js';
 import toDispatchEvents from './matchers/to-dispatch-events.js';
 import toHaveFormData from './matchers/to-have-form-data.js';
 
 export const expect = mergeExpects(
   toBeAccessible,
+  toBeExtensible,
   toBeRegistered,
   toDispatchEvents,
   toHaveFormData,
@@ -27,6 +29,8 @@ export const expect = mergeExpects(
     selector: string,
     violations?: string[],
   ) => Promise<void>;
+
+  toBeExtensible: (locator: Locator) => Promise<void>;
 
   toBeRegistered: (locator: Locator, name: string) => Promise<void>;
 

--- a/src/spinner.test.miscellaneous.ts
+++ b/src/spinner.test.miscellaneous.ts
@@ -1,0 +1,14 @@
+import { html } from 'lit';
+import { expect, test } from './playwright/test.js';
+
+test(
+  'cannot be extended',
+  { tag: '@miscellaneous' },
+  async ({ mount, page }) => {
+    await mount(html`<glide-core-spinner label="Label"></glide-core-spinner>`);
+
+    const host = page.locator('glide-core-spinner');
+
+    await expect(host).not.toBeExtensible();
+  },
+);

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -343,11 +343,7 @@ export default class Tooltip extends LitElement {
             ])}
           </div>
 
-          <div
-            class=${classMap({
-              content: true,
-            })}
-          >
+          <div class="content">
             <slot class="default-slot" name="private">
               <!--
                 @type {TooltipContainer}


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Added a `toBeExtensible()` matcher for asserting that our components throw when extended.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

N/A

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
