### PR TITLE
Remove Playwright timeout overrides

### DIFF
--- a/src/playwright/playwright.config.ts
+++ b/src/playwright/playwright.config.ts
@@ -26,11 +26,6 @@ export default defineConfig({
         'src/eslint/rules/*.test.ts',
         'src/stylelint/rules/*.test.ts',
       ],
-
-      // 30 seconds is the default. Each test should take much less than a second.
-      // Something has gone wrong if one takes longer. So we fail fast to give
-      // developers feedback quickly.
-      timeout: 1000,
     },
     ...['webkit', 'firefox', 'chromium']
       .filter((browser) => {
@@ -59,9 +54,6 @@ export default defineConfig({
             'src/spinner.test.*.ts',
           ],
           testIgnore: ['src/*.test.visuals.ts'],
-
-          // Ideally it would be lower locally. But ARIA snapshotting takes a bit.
-          timeout: process.env.CI ? undefined : 5000,
 
           use:
             browser === 'webkit'
@@ -97,9 +89,6 @@ export default defineConfig({
       ),
 
       testMatch: ['src/*.test.visuals.ts'],
-
-      // Ideally it would be lower locally. But visual snapshotting takes a bit.
-      timeout: process.env.CI ? undefined : 5000,
     },
   ],
   reporter: [


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

So tired of timeouts! 😆 

CI already uses Playwright's default timeouts. Locally I set most of them to 5 seconds. But I've recently seen some timeouts even locally. As you'd expect, they're more common if you're memory constrained (temporarily or otherwise) or you don't have idle cores. 

So I removed the timeout overrides altogether. We're now using Playwright's default, 30 seconds, everywhere.



## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

N/A

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
