### PR TITLE
Remove Options' slot assertion

### DIFF
--- a/.changeset/quick-tires-pick.md
+++ b/.changeset/quick-tires-pick.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Options now allows arbitrary elements in its default slot.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -5775,7 +5775,7 @@
               "name": "",
               "description": "",
               "type": {
-                "text": "Option | Text"
+                "text": "Element | undefined"
               }
             }
           ],

--- a/src/options.test.miscellaneous.ts
+++ b/src/options.test.miscellaneous.ts
@@ -54,18 +54,3 @@ test(
     await expect(host).not.toBeExtensible();
   },
 );
-
-test(
-  'throws its default slot is the wrong type',
-  { tag: '@miscellaneous' },
-  async ({ mount }) => {
-    await expect(
-      mount(
-        () =>
-          html`<glide-core-options>
-            <option>Label</option>
-          </glide-core-options>`,
-      ),
-    ).rejects.toThrow();
-  },
-);

--- a/src/options.ts
+++ b/src/options.ts
@@ -7,9 +7,6 @@ import packageJson from '../package.json' with { type: 'json' };
 import styles from './options.styles.js';
 import final from './library/final.js';
 import uniqueId from './library/unique-id.js';
-import assertSlot from './library/assert-slot.js';
-import Option from './option.js';
-import OptionsGroup from './options.group.js';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -46,7 +43,7 @@ declare global {
  * @readonly
  * @attr {string} [version]
  *
- * @slot {Option | Text}
+ * @slot {Element | undefined}
  *
  * @fires {Event} slotchange
  */
@@ -103,9 +100,8 @@ export default class Options extends LitElement {
       <slot
         ?hidden=${this.privateLoading}
         @slotchange=${this.#onDefaultSlotChange}
-        ${assertSlot([OptionsGroup, Option, Text], true)}
       >
-        <!-- @type {Option | Text} -->
+        <!-- @type {Element | undefined} -->
       </slot>
 
       ${when(this.privateLoading, () => {


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

We've learned that consumers of Options (via Menu and Select) need to be able to put horizontal rules between Option(s).  

We do have an Options Group component that consumers can use. But Options Group semantically implies a group with more than one Option. So it won't work for consumers that want a horizontal rule between singular Option(s).

We _could_ adjust Options' default slot assertion to allow for an `<hr>`. But the horizontal rule may not always be an `<hr>`. It may be a `<div>`, or custom element, styled as a horizontal rule. So I've gotten rid of Option's default slot assertion altogether.



## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

N/A

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
