### PR TITLE
Add a `waitForVisualSettlement()` fixture

### DIFF
--- a/src/menu.test.visuals.ts
+++ b/src/menu.test.visuals.ts
@@ -49,7 +49,10 @@ for (const story of stories) {
         });
 
         test.describe('open', () => {
-          test('open=${true}', async ({ page }, test) => {
+          test('open=${true}', async ({
+            page,
+            waitForVisualSettlement,
+          }, test) => {
             await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
             await page
@@ -64,6 +67,8 @@ for (const story of stories) {
               .evaluate<void, Menu>((element) => {
                 element.open = true;
               });
+
+            await waitForVisualSettlement('sub-Menu');
 
             await expect(page).toHaveScreenshot(
               `${test.titlePath.join('.')}.png`,

--- a/src/playwright/fixtures/wait-for-visual-settlement.ts
+++ b/src/playwright/fixtures/wait-for-visual-settlement.ts
@@ -9,7 +9,8 @@ export default test.extend<{
         let previousScreenshot: Buffer | null = null;
 
         while (true) {
-          await page.evaluate(() => new Promise(requestAnimationFrame));
+          // https://github.com/CrowdStrike/glide-core/pull/1071#discussion_r2283391089
+          await new Promise((resolve) => setTimeout(resolve, 500));
 
           const currentScreenshot = await page.screenshot({
             animations: 'disabled',

--- a/src/playwright/fixtures/wait-for-visual-settlement.ts
+++ b/src/playwright/fixtures/wait-for-visual-settlement.ts
@@ -1,0 +1,27 @@
+import { test } from '@playwright/test';
+
+export default test.extend<{
+  waitForVisualSettlement: (description: string) => Promise<void>;
+}>({
+  async waitForVisualSettlement({ page }, use) {
+    await use(async (description: string) => {
+      return test.step(description, async () => {
+        let previousScreenshot: Buffer | null = null;
+
+        while (true) {
+          await page.evaluate(() => new Promise(requestAnimationFrame));
+
+          const currentScreenshot = await page.screenshot({
+            animations: 'disabled',
+          });
+
+          if (previousScreenshot?.equals(currentScreenshot)) {
+            return;
+          }
+
+          previousScreenshot = currentScreenshot;
+        }
+      });
+    });
+  },
+});

--- a/src/playwright/test.ts
+++ b/src/playwright/test.ts
@@ -11,6 +11,7 @@ import mount from './fixtures/mount.js';
 import removeAttribute from './fixtures/remove-attribute.js';
 import setAttribute from './fixtures/set-attribute.js';
 import setProperty from './fixtures/set-property.js';
+import waitForVisualSettlement from './fixtures/wait-for-visual-settlement.js';
 import toBeAccessible from './matchers/to-be-accessible.js';
 import toBeRegistered from './matchers/to-be-registered.js';
 import toDispatchEvents from './matchers/to-dispatch-events.js';
@@ -56,4 +57,5 @@ export const test = mergeTests(
   removeAttribute,
   setAttribute,
   setProperty,
+  waitForVisualSettlement,
 );


### PR DESCRIPTION
## 🚀 Description

Implements what was discussed at https://github.com/CrowdStrike/glide-core/pull/1066#discussion_r2282375761. In my testing, I noticed that Menu was in fact still transitioning into place for a single frame before settling in the correct spot. So this should help.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

N/A
