### PR TITLE
Fix Checkbox VoiceOver issue

### DIFF
--- a/.changeset/fresh-taxis-invent.md
+++ b/.changeset/fresh-taxis-invent.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Checkbox's `label` is now only announced once in VoiceOver when using the arrow keys.

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -68,7 +68,7 @@ declare global {
 export default class CheckboxGroup extends LitElement implements FormControl {
   static formAssociated = true;
 
-    /* c8 ignore start */
+  /* c8 ignore start */
   static override shadowRootOptions: ShadowRootInit = {
     ...LitElement.shadowRootOptions,
     mode: window.navigator.webdriver ? 'open' : 'closed',

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -358,7 +358,8 @@ export default class Checkbox extends LitElement implements FormControl {
                   disabled: this.disabled,
                 })}
               >
-                <div class="checked-icon">${checkedIcon}</div>
+                <div class="checked-icon" role="none">${checkedIcon}</div>
+
                 ${icons.indeterminate}
               </div>
             </div>
@@ -410,7 +411,7 @@ export default class Checkbox extends LitElement implements FormControl {
               Screenreaders will come across the tooltip naturally as focus moves toward
               the Checkbox.
             -->
-            <div class="input-and-checkbox" slot="control">
+            <div class="input-and-checkbox" slot="control" role="none">
               <input
                 aria-describedby="summary description"
                 aria-invalid=${this.#isShowValidationFeedback}


### PR DESCRIPTION
## 🚀 Description

> ### Patch
>  Checkbox's `label` is now only announced once in VoiceOver when using the arrow keys.

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

You know what to do!
<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
