### PR TITLE
Update Menu's `isOwnTarget` to account for cases like a Tooltip target

### DIFF
--- a/.changeset/young-towns-wait.md
+++ b/.changeset/young-towns-wait.md
@@ -1,0 +1,20 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Menu options are now keyboard navigable when the target is wrapped in a Tooltip.
+
+```html
+<glide-core-menu>
+  <glide-core-tooltip label="Label" slot="target">
+    <glide-core-icon-button label="Toggle" slot="target">
+      <glide-core-example-icon name="three-dots"></glide-core-example-icon>
+    </glide-core-icon-button>
+  </glide-core-tooltip>
+
+  <glide-core-options>
+    <glide-core-option label="One"></glide-core-option>
+    <glide-core-option label="Two"></glide-core-option>
+  </glide-core-options>
+</glide-core-menu>
+```

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -798,7 +798,9 @@ export default class Menu extends LitElement {
   // On both slots because VoiceOver can focus Options, causing them to emit
   // "keydown" events.
   #onTargetAndDefaultSlotKeyDown(event: KeyboardEvent) {
-    const isOwnTarget = event.target === this.#targetElement;
+    const isOwnTarget =
+      event.target instanceof Element &&
+      this.#targetElement?.contains(event.target);
 
     const isChildOfOptions =
       event.target instanceof Element &&


### PR DESCRIPTION
## 🚀 Description

Update Menu's `isOwnTarget` to account for cases like a Tooltip target.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

Tests should be enough, but generally poke around Menu and make sure nothing is broken. We don't test combining multiple components, as the permutations would be massive.

If you want to test locally, add this to the Menu story as the target:

```html
<glide-core-tooltip label="Label" slot="target">
  <glide-core-icon-button label="Toggle" slot="target">
    <glide-core-example-icon name="three-dots"></glide-core-example-icon>
  </glide-core-icon-button>
</glide-core-tooltip>
```