### PR TITLE
Hide disabled Option sub-Menu targets

### DIFF
--- a/.changeset/pretty-taxis-burn.md
+++ b/.changeset/pretty-taxis-burn.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Disabled Option sub-Menu targets are now hidden.

--- a/src/option.styles.ts
+++ b/src/option.styles.ts
@@ -126,9 +126,11 @@ export default [
       }
 
       &:hover {
-        &::slotted(*) {
-          color: var(--glide-core-color-interactive-text-link--hover);
-          opacity: 1;
+        &:not(.disabled) {
+          &::slotted(*) {
+            color: var(--glide-core-color-interactive-text-link--hover);
+            opacity: 1;
+          }
         }
       }
 


### PR DESCRIPTION
## 🚀 Description

> ### Patch
>
> Disabled Option sub-Menu targets are now hidden.

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

1. Navigate to Menu in Storybook.
2. Disable Menu's first option.
3. Hover Menu's first option.
4. Verify the option's sub-Menu target isn't visible.

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
