### PR TITLE
Warn when Menu's target has an `aria-description`

### DIFF
--- a/.changeset/beige-dogs-fetch.md
+++ b/.changeset/beige-dogs-fetch.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Menu overwrites the `aria-description` of its target when Menu's `loading` attribute is set. So Menu now warns when `aria-description` is present.

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -178,9 +178,9 @@ export default class Menu extends LitElement {
     if (this.#optionsElement && this.#targetElement) {
       this.#optionsElement.privateLoading = this.loading;
 
-      this.#targetElement.ariaDescription = this.loading
-        ? this.#localize.term('loading')
-        : null;
+      if (this.loading) {
+        this.#targetElement.ariaDescription = this.#localize.term('loading');
+      }
     }
 
     if (this.open && !this.isTargetDisabled) {
@@ -1279,6 +1279,18 @@ export default class Menu extends LitElement {
         this.#hide();
       }
     });
+
+    /* c8 ignore start */
+    if (
+      this.#targetElement?.ariaDescription !== null &&
+      this.#targetElement?.ariaDescription !== this.#localize.term('loading')
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Menu will overwrite the `aria-description` on your target when Menu's `loading` attribute it set.",
+      );
+    }
+    /* c8 ignore end */
 
     if (this.#targetElement && this.#optionsElement) {
       observer.observe(this.#targetElement, {


### PR DESCRIPTION
## 🚀 Description

> ### Patch
> Menu overwrites the `aria-description` of its target when Menu's `loading` attribute is set. So Menu now warns when `aria-description` is present.

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

N/A

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
