### PR TITLE
Tweak `test-tag-matches-suite` lint rule

### DIFF
--- a/src/eslint/rules/test-tag-matches-suite.ts
+++ b/src/eslint/rules/test-tag-matches-suite.ts
@@ -32,7 +32,17 @@ export const testTagMatchesSuite = createRule({
 
           const base = path.parse(context.filename).base;
           const isTest = base.includes('__placeholder__');
-          const suite = isTest ? 'eslint' : base.split('.').at(-2);
+
+          let suite = '';
+
+          if (isTest) {
+            suite = 'eslint';
+          } else {
+            const pathParts = base.split('.');
+            const index = pathParts.indexOf('test');
+
+            suite = pathParts.at(index + 1) ?? '';
+          }
 
           if (details?.type === AST_NODE_TYPES.ObjectExpression) {
             const tag = details.properties.find((property) => {


### PR DESCRIPTION
## 🚀 Description

Adjusted our `test-tag-matches-suite` lint rule to account for sub-suites like `select.test.keyboard.multiple.ts`.

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

N/A

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
