### PR TITLE
Render count in DropdownOption when count=0

### DIFF
--- a/.changeset/cold-avocados-jog.md
+++ b/.changeset/cold-avocados-jog.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown Option now shows the count when it is set to 0.

--- a/src/dropdown.option.test.basics.multiple.ts
+++ b/src/dropdown.option.test.basics.multiple.ts
@@ -122,6 +122,12 @@ it('has a count', async () => {
 
   expect(count?.checkVisibility()).to.be.true;
   expect(count?.textContent?.trim()).to.equal('999+');
+
+  host.count = 0;
+  await host.updateComplete;
+
+  expect(count?.checkVisibility()).to.be.true;
+  expect(count?.textContent?.trim()).to.equal('0');
 });
 
 it('does not have a count when negative', async () => {

--- a/src/dropdown.option.test.basics.single.ts
+++ b/src/dropdown.option.test.basics.single.ts
@@ -106,6 +106,12 @@ it('has a count', async () => {
 
   expect(count?.checkVisibility()).to.be.true;
   expect(count?.textContent?.trim()).to.equal('999+');
+
+  host.count = 0;
+  await host.updateComplete;
+
+  expect(count?.checkVisibility()).to.be.true;
+  expect(count?.textContent?.trim()).to.equal('0');
 });
 
 it('does not have a count when negative', async () => {

--- a/src/dropdown.option.ts
+++ b/src/dropdown.option.ts
@@ -355,7 +355,7 @@ export default class DropdownOption extends LitElement {
                 ${pencilIcon}
               </button>`;
             })}
-            ${when(this.count && this.count > 0, () => {
+            ${when(this.#hasValidCount, () => {
               return html`<div
                 class=${classMap({
                   'count-container': true,
@@ -384,7 +384,7 @@ export default class DropdownOption extends LitElement {
             <div
               class=${classMap({
                 option: true,
-                count: Boolean(this.count),
+                count: this.#hasValidCount,
                 disabled: this.disabled,
                 editable: this.editable,
               })}
@@ -447,7 +447,7 @@ export default class DropdownOption extends LitElement {
                   class=${classMap({
                     'edit-button': true,
                     active: this.privateActive && this.privateIsEditActive,
-                    count: Boolean(this.count),
+                    count: this.#hasValidCount,
                     disabled: this.disabled,
                   })}
                   data-test="edit-button"
@@ -459,7 +459,7 @@ export default class DropdownOption extends LitElement {
                 </button>`;
               })}
 
-              ${when(this.count && this.count > 0, () => {
+              ${when(this.#hasValidCount, () => {
                 return html`<div
                   class=${classMap({
                     'count-container': true,
@@ -533,6 +533,10 @@ export default class DropdownOption extends LitElement {
   #selected = false;
 
   #value = '';
+
+  get #hasValidCount() {
+    return typeof this.count === 'number' && this.count >= 0;
+  }
 
   #onCheckboxClick(event: MouseEvent) {
     // Form controls emit two events when their labels are clicked: one from the


### PR DESCRIPTION
## 🚀 Description

Render count in DropdownOption when count=0.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

Added tests should be enough.
