### PR TITLE
Handle flattenedNodes in assert-slot

### DIFF
--- a/.changeset/strong-vans-lay.md
+++ b/.changeset/strong-vans-lay.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Slot assertions now properly validate elements when passed through multiple components.

--- a/.changeset/strong-vans-lay.md
+++ b/.changeset/strong-vans-lay.md
@@ -2,4 +2,38 @@
 '@crowdstrike/glide-core': patch
 ---
 
-Slot assertions now properly validate elements when passed through multiple components.
+Slot assertions now properly evaluate the slotted contents when wrapped.
+
+```js
+@customElement('wrapped-modal')
+export default class WrappedModal extends LitElement {
+  render() {
+    return html`
+      <glide-core-modal label="Label">
+        <!-- Reslotting the Modal's primary slot. -->
+        <slot name="primary" slot="primary"></slot>
+      </glide-core-modal>
+    `;
+  }
+}
+```
+
+This will no longer produce an error.
+
+```html
+<wrapped-modal>
+  <glide-core-button label="Submit" slot="primary"></glide-core-button>
+</wrapped-modal>
+```
+
+But this will, as the element is expected to be a GlideCoreButton.
+
+```html
+<wrapped-modal>
+  <div slot="primary"></div>
+</wrapped-modal>
+```
+
+```bash
+Uncaught TypeError: Expected Modal to have a slotted element that extends GlideCoreButton. Extends HTMLDivElement instead.
+```

--- a/src/library/assert-slot.test.ts
+++ b/src/library/assert-slot.test.ts
@@ -46,10 +46,13 @@ class Reslotted extends LitElement {
   @property({ type: Boolean })
   optional = false;
 
+  @property({ type: Array })
+  slotted?: (typeof Element | typeof Text)[] = [];
+
   override render() {
     return html`<glide-core-with-slot
       name=${ifDefined(this.name)}
-      .slotted=${this.optional ? undefined : [HTMLDivElement]}
+      .slotted=${this.slotted}
       ?optional=${this.optional}
     >
       <slot name=${ifDefined(this.name)}></slot>
@@ -452,7 +455,7 @@ it('throws when not used inside an opening tag', async () => {
   );
 });
 
-it('throws when a reslotted default slot is empty', async () => {
+it('throws when a reslotted and required default slot is empty', async () => {
   const stub = sinon.stub(console, 'error');
   const spy = sinon.spy();
   const onerror = window.onerror;
@@ -460,7 +463,11 @@ it('throws when a reslotted default slot is empty', async () => {
   // eslint-disable-next-line unicorn/prefer-add-event-listener
   window.onerror = spy;
 
-  await fixture<Reslotted>(html`<glide-core-reslotted></glide-core-reslotted>`);
+  await fixture<Reslotted>(
+    html`<glide-core-reslotted
+      .slotted=${[HTMLDivElement]}
+    ></glide-core-reslotted>`,
+  );
 
   expect(spy.callCount).to.equal(1);
 
@@ -483,7 +490,7 @@ it('throws when a reslotted default slot has the wrong element', async () => {
   window.onerror = spy;
 
   await fixture<Reslotted>(
-    html`<glide-core-reslotted>
+    html`<glide-core-reslotted .slotted=${[HTMLDivElement]}>
       <a href="/">Link</a>
     </glide-core-reslotted>`,
   );
@@ -505,7 +512,7 @@ it('does not throw when a reslotted default slot has the correct element', async
   window.addEventListener('error', spy);
 
   await fixture<Reslotted>(
-    html`<glide-core-reslotted>
+    html`<glide-core-reslotted .slotted=${[HTMLDivElement]}>
       <div>Content</div>
     </glide-core-reslotted>`,
   );
@@ -513,14 +520,17 @@ it('does not throw when a reslotted default slot has the correct element', async
   expect(spy.callCount).to.equal(0);
 });
 
-it('throws when a reslotted required named slot is empty', async () => {
+it('throws when a reslotted and required named slot is empty', async () => {
   const stub = sinon.stub(console, 'error');
   const spy = sinon.spy();
 
   window.addEventListener('unhandledrejection', spy, { once: true });
 
   await fixture<Reslotted>(
-    html`<glide-core-reslotted name="test"></glide-core-reslotted>`,
+    html`<glide-core-reslotted
+      name="test"
+      .slotted=${[HTMLDivElement]}
+    ></glide-core-reslotted>`,
   );
 
   await waitUntil(() => spy.callCount);

--- a/src/library/assert-slot.ts
+++ b/src/library/assert-slot.ts
@@ -78,14 +78,14 @@ class AssertSlot extends Directive {
             if (
               isOptional &&
               part.element instanceof HTMLSlotElement &&
-              part.element.assignedNodes().length === 0
+              part.element.assignedNodes({ flatten: true }).length === 0
             ) {
               return;
             }
 
             if (
               part.element instanceof HTMLSlotElement &&
-              part.element.assignedNodes().length === 0
+              part.element.assignedNodes({ flatten: true }).length === 0
             ) {
               if (slotted && slotted.length > 0) {
                 const message = part.element.name


### PR DESCRIPTION
## 🚀 Description

We have a use case where a consumer is wrapping one of our components and "reslotting" the primary, secondary, and tertiary slots of Modal. Rather than asserting against our expected types for those slots, it'd throw `Expected Modal to have a slotted element that extends Button or Tooltip`. This PR fixes that.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

N/A - the tests should be enough.