### PR TITLE
Add size="large" to Icon Button

### DIFF
--- a/.changeset/lucky-cars-burn.md
+++ b/.changeset/lucky-cars-burn.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Icon Button now supports a `size` attribute which can be set to `small` or `large`. `small` is the default. It does not apply when `variant="tertiary"`.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -3332,6 +3332,16 @@
             },
             {
               "kind": "field",
+              "name": "size",
+              "type": {
+                "text": "'large' | 'small'"
+              },
+              "default": "'small'",
+              "attribute": "size",
+              "reflects": true
+            },
+            {
+              "kind": "field",
               "name": "variant",
               "type": {
                 "text": "'primary' | 'secondary' | 'tertiary'"
@@ -3404,6 +3414,14 @@
               },
               "default": "false",
               "fieldName": "disabled"
+            },
+            {
+              "name": "size",
+              "type": {
+                "text": "'large' | 'small'"
+              },
+              "default": "'small'",
+              "fieldName": "size"
             },
             {
               "name": "variant",

--- a/src/button.test.visuals.ts
+++ b/src/button.test.visuals.ts
@@ -60,13 +60,30 @@ for (const story of stories) {
             });
 
             test.describe(':active', () => {
-              test('disabled', async ({ page }, test) => {
+              test('disabled=${true}', async ({ page }, test) => {
                 await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
                 await page
                   .locator('glide-core-button')
                   .evaluate((element: Button, variant) => {
                     element.disabled = true;
+                    element.variant = variant;
+                  }, variant);
+
+                await page.locator('glide-core-button').hover();
+                await page.mouse.down();
+
+                await expect(page).toHaveScreenshot(
+                  `${test.titlePath.join('.')}.png`,
+                );
+              });
+
+              test('disabled=${false}', async ({ page }, test) => {
+                await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+                await page
+                  .locator('glide-core-button')
+                  .evaluate((element: Button, variant) => {
                     element.variant = variant;
                   }, variant);
 

--- a/src/icon-button.stories.ts
+++ b/src/icon-button.stories.ts
@@ -27,6 +27,7 @@ const meta: Meta = {
     return html`
       <glide-core-icon-button
         label=${arguments_.label || nothing}
+        size=${arguments_.size === 'small' ? nothing : arguments_.size}
         variant=${arguments_.variant === 'primary'
           ? nothing
           : arguments_.variant}
@@ -42,6 +43,7 @@ const meta: Meta = {
     'addEventListener(event, handler)': '',
     disabled: false,
     variant: 'primary',
+    size: 'small',
     version: '',
   },
   argTypes: {
@@ -73,6 +75,19 @@ const meta: Meta = {
           summary: 'false',
         },
         type: { summary: 'boolean' },
+      },
+    },
+    size: {
+      control: { type: 'radio' },
+      options: ['large', 'small'],
+      table: {
+        defaultValue: {
+          summary: '"small"',
+        },
+        type: {
+          summary: '"large" | "small"',
+          detail: '// Unsupported with `variant="tertiary"`',
+        },
       },
     },
     variant: {

--- a/src/icon-button.styles.ts
+++ b/src/icon-button.styles.ts
@@ -13,14 +13,12 @@ export default [
 
     .component {
       align-items: center;
-      block-size: var(--private-size, 1.625rem);
       border-color: transparent;
       border-radius: var(--glide-core-rounding-base-radius-sm);
       border-style: solid;
       border-width: 1px;
       cursor: pointer;
       display: inline-flex;
-      inline-size: var(--private-size, 1.625rem);
       justify-content: center;
       padding-inline: 0;
       transition-duration: var(--glide-core-duration-moderate-02);
@@ -138,6 +136,16 @@ export default [
             var(--glide-core-color-interactive-icon-active--hover)
           );
         }
+      }
+
+      &.large:not(.tertiary) {
+        block-size: var(--private-size, 2.125rem);
+        inline-size: var(--private-size, 2.125rem);
+      }
+
+      &.small:not(.tertiary) {
+        block-size: var(--private-size, 1.625rem);
+        inline-size: var(--private-size, 1.625rem);
       }
     }
 

--- a/src/icon-button.test.visuals.ts
+++ b/src/icon-button.test.visuals.ts
@@ -7,189 +7,162 @@ const stories = await fetchStories('Icon Button');
 for (const story of stories) {
   test.describe(story.id, () => {
     for (const theme of story.themes) {
-      test.describe(theme, () => {
-        test('disabled', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+      for (const variant of ['primary', 'secondary', 'tertiary'] as const) {
+        test.describe(theme, () => {
+          test.describe(variant, () => {
+            test('disabled=${true}', async ({ page }, test) => {
+              await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
-          await page
-            .locator('glide-core-icon-button')
-            .evaluate<void, IconButton>((element) => {
-              element.disabled = true;
+              await page
+                .locator('glide-core-icon-button')
+                .evaluate((element: IconButton, variant) => {
+                  element.disabled = true;
+                  element.variant = variant;
+                }, variant);
+
+              await expect(page).toHaveScreenshot(
+                `${test.titlePath.join('.')}.png`,
+              );
             });
 
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
+            test('disabled=${false}', async ({ page }, test) => {
+              await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
-        test.describe(':active', () => {
-          test('disabled', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+              await page
+                .locator('glide-core-icon-button')
+                .evaluate((element: IconButton, variant) => {
+                  element.variant = variant;
+                }, variant);
 
-            await page
-              .locator('glide-core-icon-button')
-              .evaluate<void, IconButton>((element) => {
-                element.disabled = true;
-              });
-
-            await page.locator('glide-core-icon-button').hover();
-            await page.mouse.down();
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-
-          test('variant="primary"', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-            await page.locator('glide-core-icon-button').hover();
-            await page.mouse.down();
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-
-          test('variant="secondary"', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-            await page
-              .locator('glide-core-icon-button')
-              .evaluate<void, IconButton>((element) => {
-                element.variant = 'secondary';
-              });
-
-            await page.locator('glide-core-icon-button').hover();
-            await page.mouse.down();
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-
-          test('variant="tertiary"', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-            await page
-              .locator('glide-core-icon-button')
-              .evaluate<void, IconButton>((element) => {
-                element.variant = 'tertiary';
-              });
-
-            await page.locator('glide-core-icon-button').hover();
-            await page.mouse.down();
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-        });
-
-        test(':focus', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-          await page.locator('glide-core-icon-button').focus();
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
-
-        test.describe(':hover', () => {
-          test('disabled', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-            await page
-              .locator('glide-core-icon-button')
-              .evaluate<void, IconButton>((element) => {
-                element.disabled = true;
-              });
-
-            await page.locator('glide-core-icon-button').hover();
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-
-          test('variant="primary"', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-            await page.locator('glide-core-icon-button').hover();
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-
-          test('variant="secondary"', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-            await page
-              .locator('glide-core-icon-button')
-              .evaluate<void, IconButton>((element) => {
-                element.variant = 'secondary';
-              });
-
-            await page.locator('glide-core-icon-button').hover();
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-
-          test('variant="tertiary"', async ({ page }, test) => {
-            await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-            await page
-              .locator('glide-core-icon-button')
-              .evaluate<void, IconButton>((element) => {
-                element.variant = 'tertiary';
-              });
-
-            await page.locator('glide-core-icon-button').hover();
-
-            await expect(page).toHaveScreenshot(
-              `${test.titlePath.join('.')}.png`,
-            );
-          });
-        });
-
-        test('variant="primary"', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-          await page.locator('glide-core-icon-button').waitFor();
-
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
-
-        test('variant="secondary"', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
-
-          await page
-            .locator('glide-core-icon-button')
-            .evaluate<void, IconButton>((element) => {
-              element.variant = 'secondary';
+              await expect(page).toHaveScreenshot(
+                `${test.titlePath.join('.')}.png`,
+              );
             });
 
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
-        });
+            test.describe(':active', () => {
+              test('disabled=${true}', async ({ page }, test) => {
+                await page.goto(`?id=${story.id}&globals=theme:${theme}`);
 
-        test('variant="tertiary"', async ({ page }, test) => {
-          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+                await page
+                  .locator('glide-core-icon-button')
+                  .evaluate((element: IconButton, variant) => {
+                    element.disabled = true;
+                    element.variant = variant;
+                  }, variant);
 
-          await page
-            .locator('glide-core-icon-button')
-            .evaluate<void, IconButton>((element) => {
-              element.variant = 'tertiary';
+                await page.locator('glide-core-icon-button').hover();
+                await page.mouse.down();
+
+                await expect(page).toHaveScreenshot(
+                  `${test.titlePath.join('.')}.png`,
+                );
+              });
+
+              test('disabled=${false}', async ({ page }, test) => {
+                await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+                await page
+                  .locator('glide-core-icon-button')
+                  .evaluate((element: IconButton, variant) => {
+                    element.variant = variant;
+                  }, variant);
+
+                await page.locator('glide-core-icon-button').hover();
+                await page.mouse.down();
+
+                await expect(page).toHaveScreenshot(
+                  `${test.titlePath.join('.')}.png`,
+                );
+              });
             });
 
-          await expect(page).toHaveScreenshot(
-            `${test.titlePath.join('.')}.png`,
-          );
+            test.describe(':focus', () => {
+              test('disabled=${true}', async ({ page }, test) => {
+                await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+                await page
+                  .locator('glide-core-icon-button')
+                  .evaluate((element: IconButton, variant) => {
+                    element.disabled = true;
+                    element.variant = variant;
+                  }, variant);
+
+                await page.locator('glide-core-icon-button').focus();
+
+                await expect(page).toHaveScreenshot(
+                  `${test.titlePath.join('.')}.png`,
+                );
+              });
+
+              test('disabled=${false}', async ({ page }, test) => {
+                await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+                await page
+                  .locator('glide-core-icon-button')
+                  .evaluate((element: IconButton, variant) => {
+                    element.variant = variant;
+                  }, variant);
+
+                await page.locator('glide-core-icon-button').focus();
+
+                await expect(page).toHaveScreenshot(
+                  `${test.titlePath.join('.')}.png`,
+                );
+              });
+            });
+
+            test.describe(':hover', () => {
+              test('disabled=${true}', async ({ page }, test) => {
+                await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+                await page
+                  .locator('glide-core-icon-button')
+                  .evaluate((element: IconButton, variant) => {
+                    element.disabled = true;
+                    element.variant = variant;
+                  }, variant);
+
+                await page.locator('glide-core-icon-button').hover();
+
+                await expect(page).toHaveScreenshot(
+                  `${test.titlePath.join('.')}.png`,
+                );
+              });
+
+              test('disabled=${false}', async ({ page }, test) => {
+                await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+                await page
+                  .locator('glide-core-icon-button')
+                  .evaluate((element: IconButton, variant) => {
+                    element.variant = variant;
+                  }, variant);
+
+                await page.locator('glide-core-icon-button').hover();
+
+                await expect(page).toHaveScreenshot(
+                  `${test.titlePath.join('.')}.png`,
+                );
+              });
+            });
+
+            test('size="large"', async ({ page }, test) => {
+              await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+              await page
+                .locator('glide-core-icon-button')
+                .evaluate((element: IconButton, variant) => {
+                  element.size = 'large';
+                  element.variant = variant;
+                }, variant);
+
+              await expect(page).toHaveScreenshot(
+                `${test.titlePath.join('.')}.png`,
+              );
+            });
+          });
         });
-      });
+      }
     }
   });
 }

--- a/src/icon-button.ts
+++ b/src/icon-button.ts
@@ -22,6 +22,7 @@ declare global {
  * @attr {'true'|'false'|null} [aria-expanded=null]
  * @attr {'true'|'false'|'menu'|'listbox'|'tree'|'grid'|'dialog'|null} [aria-haspopup=null]
  * @attr {boolean} [disabled=false]
+ * @attr {'large'|'small'} [size='small']
  * @attr {'primary'|'secondary'|'tertiary'} [variant='primary']
  *
  * @readonly
@@ -88,6 +89,9 @@ export default class IconButton extends LitElement {
   @property({ type: Boolean, reflect: true }) disabled = false;
 
   @property({ reflect: true, useDefault: true })
+  size: 'large' | 'small' = 'small';
+
+  @property({ reflect: true, useDefault: true })
   variant: 'primary' | 'secondary' | 'tertiary' = 'primary';
 
   @property({ reflect: true })
@@ -115,6 +119,8 @@ export default class IconButton extends LitElement {
           primary: this.variant === 'primary',
           secondary: this.variant === 'secondary',
           tertiary: this.variant === 'tertiary',
+          large: this.size === 'large',
+          small: this.size === 'small',
         })}
         data-test="button"
         type="button"


### PR DESCRIPTION
## 🚀 Description

Add a `size` attribute to Icon Button to allow for `size="large"`.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

Visual tests should be enough, but to test some design-specific asks:

1. Go to Icon Button's story.
2. Switch to the tertiary variant.
3. Toggle between the different sizes.
4. Verify the Icon Button size doesn't change.
