### PR TITLE
Fill test gaps

### DIFF
--- a/src/accordion.ts
+++ b/src/accordion.ts
@@ -38,7 +38,7 @@ export default class Accordion extends LitElement {
     delegatesFocus: true,
     mode: window.navigator.webdriver ? 'open' : 'closed',
   };
-  /* v8 ignore end */
+  /* v8 ignore stop */
 
   static override styles = styles;
 
@@ -270,7 +270,7 @@ export default class Accordion extends LitElement {
     const assignedNodes = this.#prefixIconSlotElementRef.value?.assignedNodes();
     this.hasPrefixIcon = Boolean(assignedNodes && assignedNodes.length > 0);
   }
-  /* v8 ignore end */
+  /* v8 ignore stop */
 
   /* v8 ignore start */
   #onSuffixIconsSlotChange() {
@@ -279,7 +279,7 @@ export default class Accordion extends LitElement {
 
     this.hasSuffixIcons = Boolean(assignedNodes && assignedNodes.length > 0);
   }
-  /* v8 ignore end */
+  /* v8 ignore stop */
 
   #onSummaryClick(event: MouseEvent) {
     // Canceling it prevents `details` from immediately showing and hiding

--- a/src/button.ts
+++ b/src/button.ts
@@ -45,7 +45,7 @@ export default class Button extends LitElement {
     delegatesFocus: true,
     mode: window.navigator.webdriver ? 'open' : 'closed',
   };
-  /* v8 ignore end */
+  /* v8 ignore stop */
 
   static override styles = styles;
 
@@ -206,12 +206,12 @@ export default class Button extends LitElement {
     const assignedNodes = this.#prefixIconSlotElementRef.value?.assignedNodes();
     this.hasPrefixIcon = Boolean(assignedNodes && assignedNodes.length > 0);
   }
-  /* v8 ignore end */
+  /* v8 ignore stop */
 
   /* v8 ignore start */
   #onSuffixIconSlotChange() {
     const assignedNodes = this.#suffixIconSlotElementRef.value?.assignedNodes();
     this.hasSuffixIcon = Boolean(assignedNodes && assignedNodes.length > 0);
   }
-  /* v8 ignore end */
+  /* v8 ignore stop */
 }

--- a/src/icon-button.ts
+++ b/src/icon-button.ts
@@ -38,7 +38,7 @@ export default class IconButton extends LitElement {
     delegatesFocus: true,
     mode: window.navigator.webdriver ? 'open' : 'closed',
   };
-  /* v8 ignore end */
+  /* v8 ignore stop */
 
   static override styles = styles;
 

--- a/src/select.test.forms.ts
+++ b/src/select.test.forms.ts
@@ -29,7 +29,7 @@ test(
     await mount(
       () => html`
         <form>
-          <glide-core-select open>
+          <glide-core-select open required>
             <button slot="target">Target</button>
 
             <glide-core-options>
@@ -47,16 +47,20 @@ test(
     );
 
     const host = page.locator('glide-core-select');
+    const target = page.getByRole('button');
     const form = page.locator('form');
     const options = page.getByRole('option');
 
     await setProperty(options.nth(0), 'selected', false);
-    await setProperty(options.nth(1), 'selected', true);
+    await setProperty(options.nth(1), 'selected', false);
     await callMethod(form, 'reset');
 
     await expect(options.nth(0)).toHaveJSProperty('selected', true);
     await expect(options.nth(1)).toHaveJSProperty('selected', false);
     await expect(host).toHaveJSProperty('value', ['one']);
+    await expect(host).toHaveJSProperty('validity.valid', true);
+    await expect(host).toHaveJSProperty('validity.valueMissing', false);
+    await expect(target).toHaveJSProperty('ariaInvalid', 'false');
   },
 );
 

--- a/src/spinner.ts
+++ b/src/spinner.ts
@@ -29,7 +29,7 @@ export default class Spinner extends LitElement {
     delegatesFocus: true,
     mode: window.navigator.webdriver ? 'open' : 'closed',
   };
-  /* v8 ignore end */
+  /* v8 ignore stop */
 
   static override styles = styles;
 

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -39,7 +39,7 @@ export default class Tag extends LitElement {
     delegatesFocus: true,
     mode: window.navigator.webdriver ? 'open' : 'closed',
   };
-  /* v8 ignore end */
+  /* v8 ignore stop */
 
   static override styles = styles;
 


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

When we disable code coverage via `v8 ignore stop`, to re-enable is actually `v8 ignore stop`—not `v8 ignore end`. So I replaced the latter with the former everywhere, which revealed a Checkbox test gap.


In filling the gap, I found it hard to understand how validity in Checkbox works. So I reworked Checkbox's validity logic to match Select. It should be easier to understand. @ynotdraw made a ticket for bringing this change to our other form controls.

Also filled a Select test gap.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

N/A

> Menu and Select sub-Menu visual diffs continue. Still mulling what to do about them. The reason for the diffs appears to be some variance in Floating UI. There's a slightly positioning difference from run to run.

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
