### PR TITLE
Exclude font-family variables from generation

### DIFF
--- a/src/figma/variables/get-css-variables.ts
+++ b/src/figma/variables/get-css-variables.ts
@@ -160,11 +160,23 @@ function generateCSSVariablesFromTokens({
         isExtendedVariable = true;
       }
 
+      // The way Figma font family variables are defined don't align with the syntax used
+      // in CSS:
+      //
+      // 1. Fallbacks cannot be defined (e.g., 'Nunito', system-ui).
+      // 2. It doesn't like quotes (e.g., "Nunito").
+      //
+      // So unfortunately we need to maintain font family variables manually via our
+      // `src/styles/variables/miscellaneous.css` file. Luckily these don't change
+      // frequently.
+      if (value.$type === 'fontFamily') {
+        continue;
+      }
+
       let cssValue: string;
 
       switch (value.$type) {
         case 'color':
-        case 'fontFamily':
         case 'string': {
           cssValue = value.$value;
           break;

--- a/src/styles/variables/miscellaneous.css
+++ b/src/styles/variables/miscellaneous.css
@@ -1,10 +1,15 @@
 /*
-  Variables defined in Figma, but not easily
-  exportable via scripting. The naming of
-  variables is a manual process, but they
-  should align with the name in Figma.
+  Variables defined in Figma, but they're Figma effects, not easily exportable via scripting,
+  or Figma doesn't support similar syntax to CSS. The naming of these variables is a manual
+  process. They should align with the naming format in Figma.
+
+  --glide-core-{collection}-{category*}-{scope*}-{property}-{variant*}--{state*}
+  * = optional
 */
 :root {
+  --glide-core-typography-family-primary: 'Nunito', system-ui;
+  --glide-core-typography-family-monospace:
+    'Oxygen Mono', ui-monospace, monospace;
   --glide-core-effect-hovered: 0px 0px 2px 0px
     var(--glide-core-color-effect-color-elevation-hovered);
   --glide-core-effect-lifted: 0px 2px 8px 0px

--- a/src/styles/variables/typography.css
+++ b/src/styles/variables/typography.css
@@ -9,9 +9,6 @@
   --glide-core-typography-size-body-default: 0.875rem;
   --glide-core-typography-size-body-small: 0.75rem;
   --glide-core-typography-size-component-chartlabel-md: 0.625rem;
-  --glide-core-typography-family-primary: 'Nunito', system-ui;
-  --glide-core-typography-family-monospace:
-    'Oxygen Mono', ui-monospace, monospace;
   --glide-core-typography-weight-light: 300;
   --glide-core-typography-weight-regular: 400;
   --glide-core-typography-weight-semibold: 600;


### PR DESCRIPTION
## 🚀 Description

Some time after merging https://github.com/CrowdStrike/glide-core/pull/1092, I heard back from Design that their updates don't actually work in Figma (and actually break their font). So unfortunately, we need to manually maintain these two variables. Luckily, they don't change frequently.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

N/A