### PR TITLE
Expose Option and Options' private events

### DIFF
--- a/.changeset/gorgeous-guests-taste.md
+++ b/.changeset/gorgeous-guests-taste.md
@@ -1,0 +1,9 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+- Option now dispatches "enabled" and "disabled" events when programmatically enabled or disabled.
+- Option now dispatches "selected" and "deselected" events when programmatically selected or deselected.
+- Options now dispatches a "slotchange" event when the contents of its default slot have changed.
+
+You probably don't need to listen for these events. But they may come in handy if you're abstracting over Menu to add functionality to it.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -5384,7 +5384,25 @@
           ],
           "events": [
             {
-              "name": "private-disabled-change",
+              "name": "disabled",
+              "type": {
+                "text": "Event"
+              }
+            },
+            {
+              "name": "enabled",
+              "type": {
+                "text": "Event"
+              }
+            },
+            {
+              "name": "selected",
+              "type": {
+                "text": "Event"
+              }
+            },
+            {
+              "name": "deselected",
               "type": {
                 "text": "Event"
               }
@@ -5770,7 +5788,7 @@
           ],
           "events": [
             {
-              "name": "private-slot-change",
+              "name": "slotchange",
               "type": {
                 "text": "Event"
               }

--- a/src/menu.stories.ts
+++ b/src/menu.stories.ts
@@ -34,6 +34,7 @@ const meta: Meta = {
     open: false,
     placement: 'bottom-start',
     version: '',
+    '<glide-core-options>.addEventListener(event, handler)': '',
     '<glide-core-options>[slot="default"]': '',
     '<glide-core-options>.version': '',
     '<glide-core-options-group>.label': 'A',
@@ -137,6 +138,22 @@ const meta: Meta = {
         type: { summary: 'string', detail: '// For debugging' },
       },
     },
+    '<glide-core-options>.addEventListener(event, handler)': {
+      name: 'addEventListener(event, handler)',
+      control: false,
+      table: {
+        category: 'Options',
+        type: {
+          summary: 'method',
+          detail: `
+// "slotchange" is useful when you are abstracting over Menu to add functionality to it. See Select's
+// use of this event for an example.
+
+(event: "slotchange", handler: (event: Event) => void): void
+`,
+        },
+      },
+    },
     '<glide-core-options>[slot="default"]': {
       name: 'slot="default"',
       control: false,
@@ -200,7 +217,13 @@ const meta: Meta = {
         category: 'Option',
         type: {
           summary: 'method',
-          detail: '(event: "click", handler: (event: Event) => void): void',
+          detail: `
+// Listen for "click" when you want to know when an Option is selected.
+//
+// "enabled", "disabled", "selected", and "deselected" are useful when you are abstracting over Menu
+// to add functionality to it. See Select's use of these events for an example.
+
+(event: "click" | "enabled" | "disabled" | "selected" | "deselected", handler: (event: Event) => void): void'`,
         },
       },
     },

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -301,8 +301,8 @@ export default class Menu extends LitElement {
           @keydown=${this.#onTargetAndDefaultSlotKeyDown}
           @mousedown=${this.#onDefaultSlotMouseDown}
           @mouseover=${this.#onDefaultSlotMouseOver}
-          @private-disabled-change=${this.#onDefaultSlotDisabledChange}
-          @private-slot-change=${this.#onDefaultSlotSlotChange}
+          @disabled=${this.#onDefaultSlotDisabled}
+          @slotchange=${this.#onDefaultSlotSlotChange}
           @toggle=${this.#onDefaultSlotToggle}
           ${assertSlot([Element])}
           ${ref(this.#defaultSlotElementRef)}
@@ -639,7 +639,7 @@ export default class Menu extends LitElement {
     });
   }
 
-  #onDefaultSlotDisabledChange(event: Event) {
+  #onDefaultSlotDisabled(event: Event) {
     if (
       this.#activeOption === event.target &&
       event.target instanceof Option &&

--- a/src/option.test.events.ts
+++ b/src/option.test.events.ts
@@ -65,30 +65,132 @@ it('does not dispatch a "click" event when disabled and clicked via `click()`', 
   expect(spy.callCount).to.equal(0);
 });
 
-it('dispatches a "private-disabled-change" event when enabled programmatically', async () => {
+it('dispatches an "enabled" event when enabled programmatically', async () => {
   const host = await fixture<Option>(
     html`<glide-core-option label="Label" disabled></glide-core-option>`,
   );
 
   const spy = sinon.spy();
 
-  host.addEventListener('private-disabled-change', spy);
-  host.disabled = false;
+  host.addEventListener('enabled', spy);
 
+  setTimeout(() => {
+    host.disabled = false;
+  });
+
+  const event = await oneEvent(host, 'enabled');
+
+  expect(event.bubbles).to.be.true;
   expect(spy.callCount).to.equal(1);
 });
 
-it('dispatches a "private-disabled-change" event when disabled programmatically', async () => {
+it('dispatches a "disabled" event when disabled programmatically', async () => {
   const host = await fixture<Option>(
     html`<glide-core-option label="Label"></glide-core-option>`,
   );
 
   const spy = sinon.spy();
 
-  host.addEventListener('private-disabled-change', spy);
+  host.addEventListener('disabled', spy);
+
+  setTimeout(() => {
+    host.disabled = true;
+  });
+
+  const event = await oneEvent(host, 'disabled');
+
+  expect(event.bubbles).to.be.true;
+  expect(spy.callCount).to.equal(1);
+});
+
+it('does not dispatch an "enabled" event when enabled programmatically and already enabled', async () => {
+  const host = await fixture<Option>(
+    html`<glide-core-option label="Label"></glide-core-option>`,
+  );
+
+  const spy = sinon.spy();
+
+  host.addEventListener('enabled', spy);
+  host.disabled = false;
+
+  expect(spy.callCount).to.equal(0);
+});
+
+it('does not dispatch a "disabled" event when disabled programmatically and already disabled', async () => {
+  const host = await fixture<Option>(
+    html`<glide-core-option label="Label" disabled></glide-core-option>`,
+  );
+
+  const spy = sinon.spy();
+
+  host.addEventListener('disabled', spy);
   host.disabled = true;
 
+  expect(spy.callCount).to.equal(0);
+});
+
+it('dispatches a "selected" event when selected programmatically', async () => {
+  const host = await fixture<Option>(
+    html`<glide-core-option label="Label"></glide-core-option>`,
+  );
+
+  const spy = sinon.spy();
+
+  host.addEventListener('selected', spy);
+
+  setTimeout(() => {
+    host.selected = true;
+  });
+
+  const event = await oneEvent(host, 'selected');
+
+  expect(event.bubbles).to.be.true;
   expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches a "deselected" event when deselected programmatically', async () => {
+  const host = await fixture<Option>(
+    html`<glide-core-option label="Label" selected></glide-core-option>`,
+  );
+
+  const spy = sinon.spy();
+
+  host.addEventListener('deselected', spy);
+
+  setTimeout(() => {
+    host.selected = false;
+  });
+
+  const event = await oneEvent(host, 'deselected');
+
+  expect(event.bubbles).to.be.true;
+  expect(spy.callCount).to.equal(1);
+});
+
+it('does not dispatch a "selected" event when selected programmatically and already selected', async () => {
+  const host = await fixture<Option>(
+    html`<glide-core-option label="Label" selected></glide-core-option>`,
+  );
+
+  const spy = sinon.spy();
+
+  host.addEventListener('selected', spy);
+  host.selected = true;
+
+  expect(spy.callCount).to.equal(0);
+});
+
+it('does not dispatch a "deselected" event when deselected programmatically and already deselected', async () => {
+  const host = await fixture<Option>(
+    html`<glide-core-option label="Label"></glide-core-option>`,
+  );
+
+  const spy = sinon.spy();
+
+  host.addEventListener('deselected', spy);
+  host.selected = false;
+
+  expect(spy.callCount).to.equal(0);
 });
 
 it('does not allow its "toggle" event to propagate', async () => {

--- a/src/options.test.events.ts
+++ b/src/options.test.events.ts
@@ -1,7 +1,7 @@
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import Options from './options.js';
 
-it('dispatches a "private-slot-change" event', async () => {
+it('dispatches a "slotchange" event', async () => {
   const host = await fixture<Options>(
     html`<glide-core-options></glide-core-options>`,
   );
@@ -13,7 +13,7 @@ it('dispatches a "private-slot-change" event', async () => {
     host.append(option);
   });
 
-  const event = await oneEvent(host, 'private-slot-change');
+  const event = await oneEvent(host, 'slotchange');
 
   expect(event instanceof Event).to.be.true;
   expect(event.bubbles).to.be.true;

--- a/src/options.ts
+++ b/src/options.ts
@@ -48,6 +48,8 @@ declare global {
  * @attr {string} [version]
  *
  * @slot {Option | Text}
+ *
+ * @fires {Event} slotchange
  */
 @customElement('glide-core-options')
 @final
@@ -114,6 +116,6 @@ export default class Options extends LitElement {
   }
 
   #onDefaultSlotChange() {
-    this.dispatchEvent(new Event('private-slot-change', { bubbles: true }));
+    this.dispatchEvent(new Event('slotchange', { bubbles: true }));
   }
 }


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> - Option now dispatches "enabled" and "disabled" events when programmatically enabled or disabled.
> - Option now dispatches "selected" and "deselected" events when programmatically selected or deselected.
> - Options now dispatches a "slotchange" event when the contents of its default slot have changed.


People probably won't need these events because the hope, at least, is that either Menu or Select will work for everyone. But anyone, not just us, should be able to build something like Select on top of Menu. And to do that you need to listen for some or all of these events.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

The [tests](https://github.com/CrowdStrike/glide-core/pull/1069/files#diff-30bc3999a134489656cdd736be6e86902e4b99710217c72640bfdc2fd9ad1699) I added should have us covered.

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
