### PR TITLE
Use typescript paths for imports

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,7 +1,7 @@
 /** @type { import('@storybook/web-components-vite').StorybookConfig } */
 
 import { mergeConfig } from 'vite';
-import packageJson from '../package.json';
+import packageJson from '@/package.json';
 
 const config = {
   stories: ['../src/*.stories.ts'],
@@ -43,6 +43,12 @@ const config = {
   },
   viteFinal(config) {
     return mergeConfig(config, {
+      resolve: {
+        alias: {
+          '@': new URL('..', import.meta.url).pathname,
+          '@/src': new URL('../src', import.meta.url).pathname,
+        },
+      },
       build: {
         // So `event.target` and `event.srcElement` in the Actions tab aren't mangled.
         minify: false,

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,7 @@
 /** @type { import('@storybook/web-components').Preview } */
 
-import '../src/styles/fonts.css';
-import '../src/styles/variables.css';
+import '@/src/styles/fonts.css';
+import '@/src/styles/variables.css';
 import './overrides.css';
 import { create } from '@storybook/theming';
 import { html } from 'lit';

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@jridgewell/trace-mapping": "^0.3.29",
     "@open-wc/testing": "^4.0.0",
     "@playwright/test": "^1.54.2",
+    "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-commonjs": "^28.0.2",
     "@storybook/addon-actions": "^8.6.14",
     "@storybook/addon-controls": "^8.6.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@playwright/test':
         specifier: ^1.54.2
         version: 1.54.2
+      '@rollup/plugin-alias':
+        specifier: ^5.1.1
+        version: 5.1.1(rollup@4.28.1)
       '@rollup/plugin-commonjs':
         specifier: ^28.0.2
         version: 28.0.6(rollup@4.28.1)
@@ -775,6 +778,15 @@ packages:
     resolution: {integrity: sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@rollup/plugin-alias@5.1.1':
+    resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/plugin-commonjs@28.0.6':
     resolution: {integrity: sha512-XSQB1K7FUU5QP+3lOQmVCE3I0FcbbNvmNT4VJSj93iUjayaARrTQeoRdiYQoftAJBLrR9t2agwAd3ekaTgHNlw==}
@@ -5189,6 +5201,10 @@ snapshots:
     transitivePeerDependencies:
       - bare-buffer
       - supports-color
+
+  '@rollup/plugin-alias@5.1.1(rollup@4.28.1)':
+    optionalDependencies:
+      rollup: 4.28.1
 
   '@rollup/plugin-commonjs@28.0.6(rollup@4.28.1)':
     dependencies:

--- a/src/accordion.styles.ts
+++ b/src/accordion.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/accordion.test.accessibility.ts
+++ b/src/accordion.test.accessibility.ts
@@ -1,18 +1,15 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
 import type Accordion from './accordion.js';
+import { expect, test } from '@/src/playwright/test.js';
 
-test(
-  'is accessible',
-  { tag: '@accessibility' },
-  async ({ mount, page }) => {
-    await mount(
-      () => html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
-    );
+test('is accessible', { tag: '@accessibility' }, async ({ mount, page }) => {
+  await mount(
+    () =>
+      html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
+  );
 
-    await expect(page).toBeAccessible('glide-core-accordion');
-  },
-);
+  await expect(page).toBeAccessible('glide-core-accordion');
+});
 
 test('open=${true}', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=accordion--accordion');

--- a/src/accordion.test.keyboard.ts
+++ b/src/accordion.test.keyboard.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   'can be opened via Enter',

--- a/src/accordion.test.miscellaneous.ts
+++ b/src/accordion.test.miscellaneous.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(

--- a/src/accordion.test.mouse.ts
+++ b/src/accordion.test.mouse.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   'can be opened via mouse when animated',

--- a/src/accordion.test.visuals.ts
+++ b/src/accordion.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Accordion from './accordion.js';
-import fetchStories from './playwright/fetch-stories.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const stories = await fetchStories('accordion');
 

--- a/src/accordion.ts
+++ b/src/accordion.ts
@@ -3,12 +3,12 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import packageJson from '../package.json' with { type: 'json' };
-import chevronIcon from './icons/chevron.js';
 import styles from './accordion.styles.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
+import chevronIcon from '@/src/icons/chevron.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/button-group.button.styles.ts
+++ b/src/button-group.button.styles.ts
@@ -1,6 +1,6 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
-import visuallyHidden from './styles/visually-hidden.js';
+import focusOutline from '@/src/styles/focus-outline.js';
+import visuallyHidden from '@/src/styles/visually-hidden.js';
 
 export default [
   css`

--- a/src/button-group.button.test.basics.ts
+++ b/src/button-group.button.test.basics.ts
@@ -2,7 +2,7 @@ import { expect, fixture, html } from '@open-wc/testing';
 import sinon from 'sinon';
 import { customElement } from 'lit/decorators.js';
 import ButtonGroupButton from './button-group.button.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends ButtonGroupButton {}

--- a/src/button-group.button.ts
+++ b/src/button-group.button.ts
@@ -2,11 +2,11 @@ import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './button-group.button.styles.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/button-group.styles.ts
+++ b/src/button-group.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import visuallyHidden from './styles/visually-hidden.js';
+import visuallyHidden from '@/src/styles/visually-hidden.js';
 
 export default [
   css`

--- a/src/button-group.test.accessibility.ts
+++ b/src/button-group.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type ButtonGroupButton from './button-group.button.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   '<glide-core-button-group-button>[disabled=${true}]',

--- a/src/button-group.test.basics.ts
+++ b/src/button-group.test.basics.ts
@@ -3,7 +3,7 @@ import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import ButtonGroup from './button-group.js';
 import './button-group.button.js';
-import expectWindowError from './library/expect-window-error.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends ButtonGroup {}

--- a/src/button-group.test.events.ts
+++ b/src/button-group.test.events.ts
@@ -2,7 +2,7 @@ import { assert, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import ButtonGroupButton from './button-group.button.js';
-import { click } from './library/mouse.js';
+import { click } from '@/src/library/mouse.js';
 import './button-group.js';
 
 it('dispatches a "selected" event when a button is clicked and not already selected', async () => {

--- a/src/button-group.test.interactions.ts
+++ b/src/button-group.test.interactions.ts
@@ -1,8 +1,8 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import './button-group.button.js';
-import { click } from './library/mouse.js';
 import ButtonGroup from './button-group.js';
+import { click } from '@/src/library/mouse.js';
 
 it('selects a button on click', async () => {
   const host = await fixture<ButtonGroup>(

--- a/src/button-group.test.visuals.ts
+++ b/src/button-group.test.visuals.ts
@@ -1,7 +1,7 @@
-import { expect, test } from './playwright/test.js';
 import type ButtonGroup from './button-group.js';
 import type ButtonGroupButton from './button-group.button.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Button Group');
 

--- a/src/button-group.ts
+++ b/src/button-group.ts
@@ -2,12 +2,12 @@ import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
-import packageJson from '../package.json' with { type: 'json' };
 import ButtonGroupButton from './button-group.button.js';
 import styles from './button-group.styles.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/button.styles.ts
+++ b/src/button.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/button.test.accessibility.ts
+++ b/src/button.test.accessibility.ts
@@ -1,16 +1,17 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
 import type Button from './button.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   'is accessible',
   { tag: '@accessibility' },
   async ({ mount, page, setAttribute }) => {
     await mount(
-      () => html`<glide-core-button
-        label="Label"
-        aria-description="Description"
-      ></glide-core-button>`,
+      () =>
+        html`<glide-core-button
+          label="Label"
+          aria-description="Description"
+        ></glide-core-button>`,
     );
 
     await expect(page).toBeAccessible('glide-core-button');

--- a/src/button.test.forms.ts
+++ b/src/button.test.forms.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   'has a `form` property that returns its form',

--- a/src/button.test.keyboard.ts
+++ b/src/button.test.keyboard.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   'can be clicked via Enter',

--- a/src/button.test.miscellaneous.ts
+++ b/src/button.test.miscellaneous.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(() => html`<glide-core-button label="Label"></glide-core-button>`);

--- a/src/button.test.mouse.ts
+++ b/src/button.test.mouse.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('can be clicked via mouse', { tag: '@mouse' }, async ({ mount, page }) => {
   await mount(() => html`<glide-core-button label="Label"></glide-core-button>`);

--- a/src/button.test.visuals.ts
+++ b/src/button.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Button from './button.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Button');
 

--- a/src/button.ts
+++ b/src/button.ts
@@ -1,12 +1,12 @@
-import './tooltip.js';
 import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './button.styles.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
+import './tooltip.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/checkbox-group.test.accessibility.ts
+++ b/src/checkbox-group.test.accessibility.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type CheckboxGroup from './checkbox-group.js';
 import type Checkbox from './checkbox.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('disabled=${true}', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=checkbox-group--checkbox-group');

--- a/src/checkbox-group.test.basics.ts
+++ b/src/checkbox-group.test.basics.ts
@@ -3,8 +3,8 @@ import { expect, fixture, html } from '@open-wc/testing';
 import sinon from 'sinon';
 import { customElement } from 'lit/decorators.js';
 import CheckboxGroup from './checkbox-group.js';
-import expectWindowError from './library/expect-window-error.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends CheckboxGroup {}

--- a/src/checkbox-group.test.events.ts
+++ b/src/checkbox-group.test.events.ts
@@ -1,8 +1,8 @@
 import './checkbox.js';
 import * as sinon from 'sinon';
 import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
-import { click } from './library/mouse.js';
 import CheckboxGroup from './checkbox-group.js';
+import { click } from '@/src/library/mouse.js';
 
 it('dispatches a "click" event on click', async () => {
   const host = await fixture<CheckboxGroup>(

--- a/src/checkbox-group.test.forms.ts
+++ b/src/checkbox-group.test.forms.ts
@@ -1,8 +1,8 @@
 import './checkbox.js';
 import { assert, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
-import { click } from './library/mouse.js';
 import CheckboxGroup from './checkbox-group.js';
+import { click } from '@/src/library/mouse.js';
 
 it('can be reset', async () => {
   const form = document.createElement('form');

--- a/src/checkbox-group.test.interactions.ts
+++ b/src/checkbox-group.test.interactions.ts
@@ -1,7 +1,7 @@
 import './checkbox.js';
 import { assert, expect, fixture, html } from '@open-wc/testing';
-import { click } from './library/mouse.js';
 import CheckboxGroup from './checkbox-group.js';
+import { click } from '@/src/library/mouse.js';
 
 it('checks and unchecks checkboxes when its `value` is set programmatically', async () => {
   const host = await fixture<CheckboxGroup>(

--- a/src/checkbox-group.test.visuals.ts
+++ b/src/checkbox-group.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type CheckboxGroup from './checkbox-group.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Checkbox Group');
 

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -6,13 +6,13 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
-import packageJson from '../package.json' with { type: 'json' };
 import Checkbox from './checkbox.js';
 import styles from './checkbox-group.styles.js';
-import assertSlot from './library/assert-slot.js';
-import type FormControl from './library/form-control.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import assertSlot from '@/src/library/assert-slot.js';
+import type FormControl from '@/src/library/form-control.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/checkbox.styles.ts
+++ b/src/checkbox.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/checkbox.test.accessibility.ts
+++ b/src/checkbox.test.accessibility.ts
@@ -1,24 +1,21 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
 import type Checkbox from './checkbox.js';
+import { expect, test } from '@/src/playwright/test.js';
 
-test(
-  'is accessible',
-  { tag: '@accessibility' },
-  async ({ mount, page }) => {
-    await mount(
-      () => html`<glide-core-checkbox
+test('is accessible', { tag: '@accessibility' }, async ({ mount, page }) => {
+  await mount(
+    () =>
+      html`<glide-core-checkbox
         label="Label"
         summary="Summary"
         tooltip="Tooltip"
       >
         <div slot="description">Description</div>
       </glide-core-checkbox>`,
-    );
+  );
 
-    await expect(page).toBeAccessible('glide-core-checkbox');
-  },
-);
+  await expect(page).toBeAccessible('glide-core-checkbox');
+});
 
 test('checked=${true}', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=checkbox--checkbox');

--- a/src/checkbox.test.forms.ts
+++ b/src/checkbox.test.forms.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('has a `form` property', { tag: '@forms' }, async ({ mount, page }) => {
   await mount(

--- a/src/checkbox.test.keyboard.ts
+++ b/src/checkbox.test.keyboard.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   'can be checked via Space',

--- a/src/checkbox.test.miscellaneous.ts
+++ b/src/checkbox.test.miscellaneous.ts
@@ -1,6 +1,6 @@
 import { html } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(() => html`<glide-core-checkbox label="Label"></glide-core-checkbox>`);

--- a/src/checkbox.test.mouse.ts
+++ b/src/checkbox.test.mouse.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('can be checked via mouse', { tag: '@mouse' }, async ({ mount, page }) => {
   await mount(() => html`<glide-core-checkbox label="Label"></glide-core-checkbox>`);

--- a/src/checkbox.test.visuals.ts
+++ b/src/checkbox.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Checkbox from './checkbox.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Checkbox');
 

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -8,12 +8,12 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import packageJson from '../package.json' with { type: 'json' };
-import checkedIcon from './icons/checked.js';
 import styles from './checkbox.styles.js';
-import type FormControl from './library/form-control.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import checkedIcon from '@/src/icons/checked.js';
+import type FormControl from '@/src/library/form-control.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/drawer.test.accessibility.ts
+++ b/src/drawer.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type Drawer from './drawer.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('open', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=drawer--drawer');

--- a/src/drawer.test.basics.ts
+++ b/src/drawer.test.basics.ts
@@ -2,7 +2,7 @@ import { expect, fixture, html } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import Drawer from './drawer.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends Drawer {}

--- a/src/drawer.test.visuals.ts
+++ b/src/drawer.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Drawer from './drawer.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Drawer');
 

--- a/src/drawer.ts
+++ b/src/drawer.ts
@@ -3,11 +3,11 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './drawer.styles.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/dropdown.option.test.events.ts
+++ b/src/dropdown.option.test.events.ts
@@ -1,8 +1,8 @@
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import sinon from 'sinon';
 import DropdownOption from './dropdown.option.js';
-import { hover } from './library/mouse.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { hover } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('dispatches a "private-label-change" event', async () => {
   const host = await fixture<DropdownOption>(

--- a/src/dropdown.option.test.interactions.multiple.ts
+++ b/src/dropdown.option.test.interactions.multiple.ts
@@ -1,6 +1,6 @@
 import { expect, fixture, html } from '@open-wc/testing';
-import { hover } from './library/mouse.js';
 import DropdownOption from './dropdown.option.js';
+import { hover } from '@/src/library/mouse.js';
 
 it('is selected when programmatically selected', async () => {
   const host = await fixture<DropdownOption>(

--- a/src/dropdown.option.test.interactions.single.ts
+++ b/src/dropdown.option.test.interactions.single.ts
@@ -1,7 +1,7 @@
 import { aTimeout, expect, fixture, html } from '@open-wc/testing';
-import { hover } from './library/mouse.js';
 import DropdownOption from './dropdown.option.js';
 import Tooltip from './tooltip.js';
+import { hover } from '@/src/library/mouse.js';
 
 it('is selected when programmatically selected', async () => {
   const host = await fixture<DropdownOption>(

--- a/src/dropdown.option.ts
+++ b/src/dropdown.option.ts
@@ -6,15 +6,15 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
-import packageJson from '../package.json' with { type: 'json' };
-import checkedIcon from './icons/checked.js';
-import pencilIcon from './icons/pencil.js';
-import { LocalizeController } from './library/localize.js';
 import styles from './dropdown.option.styles.js';
 import type Checkbox from './checkbox.js';
-import final from './library/final.js';
-import required from './library/required.js';
-import uniqueId from './library/unique-id.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import checkedIcon from '@/src/icons/checked.js';
+import pencilIcon from '@/src/icons/pencil.js';
+import { LocalizeController } from '@/src/library/localize.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
+import uniqueId from '@/src/library/unique-id.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -1,7 +1,7 @@
 import { css } from 'lit';
-import opacityAndScaleAnimation from './styles/opacity-and-scale-animation.js';
-import visuallyHidden from './styles/visually-hidden.js';
-import skeleton from './styles/skeleton.js';
+import opacityAndScaleAnimation from '@/src/styles/opacity-and-scale-animation.js';
+import visuallyHidden from '@/src/styles/visually-hidden.js';
+import skeleton from '@/src/styles/skeleton.js';
 
 export default [
   css`

--- a/src/dropdown.test.accessibility.ts
+++ b/src/dropdown.test.accessibility.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Dropdown from './dropdown.js';
 import type DropdownOption from './dropdown.option.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('disabled=${true}', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=dropdown--dropdown');

--- a/src/dropdown.test.basics.multiple.ts
+++ b/src/dropdown.test.basics.multiple.ts
@@ -3,7 +3,7 @@ import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
 import Dropdown from './dropdown.js';
 import Tag from './tag.js';
 import type DropdownOption from './dropdown.option.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('is accessible', async () => {
   const host = await fixture<Dropdown>(

--- a/src/dropdown.test.basics.single.ts
+++ b/src/dropdown.test.basics.single.ts
@@ -1,7 +1,7 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import Dropdown from './dropdown.js';
 import type DropdownOption from './dropdown.option.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('is accessible ', async () => {
   const host = await fixture<Dropdown>(

--- a/src/dropdown.test.basics.ts
+++ b/src/dropdown.test.basics.ts
@@ -3,9 +3,9 @@ import sinon from 'sinon';
 import { customElement } from 'lit/decorators.js';
 import Dropdown from './dropdown.js';
 import './dropdown.option.js';
-import expectWindowError from './library/expect-window-error.js';
 import type Tooltip from './tooltip.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 // You'll notice quite a few duplicated tests among the "*.single.ts",
 // "*.multiple.ts", and "*.filterable.ts" test suites. The thinking is that

--- a/src/dropdown.test.events.filterable.ts
+++ b/src/dropdown.test.events.filterable.ts
@@ -1,8 +1,8 @@
 import * as sinon from 'sinon';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
-import { click } from './library/mouse.js';
 import Dropdown from './dropdown.js';
+import { click } from '@/src/library/mouse.js';
 import './dropdown.option.js';
 
 it('dispatches an "add" event on Add button selection via click', async () => {

--- a/src/dropdown.test.events.multiple.ts
+++ b/src/dropdown.test.events.multiple.ts
@@ -9,10 +9,10 @@ import {
   waitUntil,
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
-import { click } from './library/mouse.js';
 import Dropdown from './dropdown.js';
+import { click } from '@/src/library/mouse.js';
 import './dropdown.option.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('dispatches one "change" event when an option is selected via click', async () => {
   const host = await fixture<Dropdown>(

--- a/src/dropdown.test.events.single.ts
+++ b/src/dropdown.test.events.single.ts
@@ -9,9 +9,9 @@ import {
   waitUntil,
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
-import { click } from './library/mouse.js';
 import Dropdown from './dropdown.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('dispatches one "change" event when an option is selected via click', async () => {
   const host = await fixture<Dropdown>(

--- a/src/dropdown.test.events.ts
+++ b/src/dropdown.test.events.ts
@@ -8,10 +8,10 @@ import {
   oneEvent,
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
-import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
+import { click, hover } from '@/src/library/mouse.js';
 import './dropdown.option.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('dispatches an "edit" event on click', async () => {
   const host = await fixture<Dropdown>(

--- a/src/dropdown.test.focus.filterable.ts
+++ b/src/dropdown.test.focus.filterable.ts
@@ -1,9 +1,9 @@
 import { assert, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import './dropdown.option.js';
-import { click } from './library/mouse.js';
 import Dropdown from './dropdown.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('focuses the input when `focus()` is called', async () => {
   const host = await fixture<Dropdown>(

--- a/src/dropdown.test.focus.ts
+++ b/src/dropdown.test.focus.ts
@@ -1,9 +1,9 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import './dropdown.option.js';
-import { click } from './library/mouse.js';
 import Dropdown from './dropdown.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('closes and reports validity when it loses focus', async () => {
   const div = document.createElement('div');

--- a/src/dropdown.test.forms.multiple.ts
+++ b/src/dropdown.test.forms.multiple.ts
@@ -4,8 +4,8 @@ import sinon from 'sinon';
 import { sendKeys } from '@web/test-runner-commands';
 import Dropdown from './dropdown.js';
 import Tag from './tag.js';
-import { click } from './library/mouse.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('can be reset after options are selected via click', async () => {
   const form = document.createElement('form');

--- a/src/dropdown.test.forms.single.ts
+++ b/src/dropdown.test.forms.single.ts
@@ -1,8 +1,8 @@
 import { assert, expect, fixture, html } from '@open-wc/testing';
 import './dropdown.option.js';
 import Dropdown from './dropdown.js';
-import { click } from './library/mouse.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('can be reset after an option is selected via click', async () => {
   const form = document.createElement('form');

--- a/src/dropdown.test.interactions.filterable.ts
+++ b/src/dropdown.test.interactions.filterable.ts
@@ -9,11 +9,11 @@ import {
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import './dropdown.option.js';
 import type Tooltip from './tooltip.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click, hover } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('opens on click', async () => {
   const host = await fixture<Dropdown>(

--- a/src/dropdown.test.interactions.multiple.ts
+++ b/src/dropdown.test.interactions.multiple.ts
@@ -10,11 +10,11 @@ import {
 import { customElement } from 'lit/decorators.js';
 import { sendKeys } from '@web/test-runner-commands';
 import { styleMap } from 'lit/directives/style-map.js';
-import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import DropdownOption from './dropdown.option.js';
 import Tag from './tag.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click, hover } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 @customElement('glide-core-dropdown-in-another-component')
 class DropdownInAnotherComponent extends LitElement {

--- a/src/dropdown.test.interactions.single.ts
+++ b/src/dropdown.test.interactions.single.ts
@@ -9,11 +9,11 @@ import {
 import { sendKeys } from '@web/test-runner-commands';
 import { styleMap } from 'lit/directives/style-map.js';
 import sinon from 'sinon';
-import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import DropdownOption from './dropdown.option.js';
 import type Tooltip from './tooltip.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click, hover } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('opens on click', async () => {
   const host = await fixture<Dropdown>(

--- a/src/dropdown.test.interactions.ts
+++ b/src/dropdown.test.interactions.ts
@@ -1,11 +1,11 @@
 import { aTimeout, assert, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import { click, hover } from './library/mouse.js';
 import Dropdown from './dropdown.js';
 import './dropdown.option.js';
 import type Tooltip from './tooltip.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click, hover } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('opens when opened programmatically', async () => {
   const host = await fixture<Dropdown>(

--- a/src/dropdown.test.visuals.ts
+++ b/src/dropdown.test.visuals.ts
@@ -1,7 +1,7 @@
-import { expect, test } from './playwright/test.js';
 import type Dropdown from './dropdown.js';
 import type DropdownOption from './dropdown.option.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Dropdown');
 

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -12,20 +12,20 @@ import { range } from 'lit/directives/range.js';
 import { map } from 'lit/directives/map.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
-import packageJson from '../package.json' with { type: 'json' };
-import onResize from './library/on-resize.js';
 import DropdownOption from './dropdown.option.js';
-import { LocalizeController } from './library/localize.js';
 import Tag from './tag.js';
-import chevronIcon from './icons/chevron.js';
-import magnifyingGlassIcon from './icons/magnifying-glass.js';
-import pencilIcon from './icons/pencil.js';
 import styles from './dropdown.styles.js';
-import assertSlot from './library/assert-slot.js';
-import type FormControl from './library/form-control.js';
-import final from './library/final.js';
-import required from './library/required.js';
-import uniqueId from './library/unique-id.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import onResize from '@/src/library/on-resize.js';
+import { LocalizeController } from '@/src/library/localize.js';
+import chevronIcon from '@/src/icons/chevron.js';
+import magnifyingGlassIcon from '@/src/icons/magnifying-glass.js';
+import pencilIcon from '@/src/icons/pencil.js';
+import assertSlot from '@/src/library/assert-slot.js';
+import type FormControl from '@/src/library/form-control.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
+import uniqueId from '@/src/library/unique-id.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/eslint/rules/always-tag-tests.test.ts
+++ b/src/eslint/rules/always-tag-tests.test.ts
@@ -1,6 +1,6 @@
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { alwaysTagTests } from './always-tag-tests.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/comment-maximum-length.test.ts
+++ b/src/eslint/rules/comment-maximum-length.test.ts
@@ -1,6 +1,6 @@
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { commentMaximumLength } from './comment-maximum-length.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/consistent-reference-element-declarations.test.ts
+++ b/src/eslint/rules/consistent-reference-element-declarations.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { consistentReferenceElementDeclarations } from './consistent-reference-element-declarations.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/consistent-test-fixture-variable-declarator.test.ts
+++ b/src/eslint/rules/consistent-test-fixture-variable-declarator.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { consistentTestFixtureVariableDeclarator } from './consistent-test-fixture-variable-declarator.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/event-dispatch-from-this.test.ts
+++ b/src/eslint/rules/event-dispatch-from-this.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { eventDispatchFromThis } from './event-dispatch-from-this.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/no-nested-template-literals.test.ts
+++ b/src/eslint/rules/no-nested-template-literals.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { noNestedTemplateLiterals } from './no-nested-template-literals.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/no-protected-keyword.test.ts
+++ b/src/eslint/rules/no-protected-keyword.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { noProtectedKeyword } from './no-protected-keyword.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/no-redundant-property-attribute.test.ts
+++ b/src/eslint/rules/no-redundant-property-attribute.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { noRedudantPropertyAttribute } from './no-redundant-property-attribute.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/no-redundant-property-string-type.test.ts
+++ b/src/eslint/rules/no-redundant-property-string-type.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { noRedudantPropertyStringType } from './no-redundant-property-string-type.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/no-tags-in-test-names.test.ts
+++ b/src/eslint/rules/no-tags-in-test-names.test.ts
@@ -1,6 +1,6 @@
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { noTagsInTestNames } from './no-tags-in-test-names.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/no-test-fail.test.ts
+++ b/src/eslint/rules/no-test-fail.test.ts
@@ -1,6 +1,6 @@
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { noTestFail } from './no-test-fail.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/no-test-fixme.test.ts
+++ b/src/eslint/rules/no-test-fixme.test.ts
@@ -1,6 +1,6 @@
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { noTestFixme } from './no-test-fixme.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/no-to-contain-class.test.ts
+++ b/src/eslint/rules/no-to-contain-class.test.ts
@@ -1,6 +1,6 @@
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { noToContainClass } from './no-to-contain-class.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/no-to-have-class.test.ts
+++ b/src/eslint/rules/no-to-have-class.test.ts
@@ -1,6 +1,6 @@
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { noToHaveClass } from './no-to-have-class.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/one-tag-per-test.test.ts
+++ b/src/eslint/rules/one-tag-per-test.test.ts
@@ -1,6 +1,6 @@
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { oneTagPerTest } from './one-tag-per-test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/private-state-decorators.test.ts
+++ b/src/eslint/rules/private-state-decorators.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { privateStateDecorators } from './private-state-decorators.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/public-getter-default-comment.test.ts
+++ b/src/eslint/rules/public-getter-default-comment.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { publicGetterDefaultComment } from './public-getter-default-comment.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/public-member-return-type.test.ts
+++ b/src/eslint/rules/public-member-return-type.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { publicMemberReturnType } from './public-member-return-type.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/public-property-expression-type.test.ts
+++ b/src/eslint/rules/public-property-expression-type.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { publicPropertyExpressionType } from './public-property-expression-type.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/slot-type-comment.test.ts
+++ b/src/eslint/rules/slot-type-comment.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { slotTypeComment } from './slot-type-comment.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/string-event-name.test.ts
+++ b/src/eslint/rules/string-event-name.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { stringEventName } from './string-event-name.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/test-tag-matches-suite.test.ts
+++ b/src/eslint/rules/test-tag-matches-suite.test.ts
@@ -1,6 +1,6 @@
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { testTagMatchesSuite } from './test-tag-matches-suite.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/use-default-with-property-decorator.test.ts
+++ b/src/eslint/rules/use-default-with-property-decorator.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { useDefaultWithPropertyDecorator } from './use-default-with-property-decorator.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/eslint/rules/use-final-decorator.test.ts
+++ b/src/eslint/rules/use-final-decorator.test.ts
@@ -1,7 +1,7 @@
 import parser from '@typescript-eslint/parser';
 import { ESLint } from '@typescript-eslint/utils/ts-eslint';
-import { expect, test } from '../../playwright/test.js';
 import { useFinalDecorator } from './use-final-decorator.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const eslint = new ESLint({
   overrideConfigFile: true,

--- a/src/form-controls-layout.test.basics.ts
+++ b/src/form-controls-layout.test.basics.ts
@@ -4,8 +4,8 @@ import { expect, fixture, html } from '@open-wc/testing';
 import sinon from 'sinon';
 import { customElement } from 'lit/decorators.js';
 import FormControlsLayout from './form-controls-layout.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
-import expectWindowError from './library/expect-window-error.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends FormControlsLayout {}

--- a/src/form-controls-layout.test.visuals.ts
+++ b/src/form-controls-layout.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type FormControlsLayout from './form-controls-layout.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Form Controls Layout');
 

--- a/src/form-controls-layout.ts
+++ b/src/form-controls-layout.ts
@@ -1,7 +1,6 @@
 import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
-import packageJson from '../package.json' with { type: 'json' };
 import Checkbox from './checkbox.js';
 import CheckboxGroup from './checkbox-group.js';
 import Dropdown from './dropdown.js';
@@ -10,8 +9,9 @@ import RadioGroup from './radio-group.js';
 import Slider from './slider.js';
 import TextArea from './textarea.js';
 import styles from './form-controls-layout.styles.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/icon-button.styles.ts
+++ b/src/icon-button.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/icon-button.test.accessibility.ts
+++ b/src/icon-button.test.accessibility.ts
@@ -1,15 +1,19 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
 import type IconButton from './icon-button.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   'is accessible',
   { tag: '@accessibility' },
   async ({ mount, page, setAttribute }) => {
     await mount(
-      () => html`<glide-core-icon-button label="Label" aria-description="Description">
-        <div>Icon</div>
-      </glide-core-icon-button>`,
+      () =>
+        html`<glide-core-icon-button
+          label="Label"
+          aria-description="Description"
+        >
+          <div>Icon</div>
+        </glide-core-icon-button>`,
     );
 
     await expect(page).toBeAccessible('glide-core-icon-button');

--- a/src/icon-button.test.keyboard.ts
+++ b/src/icon-button.test.keyboard.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   'can be clicked via Enter',

--- a/src/icon-button.test.miscellaneous.ts
+++ b/src/icon-button.test.miscellaneous.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(

--- a/src/icon-button.test.mouse.ts
+++ b/src/icon-button.test.mouse.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('can be clicked via mouse', { tag: '@mouse' }, async ({ mount, page }) => {
   await mount(

--- a/src/icon-button.test.visuals.ts
+++ b/src/icon-button.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type IconButton from './icon-button.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Icon Button');
 

--- a/src/icon-button.ts
+++ b/src/icon-button.ts
@@ -3,11 +3,11 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './icon-button.styles.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/icons/storybook.ts
+++ b/src/icons/storybook.ts
@@ -4,7 +4,7 @@
  */
 import { css, html, LitElement, svg } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import final from '../library/final.js';
+import final from '@/src/library/final.js';
 
 @customElement('glide-core-example-icon')
 @final

--- a/src/inline-alert.test.accessibility.ts
+++ b/src/inline-alert.test.accessibility.ts
@@ -1,4 +1,4 @@
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 // Not sure what to name this test. It's not really testing
 // `variant="informational"`. It's testing the component in its default

--- a/src/inline-alert.test.basics.ts
+++ b/src/inline-alert.test.basics.ts
@@ -2,7 +2,7 @@ import { assert, expect, fixture, html, waitUntil } from '@open-wc/testing';
 import sinon from 'sinon';
 import { customElement } from 'lit/decorators.js';
 import InlineAlert from './inline-alert.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends InlineAlert {}

--- a/src/inline-alert.test.visuals.ts
+++ b/src/inline-alert.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type InlineAlert from './inline-alert.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Inline Alert');
 

--- a/src/inline-alert.ts
+++ b/src/inline-alert.ts
@@ -3,13 +3,13 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './inline-alert.styles.js';
-import severityInformationalIcon from './icons/severity-informational.js';
-import severityMediumIcon from './icons/severity-medium.js';
-import severityCriticalIcon from './icons/severity-critical.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import severityInformationalIcon from '@/src/icons/severity-informational.js';
+import severityMediumIcon from '@/src/icons/severity-medium.js';
+import severityCriticalIcon from '@/src/icons/severity-critical.js';
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/input.styles.ts
+++ b/src/input.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import visuallyHidden from './styles/visually-hidden.js';
+import visuallyHidden from '@/src/styles/visually-hidden.js';
 
 export default [
   css`

--- a/src/input.test.accessibility.ts
+++ b/src/input.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type Input from './input.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('clearable', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=input--input');

--- a/src/input.test.events.ts
+++ b/src/input.test.events.ts
@@ -1,8 +1,8 @@
 import * as sinon from 'sinon';
 import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
-import { click } from './library/mouse.js';
 import Input from './input.js';
+import { click } from '@/src/library/mouse.js';
 
 it('dispatches a "change" event on input', async () => {
   const host = await fixture<Input>(

--- a/src/input.test.forms.ts
+++ b/src/input.test.forms.ts
@@ -2,7 +2,7 @@ import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import Input from './input.js';
-import { click } from './library/mouse.js';
+import { click } from '@/src/library/mouse.js';
 
 it('can be reset to its initial value', async () => {
   const form = document.createElement('form');

--- a/src/input.test.interactions.ts
+++ b/src/input.test.interactions.ts
@@ -1,7 +1,7 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
-import { click } from './library/mouse.js';
 import Input from './input.js';
+import { click } from '@/src/library/mouse.js';
 
 it('can be cleared', async () => {
   const host = await fixture<Input>(html`

--- a/src/input.test.visuals.ts
+++ b/src/input.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Input from './input.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Input');
 

--- a/src/input.ts
+++ b/src/input.ts
@@ -8,14 +8,14 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
-import packageJson from '../package.json' with { type: 'json' };
-import { LocalizeController } from './library/localize.js';
-import magnifyingGlassIcon from './icons/magnifying-glass.js';
 import styles from './input.styles.js';
-import xIcon from './icons/x.js';
-import type FormControl from './library/form-control.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import { LocalizeController } from '@/src/library/localize.js';
+import magnifyingGlassIcon from '@/src/icons/magnifying-glass.js';
+import xIcon from '@/src/icons/x.js';
+import type FormControl from '@/src/library/form-control.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/label.styles.ts
+++ b/src/label.styles.ts
@@ -1,6 +1,6 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
-import visuallyHidden from './styles/visually-hidden.js';
+import focusOutline from '@/src/styles/focus-outline.js';
+import visuallyHidden from '@/src/styles/visually-hidden.js';
 
 export default [
   css`

--- a/src/label.test.basics.ts
+++ b/src/label.test.basics.ts
@@ -3,7 +3,7 @@ import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import Label from './label.js';
 import './tooltip.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends Label {}

--- a/src/label.test.interactions.ts
+++ b/src/label.test.interactions.ts
@@ -1,7 +1,7 @@
 import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
 import Label from './label.js';
 import Tooltip from './tooltip.js';
-import { hover } from './library/mouse.js';
+import { hover } from '@/src/library/mouse.js';
 
 it('shows a label tooltip on hover', async () => {
   const host = await fixture<Label>(

--- a/src/label.ts
+++ b/src/label.ts
@@ -7,10 +7,10 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
 import styles from './label.styles.js';
-import { LocalizeController } from './library/localize.js';
-import assertSlot from './library/assert-slot.js';
-import onResize from './library/on-resize.js';
-import final from './library/final.js';
+import { LocalizeController } from '@/src/library/localize.js';
+import assertSlot from '@/src/library/assert-slot.js';
+import onResize from '@/src/library/on-resize.js';
+import final from '@/src/library/final.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/library/localize.ts
+++ b/src/library/localize.ts
@@ -3,9 +3,9 @@ import {
   registerTranslation,
 } from '@shoelace-style/localize';
 import type { Translation as DefaultTranslation } from '@shoelace-style/localize';
-import en from '../translations/en.js'; // Register English as the default/fallback language
-import fr from '../translations/fr.js';
-import ja from '../translations/ja.js';
+import en from '@/src/translations/en.js'; // Register English as the default/fallback language
+import fr from '@/src/translations/fr.js';
+import ja from '@/src/translations/ja.js';
 
 // Extend the controller and apply our own translation interface for better typings
 export class LocalizeController extends DefaultLocalizationController<Translation> {

--- a/src/link.styles.ts
+++ b/src/link.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/link.test.accessibility.ts
+++ b/src/link.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type Link from './link.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('disabled=${true}', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=link--link');

--- a/src/link.test.events.ts
+++ b/src/link.test.events.ts
@@ -2,7 +2,7 @@ import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import sinon from 'sinon';
 import { sendKeys } from '@web/test-runner-commands';
 import Link from './link.js';
-import { click } from './library/mouse.js';
+import { click } from '@/src/library/mouse.js';
 
 it('dispatches a "click" event on click', async () => {
   const host = await fixture<Link>(

--- a/src/link.test.visuals.ts
+++ b/src/link.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Link from './link.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Link');
 

--- a/src/link.ts
+++ b/src/link.ts
@@ -3,10 +3,10 @@ import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { createRef, ref } from 'lit/directives/ref.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './link.styles.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/menu.styles.ts
+++ b/src/menu.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import opacityAndScaleAnimation from './styles/opacity-and-scale-animation.js';
+import opacityAndScaleAnimation from '@/src/styles/opacity-and-scale-animation.js';
 
 export default [
   css`

--- a/src/menu.test.accessibility.ts
+++ b/src/menu.test.accessibility.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Menu from './menu.js';
 import Option from './option.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('loading', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=menu--menu');

--- a/src/menu.test.basics.filterable.ts
+++ b/src/menu.test.basics.filterable.ts
@@ -2,11 +2,11 @@ import './options.js';
 import { LitElement } from 'lit';
 import { expect, fixture, html } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
-import { click } from './library/mouse.js';
+import Menu from './menu.js';
+import { click } from '@/src/library/mouse.js';
 import './option.js';
 import './input.js';
-import Menu from './menu.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 @customElement('glide-core-target-as-slot')
 class TargetAsSlot extends LitElement {

--- a/src/menu.test.basics.ts
+++ b/src/menu.test.basics.ts
@@ -5,9 +5,9 @@ import { expect, fixture, html } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import Menu from './menu.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
-import expectWindowError from './library/expect-window-error.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends Menu {}

--- a/src/menu.test.events.ts
+++ b/src/menu.test.events.ts
@@ -10,9 +10,9 @@ import {
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import { click } from './library/mouse.js';
 import Menu from './menu.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('dispatches a "click" event when an Option is selected via mouse', async () => {
   const host = await fixture<Menu>(

--- a/src/menu.test.focus.ts
+++ b/src/menu.test.focus.ts
@@ -3,7 +3,7 @@ import './options.js';
 import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import Menu from './menu.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('closes when it loses focus', async () => {
   const host = await fixture<Menu>(

--- a/src/menu.test.interactions.filterable.ts
+++ b/src/menu.test.interactions.filterable.ts
@@ -1,13 +1,13 @@
 import './options.js';
 import { aTimeout, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
-import { click } from './library/mouse.js';
 import Menu from './menu.js';
 import './option.js';
 import './input.js';
 import './button.js';
 import Tooltip from './tooltip.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('opens on "input"', async () => {
   const host = await fixture<Menu>(

--- a/src/menu.test.interactions.ts
+++ b/src/menu.test.interactions.ts
@@ -12,11 +12,11 @@ import {
 } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import { sendKeys } from '@web/test-runner-commands';
-import requestIdleCallback from './library/request-idle-callback.js';
-import { click, hover } from './library/mouse.js';
 import Menu from './menu.js';
-import './option.js';
 import Tooltip from './tooltip.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
+import { click, hover } from '@/src/library/mouse.js';
+import './option.js';
 
 @customElement('glide-core-options-in-nested-slot')
 class OptionsInNestedSlot extends LitElement {

--- a/src/menu.test.visuals.ts
+++ b/src/menu.test.visuals.ts
@@ -1,8 +1,8 @@
-import { expect, test } from './playwright/test.js';
 import type Menu from './menu.js';
 import type Option from './option.js';
-import fetchStories from './playwright/fetch-stories.js';
 import type OptionsGroup from './options.group.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const stories = await fetchStories('Menu');
 

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -2,16 +2,16 @@ import { html, LitElement } from 'lit';
 import { autoUpdate, computePosition, flip, offset } from '@floating-ui/dom';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
-import packageJson from '../package.json' with { type: 'json' };
-import { LocalizeController } from './library/localize.js';
 import Options from './options.js';
 import OptionsGroup from './options.group.js';
 import Option from './option.js';
 import Input from './input.js';
-import assertSlot from './library/assert-slot.js';
 import styles from './menu.styles.js';
-import final from './library/final.js';
-import uniqueId from './library/unique-id.js';
+import assertSlot from '@/src/library/assert-slot.js';
+import { LocalizeController } from '@/src/library/localize.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import uniqueId from '@/src/library/unique-id.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/modal.icon-button.test.basics.ts
+++ b/src/modal.icon-button.test.basics.ts
@@ -2,7 +2,7 @@ import { expect, fixture, html } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import ModalIconButton from './modal.icon-button.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends ModalIconButton {}

--- a/src/modal.icon-button.ts
+++ b/src/modal.icon-button.ts
@@ -2,11 +2,11 @@ import './icon-button.js';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './modal.icon-button.styles.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/modal.stories.ts
+++ b/src/modal.stories.ts
@@ -8,7 +8,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import ModalComponent from './modal.js';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 const meta: Meta = {
   title: 'Modal',

--- a/src/modal.styles.ts
+++ b/src/modal.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/modal.test.accessibility.ts
+++ b/src/modal.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type Modal from './modal.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('open', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=modal--modal');

--- a/src/modal.test.basics.ts
+++ b/src/modal.test.basics.ts
@@ -4,8 +4,8 @@ import { assert, expect, fixture, html } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import Modal from './modal.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
-import expectWindowError from './library/expect-window-error.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends Modal {}

--- a/src/modal.test.interactions.ts
+++ b/src/modal.test.interactions.ts
@@ -1,7 +1,7 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
-import { click } from './library/mouse.js';
 import Modal from './modal.js';
+import { click } from '@/src/library/mouse.js';
 
 it('can be opened programmatically', async () => {
   const host = await fixture<Modal>(

--- a/src/modal.test.visuals.ts
+++ b/src/modal.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Modal from './modal.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Modal');
 

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -4,20 +4,20 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
-import packageJson from '../package.json' with { type: 'json' };
-import { LocalizeController } from './library/localize.js';
 import ModalIconButton from './modal.icon-button.js';
 import Button from './button.js';
 import Tooltip from './tooltip.js';
 import styles from './modal.styles.js';
-import xIcon from './icons/x.js';
-import assertSlot from './library/assert-slot.js';
-import severityInformationalIcon from './icons/severity-informational.js';
-import severityMediumIcon from './icons/severity-medium.js';
-import severityCriticalIcon from './icons/severity-critical.js';
-import final from './library/final.js';
-import required from './library/required.js';
-import onResize from './library/on-resize.js';
+import { LocalizeController } from '@/src/library/localize.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import xIcon from '@/src/icons/x.js';
+import assertSlot from '@/src/library/assert-slot.js';
+import severityInformationalIcon from '@/src/icons/severity-informational.js';
+import severityMediumIcon from '@/src/icons/severity-medium.js';
+import severityCriticalIcon from '@/src/icons/severity-critical.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
+import onResize from '@/src/library/on-resize.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/option.test.events.ts
+++ b/src/option.test.events.ts
@@ -3,9 +3,9 @@ import sinon from 'sinon';
 import Option from './option.js';
 import './options.js';
 import './menu.js';
-import { click, hover } from './library/mouse.js';
-import pencilIcon from './icons/pencil.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click, hover } from '@/src/library/mouse.js';
+import pencilIcon from '@/src/icons/pencil.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('dispatches a "click" event when clicked via mouse', async () => {
   const host = await fixture<Option>(

--- a/src/option.ts
+++ b/src/option.ts
@@ -5,16 +5,16 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import { when } from 'lit/directives/when.js';
 import { html, unsafeStatic } from 'lit/static-html.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './option.styles.js';
-import assertSlot from './library/assert-slot.js';
-import checkedIcon from './icons/checked.js';
-import final from './library/final.js';
-import uniqueId from './library/unique-id.js';
 import Menu from './menu.js';
-import './options.js';
 import Tooltip from './tooltip.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import assertSlot from '@/src/library/assert-slot.js';
+import checkedIcon from '@/src/icons/checked.js';
+import final from '@/src/library/final.js';
+import uniqueId from '@/src/library/unique-id.js';
+import './options.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/options.group.styles.ts
+++ b/src/options.group.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import visuallyHidden from './styles/visually-hidden.js';
+import visuallyHidden from '@/src/styles/visually-hidden.js';
 
 export default [
   css`

--- a/src/options.group.test.basics.ts
+++ b/src/options.group.test.basics.ts
@@ -2,7 +2,7 @@ import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import { expect, fixture, html } from '@open-wc/testing';
 import OptionsGroup from './options.group.js';
-import expectWindowError from './library/expect-window-error.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
 
 customElement('glide-core-subclassed');
 class Subclassed extends OptionsGroup {}

--- a/src/options.group.ts
+++ b/src/options.group.ts
@@ -1,12 +1,12 @@
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './options.group.styles.js';
-import final from './library/final.js';
-import assertSlot from './library/assert-slot.js';
 import Option from './option.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import assertSlot from '@/src/library/assert-slot.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/options.styles.ts
+++ b/src/options.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import skeleton from './styles/skeleton.js';
+import skeleton from '@/src/styles/skeleton.js';
 
 export default [
   css`

--- a/src/options.test.basics.ts
+++ b/src/options.test.basics.ts
@@ -2,7 +2,7 @@ import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import { expect, fixture, html } from '@open-wc/testing';
 import Options from './options.js';
-import expectWindowError from './library/expect-window-error.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
 
 customElement('glide-core-subclassed');
 class Subclassed extends Options {}

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,13 +3,13 @@ import { customElement, property } from 'lit/decorators.js';
 import { map } from 'lit/directives/map.js';
 import { when } from 'lit/directives/when.js';
 import { range } from 'lit/directives/range.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './options.styles.js';
-import final from './library/final.js';
-import uniqueId from './library/unique-id.js';
-import assertSlot from './library/assert-slot.js';
 import Option from './option.js';
 import OptionsGroup from './options.group.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import uniqueId from '@/src/library/unique-id.js';
+import assertSlot from '@/src/library/assert-slot.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/playwright/fixtures/mount.ts
+++ b/src/playwright/fixtures/mount.ts
@@ -2,8 +2,8 @@ import { promises as fs } from 'node:fs';
 import { test } from '@playwright/test';
 import { type TemplateResult } from 'lit';
 import serialize from 'serialize-javascript';
-import customElements from '../../../custom-elements.json' with { type: 'json' };
-import { v8CoverageAttachmentName } from './../constants.js';
+import { v8CoverageAttachmentName } from '@/src/playwright/constants.js';
+import customElements from '@/custom-elements.json' with { type: 'json' };
 
 type Context<Type> = Type extends void ? void : Type;
 

--- a/src/playwright/merge-coverage-reports/configuration.ts
+++ b/src/playwright/merge-coverage-reports/configuration.ts
@@ -1,7 +1,7 @@
 import { type JsonOptions } from 'istanbul-reports';
 import type { FullConfig } from '@playwright/test';
-import playwrightConfiguration from '../playwright.config.js';
-import { type CoverageReporterOptions } from '../coverage-reporter.js';
+import playwrightConfiguration from '@/src/playwright/playwright.config.js';
+import { type CoverageReporterOptions } from '@/src/playwright/coverage-reporter.js';
 
 const { reporter, outputDir } = playwrightConfiguration as FullConfig & {
   // `outputDir` is a valid configuration key. But it's not on the type because, in

--- a/src/popover.stories.ts
+++ b/src/popover.stories.ts
@@ -7,7 +7,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import PopoverComponent from './popover.js';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 const meta: Meta = {
   title: 'Popover',

--- a/src/popover.styles.ts
+++ b/src/popover.styles.ts
@@ -1,6 +1,6 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
-import opacityAndScaleAnimation from './styles/opacity-and-scale-animation.js';
+import focusOutline from '@/src/styles/focus-outline.js';
+import opacityAndScaleAnimation from '@/src/styles/opacity-and-scale-animation.js';
 
 export default [
   css`

--- a/src/popover.test.accessibility.ts
+++ b/src/popover.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type Popover from './popover.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('disabled=${true}', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=popover--popover');

--- a/src/popover.test.basics.ts
+++ b/src/popover.test.basics.ts
@@ -2,8 +2,8 @@ import { expect, fixture, html } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import Popover from './popover.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends Popover {}

--- a/src/popover.test.interactions.ts
+++ b/src/popover.test.interactions.ts
@@ -1,9 +1,9 @@
 import { assert, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import { styleMap } from 'lit/directives/style-map.js';
-import { click } from './library/mouse.js';
 import Popover from './popover.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { click } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('opens when opened programmatically', async () => {
   const host = await fixture<Popover>(

--- a/src/popover.test.visuals.ts
+++ b/src/popover.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Popover from './popover.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Popover');
 

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -13,10 +13,10 @@ import { choose } from 'lit/directives/choose.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './popover.styles.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/radio-group.radio.styles.ts
+++ b/src/radio-group.radio.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/radio-group.radio.ts
+++ b/src/radio-group.radio.ts
@@ -1,10 +1,10 @@
 import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property, state } from 'lit/decorators.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './radio-group.radio.styles.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/radio-group.test.accessibility.ts
+++ b/src/radio-group.test.accessibility.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type RadioGroup from './radio-group.js';
 import type RadioGroupRadio from './radio-group.radio.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('disabled', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=radio-group--radio-group');

--- a/src/radio-group.test.basics.ts
+++ b/src/radio-group.test.basics.ts
@@ -3,8 +3,8 @@ import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import RadioGroup from './radio-group.js';
 import type RadioGroupRadio from './radio-group.radio.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
-import expectWindowError from './library/expect-window-error.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends RadioGroup {}

--- a/src/radio-group.test.events.ts
+++ b/src/radio-group.test.events.ts
@@ -10,7 +10,7 @@ import {
 import { sendKeys } from '@web/test-runner-commands';
 import './radio-group.js';
 import './radio-group.radio.js';
-import { click } from './library/mouse.js';
+import { click } from '@/src/library/mouse.js';
 
 it('dispatches a "change" event when arrowing', async () => {
   const host = await fixture(

--- a/src/radio-group.test.focus.ts
+++ b/src/radio-group.test.focus.ts
@@ -2,7 +2,7 @@ import { expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import RadioGroup from './radio-group.js';
 import './radio-group.radio.js';
-import { click } from './library/mouse.js';
+import { click } from '@/src/library/mouse.js';
 
 it('focuses an enabled radio on click', async () => {
   const host = await fixture(

--- a/src/radio-group.test.forms.ts
+++ b/src/radio-group.test.forms.ts
@@ -1,9 +1,9 @@
 import { assert, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import { click } from './library/mouse.js';
 import RadioGroup from './radio-group.js';
 import RadioGroupRadio from './radio-group.radio.js';
+import { click } from '@/src/library/mouse.js';
 
 it('can be reset when `value` is programmatically changed', async () => {
   const form = document.createElement('form');

--- a/src/radio-group.test.interactions.ts
+++ b/src/radio-group.test.interactions.ts
@@ -1,8 +1,8 @@
 import './radio-group.radio.js';
 import { assert, expect, fixture, html } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
-import { click } from './library/mouse.js';
 import RadioGroup from './radio-group.js';
+import { click } from '@/src/library/mouse.js';
 
 it('checks a radio when `value` is set programmatically', async () => {
   const host = await fixture<RadioGroup>(html`

--- a/src/radio-group.test.visuals.ts
+++ b/src/radio-group.test.visuals.ts
@@ -1,7 +1,7 @@
-import { expect, test } from './playwright/test.js';
 import type RadioGroup from './radio-group.js';
 import type RadioGroupRadio from './radio-group.radio.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Radio Group');
 

--- a/src/radio-group.ts
+++ b/src/radio-group.ts
@@ -7,13 +7,13 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
-import packageJson from '../package.json' with { type: 'json' };
 import RadioGroupRadio from './radio-group.radio.js';
 import styles from './radio-group.styles.js';
-import assertSlot from './library/assert-slot.js';
-import type FormControl from './library/form-control.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import assertSlot from '@/src/library/assert-slot.js';
+import type FormControl from '@/src/library/form-control.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/select.test.accessibility.ts
+++ b/src/select.test.accessibility.ts
@@ -1,8 +1,8 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
 import type Select from './select.js';
 import type Menu from './menu.js';
 import Option from './option.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('is accessible', { tag: '@accessibility' }, async ({ mount, page }) => {
   await mount(

--- a/src/select.test.forms.ts
+++ b/src/select.test.forms.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('has a `form` property', { tag: '@forms' }, async ({ mount, page }) => {
   await mount(

--- a/src/select.test.keyboard.ts
+++ b/src/select.test.keyboard.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   'opens when clicked via Space',

--- a/src/select.test.miscellaneous.ts
+++ b/src/select.test.miscellaneous.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(

--- a/src/select.test.mouse.ts
+++ b/src/select.test.mouse.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   'opens when its target is clicked',

--- a/src/select.test.visuals.ts
+++ b/src/select.test.visuals.ts
@@ -1,9 +1,9 @@
-import { expect, test } from './playwright/test.js';
 import type Select from './select.js';
-import fetchStories from './playwright/fetch-stories.js';
 import type Menu from './menu.js';
 import type Option from './option.js';
 import type OptionsGroup from './options.group.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const stories = await fetchStories('Select');
 

--- a/src/select.ts
+++ b/src/select.ts
@@ -1,15 +1,15 @@
 import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
-import packageJson from '../package.json' with { type: 'json' };
-import assertSlot from './library/assert-slot.js';
 import styles from './menu.styles.js';
-import final from './library/final.js';
 import Menu from './menu.js';
 import Option from './option.js';
 import Options from './options.js';
 import OptionsGroup from './options.group.js';
-import type FormControl from './library/form-control.js';
+import final from '@/src/library/final.js';
+import assertSlot from '@/src/library/assert-slot.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import type FormControl from '@/src/library/form-control.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/slider.styles.ts
+++ b/src/slider.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/slider.test.accessibility.ts
+++ b/src/slider.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type Slider from './slider.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test.describe('disabled', () => {
   test('multiple=${true}', { tag: '@accessibility' }, async ({ page }) => {

--- a/src/slider.test.events.multiple.ts
+++ b/src/slider.test.events.multiple.ts
@@ -2,7 +2,7 @@ import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
 import sinon from 'sinon';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import Slider from './slider.js';
-import { hover } from './library/mouse.js';
+import { hover } from '@/src/library/mouse.js';
 
 // You'd think you'd be able to call `resetMouse()` anywhere. But, for whatever
 // reason, calling it outside `afterEach()` results in sporadic bouts of the

--- a/src/slider.test.events.single.ts
+++ b/src/slider.test.events.single.ts
@@ -2,7 +2,7 @@ import { assert, aTimeout, expect, fixture, html } from '@open-wc/testing';
 import sinon from 'sinon';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import Slider from './slider.js';
-import { hover } from './library/mouse.js';
+import { hover } from '@/src/library/mouse.js';
 
 // You'd think you'd be able to call `resetMouse()` anywhere. But, for whatever
 // reason, calling it outside `afterEach()` results in sporadic bouts of the

--- a/src/slider.test.interactions.multiple.ts
+++ b/src/slider.test.interactions.multiple.ts
@@ -2,7 +2,7 @@ import { assert, expect, fixture, html } from '@open-wc/testing';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import Slider from './slider.js';
-import { hover } from './library/mouse.js';
+import { hover } from '@/src/library/mouse.js';
 
 // You'd think you'd be able to call `resetMouse()` anywhere. But, for whatever
 // reason, calling it outside `afterEach()` results in sporadic bouts of the

--- a/src/slider.test.interactions.single.ts
+++ b/src/slider.test.interactions.single.ts
@@ -1,7 +1,7 @@
 import { assert, expect, fixture, html } from '@open-wc/testing';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import Slider from './slider.js';
-import { hover } from './library/mouse.js';
+import { hover } from '@/src/library/mouse.js';
 
 // You'd think you'd be able to call `resetMouse()` anywhere. But, for whatever
 // reason, calling it outside `afterEach()` results in sporadic bouts of the

--- a/src/slider.test.visuals.ts
+++ b/src/slider.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Slider from './slider.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Slider');
 

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -6,12 +6,12 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
-import packageJson from '../package.json' with { type: 'json' };
-import { LocalizeController } from './library/localize.js';
 import styles from './slider.styles.js';
-import type FormControl from './library/form-control.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import { LocalizeController } from '@/src/library/localize.js';
+import type FormControl from '@/src/library/form-control.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/spinner.test.accessibility.ts
+++ b/src/spinner.test.accessibility.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   'is accessible',

--- a/src/spinner.test.miscellaneous.ts
+++ b/src/spinner.test.miscellaneous.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { expect, test } from './playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   'cannot be extended',

--- a/src/spinner.test.visuals.ts
+++ b/src/spinner.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Spinner from './spinner.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Spinner');
 

--- a/src/spinner.ts
+++ b/src/spinner.ts
@@ -2,10 +2,10 @@ import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './spinner.styles.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/split-button.primary-button.styles.ts
+++ b/src/split-button.primary-button.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 // These styles are shared between Split Button Primary Button and Split Button
 // Primary Link.

--- a/src/split-button.primary-button.ts
+++ b/src/split-button.primary-button.ts
@@ -2,10 +2,10 @@ import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './split-button.primary-button.styles.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/split-button.primary-link.ts
+++ b/src/split-button.primary-link.ts
@@ -2,10 +2,10 @@ import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './split-button.primary-button.styles.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/split-button.secondary-button.styles.ts
+++ b/src/split-button.secondary-button.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/split-button.secondary-button.test.basics.ts
+++ b/src/split-button.secondary-button.test.basics.ts
@@ -3,8 +3,8 @@ import './option.js';
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import SplitButtonSecondaryButton from './split-button.secondary-button.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
-import expectWindowError from './library/expect-window-error.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends SplitButtonSecondaryButton {}

--- a/src/split-button.secondary-button.test.interactions.ts
+++ b/src/split-button.secondary-button.test.interactions.ts
@@ -1,7 +1,7 @@
 import './option.js';
 import { expect, fixture, html } from '@open-wc/testing';
-import { click } from './library/mouse.js';
 import SplitButtonSecondaryButton from './split-button.secondary-button.js';
+import { click } from '@/src/library/mouse.js';
 
 it('sets `menuOpen` when its menu is opened', async () => {
   const host = await fixture<SplitButtonSecondaryButton>(html`

--- a/src/split-button.secondary-button.ts
+++ b/src/split-button.secondary-button.ts
@@ -4,14 +4,14 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import packageJson from '../package.json' with { type: 'json' };
 import Menu from './menu.js';
-import chevronIcon from './icons/chevron.js';
 import styles from './split-button.secondary-button.styles.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
-import required from './library/required.js';
 import Option from './option.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import chevronIcon from '@/src/icons/chevron.js';
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/split-button.styles.ts
+++ b/src/split-button.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/split-button.test.accessibility.ts
+++ b/src/split-button.test.accessibility.ts
@@ -1,7 +1,7 @@
-import { expect, test } from './playwright/test.js';
 import type SplitButtonPrimaryButton from './split-button.primary-button.js';
 import type SplitButtonPrimaryLink from './split-button.primary-link.js';
 import type SplitButtonSecondaryButton from './split-button.secondary-button.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   '<glide-core-split-button-primary-button>[disabled=${true}]',

--- a/src/split-button.test.basics.ts
+++ b/src/split-button.test.basics.ts
@@ -6,8 +6,8 @@ import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import SplitButton from './split-button.js';
 import './split-button.secondary-button.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
-import expectWindowError from './library/expect-window-error.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends SplitButton {}

--- a/src/split-button.test.visuals.ts
+++ b/src/split-button.test.visuals.ts
@@ -1,9 +1,9 @@
-import { expect, test } from './playwright/test.js';
 import type SplitButton from './split-button.js';
 import type SplitButtonPrimaryButton from './split-button.primary-button.js';
 import type SplitButtonPrimaryLink from './split-button.primary-link.js';
 import type SplitButtonSecondaryButton from './split-button.secondary-button.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Split Button');
 

--- a/src/split-button.ts
+++ b/src/split-button.ts
@@ -1,13 +1,13 @@
 import { html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
-import packageJson from '../package.json' with { type: 'json' };
 import SplitButtonPrimaryButton from './split-button.primary-button.js';
 import SplitButtonPrimaryLink from './split-button.primary-link.js';
 import SplitButtonSecondaryButton from './split-button.secondary-button.js';
 import styles from './split-button.styles.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/stylelint/rules/no-unprefixed-private-custom-property.test.ts
+++ b/src/stylelint/rules/no-unprefixed-private-custom-property.test.ts
@@ -1,5 +1,5 @@
 import stylelint from 'stylelint';
-import { expect, test } from '../../playwright/test.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 const config = {
   plugins: ['../plugin.js'],

--- a/src/tab.group.test.accessibility.ts
+++ b/src/tab.group.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type Tab from './tab.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test(
   '<glide-core-tab>.disabled',

--- a/src/tab.group.test.basics.ts
+++ b/src/tab.group.test.basics.ts
@@ -5,8 +5,8 @@ import sinon from 'sinon';
 import TabGroup from './tab.group.js';
 import './tab.js';
 import TabPanel from './tab.panel.js';
-import expectWindowError from './library/expect-window-error.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends TabGroup {}

--- a/src/tab.group.test.events.ts
+++ b/src/tab.group.test.events.ts
@@ -3,7 +3,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import './tab.group.js';
 import './tab.js';
 import './tab.panel.js';
-import { click } from './library/mouse.js';
+import { click } from '@/src/library/mouse.js';
 
 it('dispatches a "selected" event on click', async () => {
   const host = await fixture(html`

--- a/src/tab.group.test.interactions.ts
+++ b/src/tab.group.test.interactions.ts
@@ -8,10 +8,10 @@ import {
   waitUntil,
 } from '@open-wc/testing';
 import './tab.js';
-import { click } from './library/mouse.js';
 import TabGroup from './tab.group.js';
+import { click } from '@/src/library/mouse.js';
 import './tab.panel.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('sets the selected tab using the `selected` attribute', async () => {
   const host = await fixture<TabGroup>(html`

--- a/src/tab.group.test.visuals.ts
+++ b/src/tab.group.test.visuals.ts
@@ -1,7 +1,7 @@
-import { expect, test } from './playwright/test.js';
 import type TabGroup from './tab.group.js';
 import type Tab from './tab.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Tab Group');
 

--- a/src/tab.group.ts
+++ b/src/tab.group.ts
@@ -4,15 +4,15 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
-import packageJson from '../package.json' with { type: 'json' };
-import { LocalizeController } from './library/localize.js';
 import Tab from './tab.js';
 import TabPanel from './tab.panel.js';
-import chevronIcon from './icons/chevron.js';
-import onResize from './library/on-resize.js';
 import styles from './tab.group.styles.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import { LocalizeController } from '@/src/library/localize.js';
+import chevronIcon from '@/src/icons/chevron.js';
+import onResize from '@/src/library/on-resize.js';
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/tab.panel.styles.ts
+++ b/src/tab.panel.styles.ts
@@ -1,6 +1,6 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
-import visuallyHidden from './styles/visually-hidden.js';
+import focusOutline from '@/src/styles/focus-outline.js';
+import visuallyHidden from '@/src/styles/visually-hidden.js';
 
 export default [
   css`

--- a/src/tab.panel.ts
+++ b/src/tab.panel.ts
@@ -1,11 +1,11 @@
 import { html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property } from 'lit/decorators.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './tab.panel.styles.js';
-import final from './library/final.js';
-import required from './library/required.js';
-import uniqueId from './library/unique-id.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
+import uniqueId from '@/src/library/unique-id.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/tab.styles.ts
+++ b/src/tab.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -1,11 +1,11 @@
 import { html, LitElement, type PropertyValues } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property } from 'lit/decorators.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './tab.styles.js';
-import final from './library/final.js';
-import required from './library/required.js';
-import uniqueId from './library/unique-id.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
+import uniqueId from '@/src/library/unique-id.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/tag.styles.ts
+++ b/src/tag.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/tag.test.accessibility.ts
+++ b/src/tag.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type Tag from './tag.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('disabled=${true}', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=tag--tag');

--- a/src/tag.test.events.ts
+++ b/src/tag.test.events.ts
@@ -1,8 +1,8 @@
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import { click } from './library/mouse.js';
 import Tag from './tag.js';
+import { click } from '@/src/library/mouse.js';
 
 it('dispatches one "remove" event on click', async () => {
   const host = await fixture(

--- a/src/tag.test.visuals.ts
+++ b/src/tag.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Tag from './tag.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Tag');
 

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -3,13 +3,13 @@ import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
-import packageJson from '../package.json' with { type: 'json' };
-import { LocalizeController } from './library/localize.js';
-import pencilIcon from './icons/pencil.js';
 import styles from './tag.styles.js';
-import xIcon from './icons/x.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import { LocalizeController } from '@/src/library/localize.js';
+import pencilIcon from '@/src/icons/pencil.js';
+import xIcon from '@/src/icons/x.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/textarea.styles.ts
+++ b/src/textarea.styles.ts
@@ -1,5 +1,5 @@
 import { css, unsafeCSS } from 'lit';
-import visuallyHidden from './styles/visually-hidden.js';
+import visuallyHidden from '@/src/styles/visually-hidden.js';
 
 /*
   `field-sizing` is only supported in Chrome and Edge

--- a/src/textarea.test.accessibility.ts
+++ b/src/textarea.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type Textarea from './textarea.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('disabled', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=textarea--textarea');

--- a/src/textarea.test.visuals.ts
+++ b/src/textarea.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Textarea from './textarea.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Textarea');
 

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -6,12 +6,12 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
-import packageJson from '../package.json' with { type: 'json' };
-import { LocalizeController } from './library/localize.js';
 import styles from './textarea.styles.js';
-import type FormControl from './library/form-control.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import { LocalizeController } from '@/src/library/localize.js';
+import type FormControl from '@/src/library/form-control.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/toast.stories.ts
+++ b/src/toast.stories.ts
@@ -9,7 +9,7 @@ import { addons } from '@storybook/preview-api';
 import { withActions } from '@storybook/addon-actions/decorator';
 import { UPDATE_STORY_ARGS } from '@storybook/core-events';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import uniqueId from './library/unique-id.js';
+import uniqueId from '@/src/library/unique-id.js';
 
 interface Toast {
   description?: string;

--- a/src/toast.test.accessibility.ts
+++ b/src/toast.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type Button from './button.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('variant="informational"', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=toast--toast');

--- a/src/toast.test.basics.ts
+++ b/src/toast.test.basics.ts
@@ -3,8 +3,8 @@ import { aTimeout, expect, fixture, html } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import { emulateMedia } from '@web/test-runner-commands';
-import expectWindowError from './library/expect-window-error.js';
 import Toast from './toast.js';
+import expectWindowError from '@/src/library/expect-window-error.js';
 
 // "transitionend" is dispatched manually throughout these tests because that
 // event isn't consistently emitted in CI. It's not clear why. The below issue

--- a/src/toast.test.events.ts
+++ b/src/toast.test.events.ts
@@ -2,7 +2,7 @@ import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { emulateMedia } from '@web/test-runner-commands';
 import './link.js';
 import './toast.js';
-import { click } from './library/mouse.js';
+import { click } from '@/src/library/mouse.js';
 
 afterEach(() => {
   // Toasts isn't removed for us by `fixture()` because Toasts is rendered as

--- a/src/toast.test.visuals.ts
+++ b/src/toast.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Button from './button.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Toast');
 

--- a/src/toast.toasts.styles.ts
+++ b/src/toast.toasts.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import visuallyHidden from './styles/visually-hidden.js';
+import visuallyHidden from '@/src/styles/visually-hidden.js';
 
 export default [
   css`

--- a/src/toast.toasts.test.interactions.ts
+++ b/src/toast.toasts.test.interactions.ts
@@ -1,7 +1,7 @@
 import { aTimeout, expect, fixture, html } from '@open-wc/testing';
 import { emulateMedia } from '@web/test-runner-commands';
 import Toast from './toast.js';
-import { click, hover } from './library/mouse.js';
+import { click, hover } from '@/src/library/mouse.js';
 
 // "transitionend" is dispatched manually throughout these tests because that
 // event isn't consistently emitted in CI. It's not clear why. The below issue

--- a/src/toast.toasts.ts
+++ b/src/toast.toasts.ts
@@ -8,12 +8,12 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { choose } from 'lit/directives/choose.js';
 import { when } from 'lit/directives/when.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import xIcon from './icons/x.js';
-import { LocalizeController } from './library/localize.js';
 import styles from './toast.toasts.styles.js';
-import final from './library/final.js';
 import Toast from './toast.js';
 import Link from './link.js';
+import xIcon from '@/src/icons/x.js';
+import { LocalizeController } from '@/src/library/localize.js';
+import final from '@/src/library/final.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/toast.ts
+++ b/src/toast.ts
@@ -1,13 +1,13 @@
 import './icon-button.js';
 import { LitElement, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import packageJson from '../package.json' with { type: 'json' };
 import Toasts from './toast.toasts.js';
-import final from './library/final.js';
-import required from './library/required.js';
 import Link from './link.js';
-import assertSlot from './library/assert-slot.js';
-import uniqueId from './library/unique-id.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
+import assertSlot from '@/src/library/assert-slot.js';
+import uniqueId from '@/src/library/unique-id.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/toggle.styles.ts
+++ b/src/toggle.styles.ts
@@ -1,5 +1,5 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 export default [
   css`

--- a/src/toggle.test.accessibility.ts
+++ b/src/toggle.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type Toggle from './toggle.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('checked=${true}', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=toggle--toggle');

--- a/src/toggle.test.events.ts
+++ b/src/toggle.test.events.ts
@@ -1,6 +1,6 @@
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
-import { click } from './library/mouse.js';
 import Toggle from './toggle.js';
+import { click } from '@/src/library/mouse.js';
 
 it('dispatches a "click" event on click', async () => {
   const host = await fixture<Toggle>(

--- a/src/toggle.test.interactions.ts
+++ b/src/toggle.test.interactions.ts
@@ -1,6 +1,6 @@
 import { expect, fixture, html } from '@open-wc/testing';
-import { click } from './library/mouse.js';
 import Toggle from './toggle.js';
+import { click } from '@/src/library/mouse.js';
 
 it('is checked after being clicked', async () => {
   const host = await fixture<Toggle>(

--- a/src/toggle.test.visuals.ts
+++ b/src/toggle.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Toggle from './toggle.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Toggle');
 

--- a/src/toggle.ts
+++ b/src/toggle.ts
@@ -4,10 +4,10 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './toggle.styles.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import packageJson from '@/package.json' with { type: 'json' };
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/tooltip.container.ts
+++ b/src/tooltip.container.ts
@@ -4,8 +4,8 @@ import { classMap } from 'lit/directives/class-map.js';
 import { map } from 'lit/directives/map.js';
 import { when } from 'lit/directives/when.js';
 import styles from './tooltip.container.styles.js';
-import final from './library/final.js';
-import uniqueId from './library/unique-id.js';
+import final from '@/src/library/final.js';
+import uniqueId from '@/src/library/unique-id.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/tooltip.stories.ts
+++ b/src/tooltip.stories.ts
@@ -7,7 +7,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import TooltipComponent from './tooltip.js';
-import focusOutline from './styles/focus-outline.js';
+import focusOutline from '@/src/styles/focus-outline.js';
 
 const meta: Meta = {
   title: 'Tooltip',

--- a/src/tooltip.styles.ts
+++ b/src/tooltip.styles.ts
@@ -1,6 +1,6 @@
 import { css } from 'lit';
-import focusOutline from './styles/focus-outline.js';
-import opacityAndScaleAnimation from './styles/opacity-and-scale-animation.js';
+import focusOutline from '@/src/styles/focus-outline.js';
+import opacityAndScaleAnimation from '@/src/styles/opacity-and-scale-animation.js';
 
 export default [
   css`

--- a/src/tooltip.test.accessibility.ts
+++ b/src/tooltip.test.accessibility.ts
@@ -1,5 +1,5 @@
-import { expect, test } from './playwright/test.js';
 import type Tooltip from './tooltip.js';
+import { expect, test } from '@/src/playwright/test.js';
 
 test('description', { tag: '@accessibility' }, async ({ page }) => {
   await page.goto('?id=tooltip--tooltip');

--- a/src/tooltip.test.basics.ts
+++ b/src/tooltip.test.basics.ts
@@ -3,8 +3,8 @@ import sinon from 'sinon';
 import { customElement } from 'lit/decorators.js';
 import Tooltip from './tooltip.js';
 import TooltipContainer from './tooltip.container.js';
-import expectUnhandledRejection from './library/expect-unhandled-rejection.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import expectUnhandledRejection from '@/src/library/expect-unhandled-rejection.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 @customElement('glide-core-subclassed')
 class Subclassed extends Tooltip {}

--- a/src/tooltip.test.interactions.ts
+++ b/src/tooltip.test.interactions.ts
@@ -8,10 +8,10 @@ import {
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import { styleMap } from 'lit/directives/style-map.js';
-import { hover } from './library/mouse.js';
 import Tooltip from './tooltip.js';
 import TooltipContainer from './tooltip.container.js';
-import requestIdleCallback from './library/request-idle-callback.js';
+import { hover } from '@/src/library/mouse.js';
+import requestIdleCallback from '@/src/library/request-idle-callback.js';
 
 it('passes down certain properties to its container', async () => {
   const host = await fixture<Tooltip>(

--- a/src/tooltip.test.visuals.ts
+++ b/src/tooltip.test.visuals.ts
@@ -1,6 +1,6 @@
-import { expect, test } from './playwright/test.js';
 import type Tooltip from './tooltip.js';
-import fetchStories from './playwright/fetch-stories.js';
+import { expect, test } from '@/src/playwright/test.js';
+import fetchStories from '@/src/playwright/fetch-stories.js';
 
 const stories = await fetchStories('Tooltip');
 

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -13,12 +13,12 @@ import { choose } from 'lit/directives/choose.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from 'lit/decorators.js';
-import packageJson from '../package.json' with { type: 'json' };
 import styles from './tooltip.styles.js';
+import packageJson from '@/package.json' with { type: 'json' };
 import './tooltip.container.js';
-import assertSlot from './library/assert-slot.js';
-import final from './library/final.js';
-import required from './library/required.js';
+import assertSlot from '@/src/library/assert-slot.js';
+import final from '@/src/library/final.js';
+import required from '@/src/library/required.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1,4 +1,4 @@
-import type { Translation } from '../library/localize.js';
+import type { Translation } from '@/src/library/localize.js';
 
 const translation: Translation = {
   $code: 'en',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1,4 +1,4 @@
-import type { Translation } from '../library/localize.js';
+import type { Translation } from '@/src/library/localize.js';
 
 export const PENDING_STRINGS = [
   'severityInformational',

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -1,4 +1,4 @@
-import type { Translation } from '../library/localize.js';
+import type { Translation } from '@/src/library/localize.js';
 
 export const PENDING_STRINGS = [
   'severityInformational',

--- a/src/ts-morph/get-attribute-tags.ts
+++ b/src/ts-morph/get-attribute-tags.ts
@@ -1,5 +1,5 @@
 import { type JSDocTagStructure, type OptionalKind } from 'ts-morph';
-import manifest from '../../custom-elements.json' with { type: 'json' };
+import manifest from '@/custom-elements.json' with { type: 'json' };
 
 export default (
   declaration: (typeof manifest)['modules'][number]['declarations'][number],

--- a/src/ts-morph/get-css-property-tags.ts
+++ b/src/ts-morph/get-css-property-tags.ts
@@ -1,5 +1,5 @@
 import { type JSDocTagStructure, type OptionalKind } from 'ts-morph';
-import manifest from '../../custom-elements.json' with { type: 'json' };
+import manifest from '@/custom-elements.json' with { type: 'json' };
 
 export default (
   declaration: (typeof manifest)['modules'][number]['declarations'][number],

--- a/src/ts-morph/get-event-tags.ts
+++ b/src/ts-morph/get-event-tags.ts
@@ -1,5 +1,5 @@
 import { type JSDocTagStructure, type OptionalKind } from 'ts-morph';
-import manifest from '../../custom-elements.json' with { type: 'json' };
+import manifest from '@/custom-elements.json' with { type: 'json' };
 
 export default (
   declaration: (typeof manifest)['modules'][number]['declarations'][number],

--- a/src/ts-morph/get-method-tags.ts
+++ b/src/ts-morph/get-method-tags.ts
@@ -1,5 +1,5 @@
 import { type JSDocTagStructure, type OptionalKind } from 'ts-morph';
-import manifest from '../../custom-elements.json' with { type: 'json' };
+import manifest from '@/custom-elements.json' with { type: 'json' };
 
 export default (
   declaration: (typeof manifest)['modules'][number]['declarations'][number],

--- a/src/ts-morph/get-property-tags.ts
+++ b/src/ts-morph/get-property-tags.ts
@@ -1,5 +1,5 @@
 import { type JSDocTagStructure, type OptionalKind } from 'ts-morph';
-import manifest from '../../custom-elements.json' with { type: 'json' };
+import manifest from '@/custom-elements.json' with { type: 'json' };
 
 export default (
   declaration: (typeof manifest)['modules'][number]['declarations'][number],

--- a/src/ts-morph/get-slot-tags.ts
+++ b/src/ts-morph/get-slot-tags.ts
@@ -1,5 +1,5 @@
 import { type JSDocTagStructure, type OptionalKind } from 'ts-morph';
-import manifest from '../../custom-elements.json' with { type: 'json' };
+import manifest from '@/custom-elements.json' with { type: 'json' };
 
 export default (
   declaration: (typeof manifest)['modules'][number]['declarations'][number],

--- a/src/ts-morph/run.ts
+++ b/src/ts-morph/run.ts
@@ -1,11 +1,11 @@
 import { Project } from 'ts-morph';
-import manifest from '../../custom-elements.json' with { type: 'json' };
 import getAttributeTags from './get-attribute-tags.js';
 import getCssPropertyTags from './get-css-property-tags.js';
 import getPropertyTags from './get-property-tags.js';
 import getSlotTags from './get-slot-tags.js';
 import getEventTags from './get-event-tags.js';
 import getMethodTags from './get-method-tags.js';
+import manifest from '@/custom-elements.json' with { type: 'json' };
 
 /**
  * Uses the information in the elements manifest to add a top-level JSDoc

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,11 @@
     "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "noUncheckedIndexedAccess": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@/src/*": ["./src/*"]
+    },
     "plugins": [
       {
         "name": "ts-lit-plugin",

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -5,6 +5,7 @@ import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { fromRollup } from '@web/dev-server-rollup';
 import { playwrightLauncher } from '@web/test-runner-playwright';
 import rollupPluginCommonjs from '@rollup/plugin-commonjs';
+import rollupPluginAlias from '@rollup/plugin-alias';
 
 export default {
   browsers: [playwrightLauncher()],
@@ -66,6 +67,16 @@ export default {
     exportConditions: ['production'],
   },
   plugins: [
+    // Handle path aliases for TypeScript paths
+    fromRollup(rollupPluginAlias)({
+      entries: [
+        {
+          find: '@/src',
+          replacement: fileURLToPath(new URL('src', import.meta.url)),
+        },
+        { find: '@', replacement: import.meta.dirname },
+      ],
+    }),
     // Some modules still use CommonJS-style exports. This plugin handles them.
     //
     // https://github.com/modernweb-dev/web/issues/1700#issuecomment-1059441615


### PR DESCRIPTION
## 🚀 Description

Use typescript paths for imports. The "rules" are:

- Sibling imports can continue to use `./<file>.js`
- Going to a directory like `./playwright`, `./library`, or to the root `package.json` should use `@/src` | `@/`

I can add a lint rule for this if folks think it'd be helpful in a follow up PR.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

N/A
