### PR TITLE
Fix filterable Dropdown flicker bug

### DIFF
--- a/.changeset/wise-singers-tickle.md
+++ b/.changeset/wise-singers-tickle.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown, when filterable and in Form Controls Layout in a Modal, now longer has a flickering ellipsis when the viewport is resized.

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -1791,8 +1791,7 @@ export default class Dropdown extends LitElement implements FormControl {
               this.inputValue = this.activeOption.label;
 
               // One is subtracted to account for an apparent Chrome bug where `scrollWidth`
-              // is off by one relative to `clientWidth` when they should be the same. It
-              // happens whenever the input field was overflowing and now isn't.
+              // is off by one relative to `clientWidth` when they should be the same.
               this.isInputOverflowing =
                 this.#inputElementRef.value.scrollWidth - 1 >
                 this.#inputElementRef.value.clientWidth;
@@ -2326,7 +2325,9 @@ export default class Dropdown extends LitElement implements FormControl {
   #onInputResize() {
     if (this.#inputElementRef.value) {
       this.isInputOverflowing =
-        this.#inputElementRef.value.scrollWidth >
+        // One is subtracted to account for an apparent Chrome bug where `scrollWidth`
+        // is off by one relative to `clientWidth` when they should be the same.
+        this.#inputElementRef.value.scrollWidth - 1 >
         this.#inputElementRef.value.clientWidth;
     }
   }
@@ -2433,8 +2434,7 @@ export default class Dropdown extends LitElement implements FormControl {
           this.inputValue = option.label;
 
           // One is subtracted to account for an apparent Chrome bug where `scrollWidth`
-          // is off by one relative to `clientWidth` when they should be the same. It
-          // happens whenever the input field was overflowing and now isn't.
+          // is off by one relative to `clientWidth` when they should be the same.
           this.isInputOverflowing =
             this.#inputElementRef.value.scrollWidth - 1 >
             this.#inputElementRef.value.clientWidth;
@@ -2528,8 +2528,7 @@ export default class Dropdown extends LitElement implements FormControl {
         this.inputValue = this.lastSelectedAndEnabledOption?.label ?? '';
 
         // One is subtracted to account for an apparent Chrome bug where `scrollWidth`
-        // is off by one relative to `clientWidth` when they should be the same. It
-        // happens whenever the input field was overflowing and now isn't.
+        // is off by one relative to `clientWidth` when they should be the same.
         this.isInputOverflowing =
           this.#inputElementRef.value.scrollWidth - 1 >
           this.#inputElementRef.value.clientWidth;
@@ -2607,8 +2606,7 @@ export default class Dropdown extends LitElement implements FormControl {
         this.inputValue = event.target.label;
 
         // One is subtracted to account for an apparent Chrome bug where `scrollWidth`
-        // is off by one relative to `clientWidth` when they should be the same. It
-        // happens whenever the input field was overflowing and now isn't.
+        // is off by one relative to `clientWidth` when they should be the same.
         this.isInputOverflowing =
           this.#inputElementRef.value.scrollWidth - 1 >
           this.#inputElementRef.value.clientWidth;
@@ -2653,8 +2651,10 @@ export default class Dropdown extends LitElement implements FormControl {
 
         this.inputValue = this.lastSelectedAndEnabledOption.label;
 
+        // One is subtracted to account for an apparent Chrome bug where `scrollWidth`
+        // is off by one relative to `clientWidth` when they should be the same.
         this.isInputOverflowing =
-          this.#inputElementRef.value.scrollWidth >
+          this.#inputElementRef.value.scrollWidth - 1 >
           this.#inputElementRef.value.clientWidth;
       } else {
         // The option's label has changed and is reactive. But it's a separate component.


### PR DESCRIPTION
## 🚀 Description



<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> Dropdown, when filterable and in Form Controls Layout in a Modal, now longer has a flickering ellipsis when the viewport is resized.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

1. Check out this branch.
2. Modify Modal's "Kitchen Sink" story to include a filterable Dropdown inside Form Controls Layout. 
3. Select one of  Dropdown's options.
4. Resize the viewport to a smaller size.
5. Verify Dropdown's ellipsis no longer flickers. It should be hidden altogether.

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
