### PR TITLE
Fix Menu slotted target bug

### DIFF
--- a/.changeset/fuzzy-mugs-fly.md
+++ b/.changeset/fuzzy-mugs-fly.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Menu no longer immediately reopens when its target is a slot and one slotted element is clicked after another.

--- a/src/menu.test.interactions.ts
+++ b/src/menu.test.interactions.ts
@@ -17,6 +17,7 @@ import { click, hover } from './library/mouse.js';
 import Menu from './menu.js';
 import './option.js';
 import Tooltip from './tooltip.js';
+import './select.js';
 
 @customElement('glide-core-options-in-nested-slot')
 class OptionsInNestedSlot extends LitElement {
@@ -2706,6 +2707,32 @@ it('closes child sub-Menus when the target of a super-Menu is disabled', async (
   expect(defaultSlots[0]?.checkVisibility()).to.be.true;
   expect(defaultSlots[1]?.checkVisibility()).to.not.be.ok;
   expect(defaultSlots[2]?.checkVisibility()).to.not.be.ok;
+});
+
+it('closes when its target is a slot and another element in the slot is clicked', async () => {
+  const host = await fixture<Menu>(
+    html`<glide-core-select>
+      <div slot="target">
+        <button>Target</button>
+        <span>Target</span>
+      </div>
+
+      <glide-core-options>
+        <glide-core-option label="Label"></glide-core-option>
+      </glide-core-options>
+    </glide-core-select>`,
+  );
+
+  const button = host.querySelector('button');
+  const span = host.querySelector('span');
+
+  await click(button);
+  await requestIdleCallback(); // Wait for Floating UI
+
+  await click(span);
+  await requestIdleCallback(); // Wait for Floating UI
+
+  expect(host.open).to.be.false;
 });
 
 it('is opened when open and `disabled` is set on its target programmatically', async () => {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -585,7 +585,7 @@ export default class Menu extends LitElement {
   #onComponentFocusOut(event: FocusEvent) {
     const isTargetFocused =
       event.relatedTarget instanceof Element &&
-      this.contains(event.relatedTarget);
+      this.#targetElement?.contains(event.relatedTarget);
 
     this.#hasVoiceOverMovedFocusToOptionsOrAnOption =
       event.target instanceof Option || event.target instanceof Options;


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> 
> Menu no longer immediately reopens when its target is a slot and one slotted element is clicked after another.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

A difficult one to test manually. But [this](https://github.com/CrowdStrike/glide-core/pull/1188/files#diff-aa522480ff718a3cdde90c3c84f5582e382bb8be5c6ec67e7d520f905b664a92R2712-R2737) test should have us covered.

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
