### PR TITLE
Rename `toBeRegistered()`

### DIFF
--- a/src/accordion.test.miscellaneous.ts
+++ b/src/accordion.test.miscellaneous.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit';
 import { expect, test } from './playwright/test.js';
 
-test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
+test('defines itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(
     () =>
       html`<glide-core-accordion label="Label">Content</glide-core-accordion>`,
@@ -9,7 +9,7 @@ test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
 
   const host = page.locator('glide-core-accordion');
 
-  await expect(host).toBeRegistered('glide-core-accordion');
+  await expect(host).toBeDefined('glide-core-accordion');
 });
 
 test(

--- a/src/button.test.miscellaneous.ts
+++ b/src/button.test.miscellaneous.ts
@@ -1,14 +1,14 @@
 import { html } from 'lit';
 import { expect, test } from './playwright/test.js';
 
-test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
+test('defines itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(
     () => html`<glide-core-button label="Label"></glide-core-button>`,
   );
 
   const host = page.locator('glide-core-button');
 
-  await expect(host).toBeRegistered('glide-core-button');
+  await expect(host).toBeDefined('glide-core-button');
 });
 
 test(

--- a/src/checkbox.test.miscellaneous.ts
+++ b/src/checkbox.test.miscellaneous.ts
@@ -2,14 +2,14 @@ import { html } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 import { expect, test } from './playwright/test.js';
 
-test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
+test('defines itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(
     () => html`<glide-core-checkbox label="Label"></glide-core-checkbox>`,
   );
 
   const host = page.locator('glide-core-checkbox');
 
-  await expect(host).toBeRegistered('glide-core-checkbox');
+  await expect(host).toBeDefined('glide-core-checkbox');
 });
 
 test('can be disabled', { tag: '@miscellaneous' }, async ({ mount, page }) => {

--- a/src/icon-button.test.miscellaneous.ts
+++ b/src/icon-button.test.miscellaneous.ts
@@ -1,16 +1,17 @@
 import { html } from 'lit';
 import { expect, test } from './playwright/test.js';
 
-test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
+test('defines itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(
-    () => html`<glide-core-icon-button label="Label">
-      <div>Icon</div>
-    </glide-core-icon-button>`,
+    () =>
+      html`<glide-core-icon-button label="Label">
+        <div>Icon</div>
+      </glide-core-icon-button>`,
   );
 
   const host = page.locator('glide-core-icon-button');
 
-  await expect(host).toBeRegistered('glide-core-icon-button');
+  await expect(host).toBeDefined('glide-core-icon-button');
 });
 
 test(
@@ -18,9 +19,10 @@ test(
   { tag: '@miscellaneous' },
   async ({ callMethod, mount, page }) => {
     await mount(
-      () => html`<glide-core-icon-button label="Label">
-        <div>Icon</div>
-      </glide-core-icon-button>`,
+      () =>
+        html`<glide-core-icon-button label="Label">
+          <div>Icon</div>
+        </glide-core-icon-button>`,
     );
 
     const host = page.locator('glide-core-icon-button');
@@ -36,9 +38,10 @@ test(
   { tag: '@miscellaneous' },
   async ({ mount, page }) => {
     await mount(
-      () => html`<glide-core-icon-button label="Label">
-        <div>Icon</div>
-      </glide-core-icon-button>`,
+      () =>
+        html`<glide-core-icon-button label="Label">
+          <div>Icon</div>
+        </glide-core-icon-button>`,
     );
 
     const host = page.locator('glide-core-icon-button');
@@ -53,9 +56,10 @@ test(
   async ({ mount }) => {
     await expect(
       mount(
-        () => html`<glide-core-icon-button>
-          <div>Icon</div>
-        </glide-core-icon-button>`,
+        () =>
+          html`<glide-core-icon-button>
+            <div>Icon</div>
+          </glide-core-icon-button>`,
       ),
     ).rejects.toThrow();
   },

--- a/src/inline-alert.test.miscellaneous.ts
+++ b/src/inline-alert.test.miscellaneous.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit';
 import { expect, test } from './playwright/test.js';
 
-test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
+test('defines itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(
     () =>
       html`<glide-core-inline-alert variant="informational">
@@ -11,7 +11,7 @@ test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
 
   const host = page.locator('glide-core-inline-alert');
 
-  await expect(host).toBeRegistered('glide-core-inline-alert');
+  await expect(host).toBeDefined('glide-core-inline-alert');
 });
 
 test(

--- a/src/playwright/matchers/to-be-defined.ts
+++ b/src/playwright/matchers/to-be-defined.ts
@@ -1,15 +1,18 @@
 import { type Locator, expect } from '@playwright/test';
 
+/**
+ * Asserts that an element is in the custom element registry.
+ */
 export default expect.extend({
-  async toBeRegistered(locator: Locator, name: string) {
-    const isRegistered = await locator.evaluate((node, name) => {
+  async toBeDefined(locator: Locator, name: string) {
+    const isDefined = await locator.evaluate((node, name) => {
       return window.customElements.get(name) === node.constructor;
     }, name);
 
-    const message = isRegistered
+    const message = isDefined
       ? () => ''
       : () =>
-          this.utils.matcherHint('toBeRegistered', isRegistered, true) +
+          this.utils.matcherHint('toBeDefined', isDefined, true) +
           '\n\n' +
           // Locators have a `toString()` implementation that serializes nicely.
           //
@@ -20,9 +23,9 @@ export default expect.extend({
 
     return {
       message,
-      pass: isRegistered,
-      name: 'toBeRegistered',
-      actual: isRegistered,
+      pass: isDefined,
+      name: 'toBeDefined',
+      actual: isDefined,
       expected: true as const,
     };
   },

--- a/src/playwright/test.ts
+++ b/src/playwright/test.ts
@@ -12,15 +12,15 @@ import removeAttribute from './fixtures/remove-attribute.js';
 import setAttribute from './fixtures/set-attribute.js';
 import setProperty from './fixtures/set-property.js';
 import toBeAccessible from './matchers/to-be-accessible.js';
-import toHaveFormData from './matchers/to-have-form-data.js';
+import toBeDefined from './matchers/to-be-defined.js';
 import toBeExtensible from './matchers/to-be-extensible.js';
-import toBeRegistered from './matchers/to-be-registered.js';
+import toHaveFormData from './matchers/to-have-form-data.js';
 import toDispatchEvents from './matchers/to-dispatch-events.js';
 
 export const expect = mergeExpects(
   toBeAccessible,
+  toBeDefined,
   toBeExtensible,
-  toBeRegistered,
   toDispatchEvents,
   toHaveFormData,
 ) as Expect<{
@@ -30,9 +30,9 @@ export const expect = mergeExpects(
     violations?: string[],
   ) => Promise<void>;
 
-  toBeExtensible: (locator: Locator) => Promise<void>;
+  toBeDefined: (locator: Locator, name: string) => Promise<void>;
 
-  toBeRegistered: (locator: Locator, name: string) => Promise<void>;
+  toBeExtensible: (locator: Locator) => Promise<void>;
 
   toDispatchEvents: (
     locator: Locator,

--- a/src/select.test.miscellaneous.ts
+++ b/src/select.test.miscellaneous.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit';
 import { expect, test } from './playwright/test.js';
 
-test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
+test('defines itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(
     () => html`
       <glide-core-select>
@@ -13,7 +13,7 @@ test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
 
   const host = page.locator('glide-core-select');
 
-  await expect(host).toBeRegistered('glide-core-select');
+  await expect(host).toBeDefined('glide-core-select');
 });
 
 test(

--- a/src/spinner.test.miscellaneous.ts
+++ b/src/spinner.test.miscellaneous.ts
@@ -1,11 +1,23 @@
 import { html } from 'lit';
 import { expect, test } from './playwright/test.js';
 
+test('defines itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
+  await mount(
+    () => html`<glide-core-spinner label="Label"></glide-core-spinner>`,
+  );
+
+  const host = page.locator('glide-core-spinner');
+
+  await expect(host).toBeDefined('glide-core-spinner');
+});
+
 test(
   'cannot be extended',
   { tag: '@miscellaneous' },
   async ({ mount, page }) => {
-    await mount(() => html`<glide-core-spinner label="Label"></glide-core-spinner>`);
+    await mount(
+      () => html`<glide-core-spinner label="Label"></glide-core-spinner>`,
+    );
 
     const host = page.locator('glide-core-spinner');
 

--- a/src/tag.test.miscellaneous.ts
+++ b/src/tag.test.miscellaneous.ts
@@ -1,12 +1,12 @@
 import { html } from 'lit';
 import { expect, test } from './playwright/test.js';
 
-test('registers itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
+test('defines itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(() => html`<glide-core-tag label="Label"></glide-core-tag>`);
 
   const host = page.locator('glide-core-tag');
 
-  await expect(host).toBeRegistered('glide-core-tag');
+  await expect(host).toBeDefined('glide-core-tag');
 });
 
 test('can be removable', { tag: '@miscellaneous' }, async ({ mount, page }) => {


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

- Renamed `toBeRegistered()` to `toBeDefined()`. The former is arguably more natural. But the latter is [standard](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define).
- Added a missing "defines itself" test for Spinner.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

N/A

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
