### PR TITLE
Improve Toast accessibility

### DIFF
--- a/.changeset/dull-pugs-brush.md
+++ b/.changeset/dull-pugs-brush.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Toast's `label` and `variant` are no longer announced twice by screenreaders.

--- a/src/toast.test.accessibility.ts
+++ b/src/toast.test.accessibility.ts
@@ -12,8 +12,10 @@ test('variant="informational"', { tag: '@accessibility' }, async ({ page }) => {
 
   await expect(page.locator('glide-core-private-toasts')).toMatchAriaSnapshot(`
     - region "Notifications":
-      - 'alert "Informational: Label Description"':
+      - alert:
+        - text: "Informational: Label"
         - button "Dismiss"
+        - text: Description
   `);
 });
 
@@ -29,8 +31,10 @@ test('variant="success"', { tag: '@accessibility' }, async ({ page }) => {
 
   await expect(page.locator('glide-core-private-toasts')).toMatchAriaSnapshot(`
     - region "Notifications":
-      - 'alert "Success: Label Description"':
+      - alert:
+        - text: "Success: Label"
         - button "Dismiss"
+        - text: Description
   `);
 });
 
@@ -46,7 +50,9 @@ test('variant="error"', { tag: '@accessibility' }, async ({ page }) => {
 
   await expect(page.locator('glide-core-private-toasts')).toMatchAriaSnapshot(`
     - region "Notifications":
-      - 'alert "Error: Label Description"':
+      - alert:
+        - text: "Error: Label"
         - button "Dismiss"
+        - text: Description
   `);
 });

--- a/src/toast.toasts.ts
+++ b/src/toast.toasts.ts
@@ -90,7 +90,7 @@ export default class Toasts extends LitElement {
           (toast) => toast.privateId,
           (toast) => {
             return html`<div
-              aria-labelledby="prefix label description"
+              aria-describedby="description"
               class=${classMap({
                 toast: true,
                 error: toast.variant === 'error',
@@ -108,7 +108,7 @@ export default class Toasts extends LitElement {
               @mouseout=${this.#onToastMouseOut.bind(this, toast)}
               @transitionend=${this.#onToastTransitionEnd.bind(this, toast)}
             >
-              <span class="prefix" id="prefix">
+              <span class="prefix">
                 ${this.#localize.term(toast.variant)}
               </span>
 
@@ -121,9 +121,7 @@ export default class Toasts extends LitElement {
                 () => icons.warningInformational,
               )}
 
-              <div class="label" data-test="label" id="label">
-                ${toast.label}
-              </div>
+              <div class="label" data-test="label">${toast.label}</div>
 
               <glide-core-icon-button
                 class="dismiss-button"


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> Toast's `label` and `variant` are no longer announced twice by screenreaders.


## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

1. Navigate to Toast in Storybook.
2. Turn on VoiceOver.
3. Add a Toast.
4. Verify the Toast's `label` and `variant` are only announced once.

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
