### PR TITLE
Fix Menu accessibility bug

### DIFF
--- a/.changeset/five-hotels-burn.md
+++ b/.changeset/five-hotels-burn.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+The `role` attribute of Select's target is now "listbox" instead of "menu".

--- a/src/menu.test.basics.ts
+++ b/src/menu.test.basics.ts
@@ -91,6 +91,39 @@ it('is accessible when its target is a DIV', async () => {
   expect(target?.role).to.equal('button');
 });
 
+it('is accessible when Options is a menu', async () => {
+  const host = await fixture<Menu>(
+    html`<glide-core-menu>
+      <div slot="target">Target</div>
+
+      <glide-core-options>
+        <glide-core-option label="Label"></glide-core-option>
+      </glide-core-options>
+    </glide-core-menu>`,
+  );
+
+  const target = host.querySelector('div');
+
+  expect(target?.ariaHasPopup).to.equal('true');
+});
+
+it('is accessible when Options is a listbox', async () => {
+  const host = await fixture<Menu>(
+    /* eslint-disable lit-a11y/accessible-name */
+    html`<glide-core-menu>
+      <div slot="target">Target</div>
+
+      <glide-core-options role="listbox">
+        <glide-core-option label="Label"></glide-core-option>
+      </glide-core-options>
+    </glide-core-menu>`,
+  );
+
+  const target = host.querySelector('div');
+
+  expect(target?.ariaHasPopup).to.equal('listbox');
+});
+
 it('is accessible when its target is an SVG', async () => {
   const host = await fixture<Menu>(
     html`<glide-core-menu>

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -1305,8 +1305,13 @@ export default class Menu extends LitElement {
 
       if (this.#isSubMenu && this.#parentOption) {
         this.#parentOption.ariaHasPopup = 'true';
-      } else if (!this.#isSubMenu && this.#targetElement) {
-        this.#targetElement.ariaHasPopup = 'true';
+      } else if (
+        !this.#isSubMenu &&
+        this.#targetElement &&
+        this.#optionsElement
+      ) {
+        this.#targetElement.ariaHasPopup =
+          this.#optionsElement.role === 'listbox' ? 'listbox' : 'true';
       }
 
       if (this.#isFilterable && !this.#isSubMenu) {


### PR DESCRIPTION
## 🚀 Description

> ### Patch
> 
> The `role` attribute of Select's target is now "listbox" instead of "menu".
<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

1. Navigate to Select in Storybook.
2. Verify the `role` of Select's target is `"listbox"`.
3. Navigate to Menu in Storybook.
4. Verify the `role` of Menu target is `"true"`.

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
