### PR TITLE
Make Label public

### DIFF
--- a/.changeset/chilly-experts-march.md
+++ b/.changeset/chilly-experts-march.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Added a Label component.

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -74,25 +74,39 @@ export default {
           // Now strip out the rest. These are elements inside component slots used primarily
           // for styling.
           for (const $element of $container.querySelectorAll('*')) {
-            const isCoreElement = $element.tagName.startsWith('GLIDE-CORE');
+            const isCoreComponent = $element.tagName.startsWith('GLIDE-CORE');
+
+            const isLabelComponentElement =
+              $element.parentElement?.tagName === 'GLIDE-CORE-LABEL' &&
+              ($element.tagName === 'LABEL' || $element.tagName === 'INPUT');
+
             const isSlotted = Boolean($element.slot);
             const isScriptTag = $element.tagName === 'SCRIPT';
             const isStyleTag = $element.tagName === 'STYLE';
 
-            // IDs are only for internal use and so are removed. You'll find comments in
-            // the Radio Group story explaining why they're needed.
-            $element.removeAttribute('id');
+            if (!isLabelComponentElement) {
+              // IDs are only for internal use and so are removed. You'll find comments in
+              // the Radio Group story explaining why they're needed.
+              $element.removeAttribute('id');
+            }
 
-            if (isScriptTag) {
-              if ($element.type === 'ignore') {
-                // Scripts with `type="ignore"` exist to show consumers what needs
-                // to be imported. `"ignore"` is just a hack to prevent the script
-                // from executing and shouldn't show up in the code example.
-                $element.removeAttribute('type');
-              }
-            } else if (isStyleTag) {
+            if (isScriptTag && $element.type === 'ignore') {
+              // Scripts with `type="ignore"` exist to show consumers what needs
+              // to be imported. `"ignore"` is just a hack to prevent the script
+              // from executing and shouldn't show up in the code example.
+              $element.removeAttribute('type');
+            }
+
+            if (isStyleTag) {
               $element.remove();
-            } else if (!isCoreElement && !isSlotted && !isScriptTag) {
+            }
+
+            if (
+              !isCoreComponent &&
+              !isSlotted &&
+              !isScriptTag &&
+              !isLabelComponentElement
+            ) {
               if ($element.children.length === 0) {
                 // `<div style="margin: 0.625rem;">Panel</div>` → `Panel`
                 $element.replaceWith($element.textContent);

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -4219,12 +4219,12 @@
             },
             {
               "kind": "field",
-              "name": "hide",
+              "name": "hideLabel",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
-              "attribute": "hide",
+              "attribute": "hide-label",
               "reflects": true
             },
             {
@@ -4290,12 +4290,12 @@
               "fieldName": "error"
             },
             {
-              "name": "hide",
+              "name": "hide-label",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
-              "fieldName": "hide"
+              "fieldName": "hideLabel"
             },
             {
               "name": "orientation",
@@ -4339,7 +4339,7 @@
             "name": "LitElement",
             "package": "lit"
           },
-          "tagName": "glide-core-private-label",
+          "tagName": "glide-core-label",
           "customElement": true
         }
       ],
@@ -4354,7 +4354,7 @@
         },
         {
           "kind": "custom-element-definition",
-          "name": "glide-core-private-label",
+          "name": "glide-core-label",
           "declaration": {
             "name": "Label",
             "module": "src/label.ts"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "./styles/fonts.css": "./dist/styles/fonts.css",
     "./styles/*": null,
     "./library/*": null,
-    "./label.js": null,
     "./icons/*": null,
     "./*.styles.js": null
   },

--- a/src/checkbox-group.styles.ts
+++ b/src/checkbox-group.styles.ts
@@ -10,7 +10,7 @@ export default [
       }
     }
 
-    glide-core-private-label::part(private-tooltips) {
+    glide-core-label::part(private-tooltips) {
       align-items: flex-start;
     }
 

--- a/src/checkbox-group.ts
+++ b/src/checkbox-group.ts
@@ -269,12 +269,12 @@ export default class CheckboxGroup extends LitElement implements FormControl {
       data-test="component"
       ${ref(this.#componentElementRef)}
     >
-      <glide-core-private-label
+      <glide-core-label
         label=${ifDefined(this.label)}
         orientation=${this.orientation}
         split=${ifDefined(this.privateSplit ?? undefined)}
         tooltip=${ifDefined(this.tooltip)}
-        ?hide=${this.hideLabel}
+        ?hide-label=${this.hideLabel}
         ?disabled=${this.disabled}
         ?error=${this.#isShowValidationFeedback}
         ?required=${this.required}
@@ -333,7 +333,7 @@ export default class CheckboxGroup extends LitElement implements FormControl {
               </span>`,
           )}
         </div>
-      </glide-core-private-label>
+      </glide-core-label>
     </div>`;
   }
 

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -316,14 +316,14 @@ export default class Checkbox extends LitElement implements FormControl {
           </label>
         `,
         () =>
-          html`<glide-core-private-label
+          html`<glide-core-label
             label=${ifDefined(this.label)}
             orientation=${this.orientation}
             split=${ifDefined(this.privateSplit ?? undefined)}
             tooltip=${ifDefined(this.tooltip)}
             ?disabled=${this.disabled}
             ?error=${this.#isShowValidationFeedback}
-            ?hide=${this.hideLabel}
+            ?hide-label=${this.hideLabel}
             ?required=${this.required}
           >
             <label for="input"> ${this.label} </label>
@@ -405,7 +405,7 @@ export default class Checkbox extends LitElement implements FormControl {
                   </span>`,
               )}
             </div>
-          </glide-core-private-label>`,
+          </glide-core-label>`,
       )}
     </div>`;
   }

--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -22,7 +22,7 @@ export default [
       position: relative;
     }
 
-    glide-core-private-label {
+    glide-core-label {
       &::part(private-control-and-summary) {
         /*
           The Label component's grid column styling combined with the fact that

--- a/src/dropdown.test.focus.ts
+++ b/src/dropdown.test.focus.ts
@@ -40,8 +40,7 @@ it('closes and reports validity when it loses focus', async () => {
   expect(host.shadowRoot?.activeElement).to.be.null;
   expect(host.validity.valid).to.be.false;
 
-  expect(host.shadowRoot?.querySelector('glide-core-private-label')?.error).to
-    .be.true;
+  expect(host.shadowRoot?.querySelector('glide-core-label')?.error).to.be.true;
 });
 
 it('is focused on click', async () => {

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -669,14 +669,14 @@ export default class Dropdown extends LitElement implements FormControl {
       ${onResize(this.#setTagOverflowLimit.bind(this))}
       ${ref(this.#componentElementRef)}
     >
-      <glide-core-private-label
+      <glide-core-label
         label=${ifDefined(this.label)}
         orientation=${this.orientation}
         split=${ifDefined(this.privateSplit ?? undefined)}
         tooltip=${ifDefined(this.tooltip)}
         ?disabled=${this.disabled}
         ?error=${this.#isShowValidationFeedback}
-        ?hide=${this.hideLabel}
+        ?hide-label=${this.hideLabel}
         ?required=${this.required}
       >
         <label for="primary-button" id="label"> ${this.label} </label>
@@ -1141,7 +1141,7 @@ export default class Dropdown extends LitElement implements FormControl {
               </span>`,
           )}
         </div>
-      </glide-core-private-label>
+      </glide-core-label>
     </div>`;
   }
 

--- a/src/form-controls-layout.test.miscellaneous.ts
+++ b/src/form-controls-layout.test.miscellaneous.ts
@@ -103,7 +103,7 @@ test(
       mount(
         () => html`
           <glide-core-form-controls-layout>
-            <input />
+            Text
           </glide-core-form-controls-layout>
         `,
       ),

--- a/src/form-controls-layout.ts
+++ b/src/form-controls-layout.ts
@@ -30,12 +30,12 @@ declare global {
 @customElement('glide-core-form-controls-layout')
 @final
 export default class FormControlsLayout extends LitElement {
-  /* c8 ignore start */
+  /* v8 ignore start */
   static override shadowRootOptions: ShadowRootInit = {
     ...LitElement.shadowRootOptions,
     mode: window.navigator.webdriver ? 'open' : 'closed',
   };
-  /* c8 ignore end */
+  /* v8 ignore stop */
 
   static override styles = styles;
 

--- a/src/input.ts
+++ b/src/input.ts
@@ -286,7 +286,7 @@ export default class Input extends LitElement implements FormControl {
 
   override render() {
     return html`
-      <glide-core-private-label
+      <glide-core-label
         class=${classMap({
           left: this.privateSplit === 'left',
           middle: this.privateSplit === 'middle',
@@ -298,7 +298,7 @@ export default class Input extends LitElement implements FormControl {
         ?disabled=${this.disabled}
         ?error=${this.#isShowValidationFeedback ||
         this.#isMaxCharacterCountExceeded}
-        ?hide=${this.hideLabel}
+        ?hide-label=${this.hideLabel}
         ?required=${this.required}
       >
         <label for="input"> ${this.label} </label>
@@ -462,7 +462,7 @@ export default class Input extends LitElement implements FormControl {
               `
             : nothing}
         </div>
-      </glide-core-private-label>
+      </glide-core-label>
     `;
   }
 

--- a/src/label.stories.ts
+++ b/src/label.stories.ts
@@ -1,0 +1,203 @@
+import './label.js';
+import { html, nothing } from 'lit';
+import { withActions } from '@storybook/addon-actions/decorator';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { when } from 'lit/directives/when.js';
+
+const meta: Meta = {
+  title: 'Label',
+  decorators: [
+    withActions,
+    (story) => html`
+      <script type="ignore">
+        import '@crowdstrike/glide-core/label.js';
+      </script>
+
+      ${story()}
+    `,
+  ],
+  args: {
+    label: 'Label',
+    'slot="default"': 'Label',
+    'slot="control"': '',
+    'slot="description"': '',
+    disabled: false,
+    error: false,
+    'hide-label': false,
+    orientation: 'horizontal',
+    required: false,
+    'slot="summary"': '',
+    split: '',
+    tooltip: '',
+    version: '',
+  },
+  argTypes: {
+    label: {
+      table: {
+        type: {
+          summary: 'string',
+          detail: `
+// Shown in a tooltip when the content of the default slot is truncated and hovered. This attribute's
+// value should be the same as the text content of the default slot.`,
+        },
+      },
+      type: { name: 'string', required: true },
+    },
+    'slot="default"': {
+      table: {
+        type: {
+          summary: 'Element',
+          detail:
+            "// The label for your control. Usually a `<label>`. Don't forget to associate this element with your control using `for`.",
+        },
+      },
+      type: { name: 'string', required: true },
+    },
+    'slot="control"': {
+      control: false,
+      table: {
+        type: {
+          summary: 'Element',
+        },
+      },
+      type: { name: 'function', required: true },
+    },
+    'slot="description"': {
+      table: {
+        type: {
+          summary: 'string | Element',
+          detail: '// Content shown below the "control" slot',
+        },
+      },
+    },
+    disabled: {
+      table: {
+        defaultValue: {
+          summary: 'false',
+        },
+        type: {
+          summary: 'boolean',
+          detail: `
+// Disables the tooltip that's shown on the default slot when it is truncated and hovered. Also adds a
+// "not-allowed" cursor to the "control" slot when hovered.
+`,
+        },
+      },
+    },
+    error: {
+      table: {
+        defaultValue: {
+          summary: 'false',
+        },
+        type: {
+          summary: 'boolean',
+          detail:
+            '// Changes the color of the "description" slot to indicate your control failed to pass validation.',
+        },
+      },
+    },
+    'hide-label': {
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+        },
+      },
+    },
+    orientation: {
+      control: { type: 'radio' },
+      options: ['horizontal', 'vertical'],
+      defaultValue: 'horizontal',
+      table: {
+        defaultValue: { summary: '"horizontal"' },
+        type: { summary: '"horizontal" | "vertical"' },
+      },
+    },
+    required: {
+      table: {
+        defaultValue: {
+          summary: 'false',
+        },
+        table: {
+          type: {
+            detail: '// Adds an asterisk after the default slot',
+          },
+        },
+      },
+    },
+    'slot="summary"': {
+      table: {
+        type: {
+          summary: 'boolean',
+          detail: '// Content shown to the right the "control" slot',
+        },
+      },
+    },
+    split: {
+      control: 'select',
+      options: ['', 'left', 'middle', 'right'],
+      table: {
+        type: {
+          summary: '"left" | "middle" | "right"',
+          detail: `
+// The layout of the default and "control" slots:
+//
+// - "left": 1/3 of the available space for the default slot. 2/3 for "control" slot.
+// - "middle": 1/2 of the available space the default slot. 1/2 for "control" slot.
+// - "right": 2/3 of the available space the default slot. 1/3 for "control" slot.
+`,
+        },
+      },
+    },
+    tooltip: {
+      table: {
+        type: {
+          summary: 'string',
+        },
+      },
+    },
+    version: {
+      control: false,
+      table: {
+        defaultValue: {
+          summary: import.meta.env.VITE_GLIDE_CORE_VERSION,
+        },
+        type: { summary: 'string', detail: '// For debugging' },
+      },
+    },
+  },
+  render(arguments_) {
+    /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
+    return html`
+      <glide-core-label
+        label=${arguments_.label || nothing}
+        orientation=${arguments_.orientation || nothing}
+        split=${arguments_.split || nothing}
+        tooltip=${arguments_.tooltip || nothing}
+        ?disabled=${arguments_.disabled || nothing}
+        ?error=${arguments_.error || nothing}
+        ?hide-label=${arguments_['hide-label'] || nothing}
+        ?required=${arguments_.required || nothing}
+      >
+        <label for="input"> ${arguments_['slot="default"']} </label>
+        <input id="input" slot="control" />
+        ${when(
+          arguments_['slot="summary"'],
+          () =>
+            html` <div slot="summary">${arguments_['slot="summary"']}</div>`,
+        )}
+        ${when(
+          arguments_['slot="description"'],
+          () =>
+            html` <div slot="description">
+              ${arguments_['slot="description"']}
+            </div>`,
+        )}
+      </glide-core-label>
+    `;
+  },
+};
+
+export default meta;
+
+export const Label: StoryObj = {};

--- a/src/label.test.accessibility.ts
+++ b/src/label.test.accessibility.ts
@@ -1,16 +1,47 @@
 import { html } from 'lit';
 import { expect, test } from './playwright/test.js';
+import type Label from './label.js';
 
 test('is accessible', { tag: '@accessibility' }, async ({ mount, page }) => {
   await mount(
     () =>
-      html`<glide-core-private-label tooltip="Tooltip">
+      html`<glide-core-label tooltip="Tooltip">
         <label for="input">Label</label>
         <input id="input" slot="control" />
         <div slot="summary">Summary</div>
         <div slot="description">Description</div>
-      </glide-core-private-label>`,
+      </glide-core-label>`,
   );
 
-  await expect(page).toBeAccessible('glide-core-private-label');
+  await expect(page).toBeAccessible('glide-core-label');
+});
+
+test('hide-label', { tag: '@accessibility' }, async ({ page }) => {
+  await page.goto('?id=label--label');
+
+  await page.locator('glide-core-label').evaluate<void, Label>((element) => {
+    element.hideLabel = true;
+  });
+
+  await expect(page.locator('glide-core-label')).toMatchAriaSnapshot(`
+    - text: Label
+    - textbox "Label"
+  `);
+});
+
+test('tooltip', { tag: '@accessibility' }, async ({ page }) => {
+  await page.goto('?id=label--label');
+
+  await page.locator('glide-core-label').evaluate<void, Label>((element) => {
+    element.tooltip = 'Tooltip';
+  });
+
+  await page.locator('glide-core-tooltip').getByRole('button').focus();
+
+  await expect(page.locator('glide-core-label')).toMatchAriaSnapshot(`
+    - button "Tooltip:"
+    - tooltip "Tooltip"
+    - text: Label
+    - textbox "Label"
+  `);
 });

--- a/src/label.test.miscellaneous.ts
+++ b/src/label.test.miscellaneous.ts
@@ -4,15 +4,15 @@ import { expect, test } from './playwright/test.js';
 test('defines itself', { tag: '@miscellaneous' }, async ({ mount, page }) => {
   await mount(
     () =>
-      html`<glide-core-private-label>
+      html`<glide-core-label>
         <label>Label</label>
         <input slot="control" />
-      </glide-core-private-label>`,
+      </glide-core-label>`,
   );
 
-  const host = page.locator('glide-core-private-label');
+  const host = page.locator('glide-core-label');
 
-  await expect(host).toBeInTheCustomElementRegistry('glide-core-private-label');
+  await expect(host).toBeInTheCustomElementRegistry('glide-core-label');
 });
 
 test(
@@ -21,10 +21,10 @@ test(
   async ({ mount, page }) => {
     await mount(
       () =>
-        html`<glide-core-private-label required>
+        html`<glide-core-label required>
           <label>Label</label>
           <input slot="control" />
-        </glide-core-private-label>`,
+        </glide-core-label>`,
     );
 
     const asterisk = page.getByTestId('asterisk');
@@ -39,10 +39,10 @@ test(
   async ({ mount, page }) => {
     await mount(
       () =>
-        html`<glide-core-private-label tooltip="Tooltip">
+        html`<glide-core-label tooltip="Tooltip">
           <label>Label</label>
           <input slot="control" />
-        </glide-core-private-label>`,
+        </glide-core-label>`,
     );
 
     const tooltip = page.getByTestId('optional-tooltip');
@@ -57,10 +57,10 @@ test(
   async ({ mount, page }) => {
     await mount(
       () =>
-        html`<glide-core-private-label orientation="vertical" tooltip="Tooltip">
+        html`<glide-core-label orientation="vertical" tooltip="Tooltip">
           <label>Label</label>
           <input slot="control" />
-        </glide-core-private-label>`,
+        </glide-core-label>`,
     );
 
     const tooltip = page.getByTestId('optional-tooltip');
@@ -75,13 +75,13 @@ test(
   async ({ mount, page }) => {
     await mount(
       () =>
-        html`<glide-core-private-label>
+        html`<glide-core-label>
           <label>Label</label>
           <input slot="control" />
-        </glide-core-private-label>`,
+        </glide-core-label>`,
     );
 
-    const host = page.locator('glide-core-private-label');
+    const host = page.locator('glide-core-label');
 
     await expect(host).not.toBeExtensible();
   },
@@ -94,9 +94,7 @@ test(
     await expect(
       mount(
         () =>
-          html`<glide-core-private-label
-            ><input slot="control"
-          /></glide-core-private-label>`,
+          html`<glide-core-label><input slot="control" /></glide-core-label>`,
       ),
     ).rejects.toThrow();
   },
@@ -109,9 +107,9 @@ test(
     await expect(
       mount(
         () =>
-          html`<glide-core-private-label>
+          html`<glide-core-label>
             <label>Label</label>
-          </glide-core-private-label>`,
+          </glide-core-label>`,
       ),
     ).rejects.toThrow();
   },

--- a/src/label.test.mouse.ts
+++ b/src/label.test.mouse.ts
@@ -7,10 +7,10 @@ test(
   async ({ mount, page }) => {
     await mount(
       () =>
-        html`<glide-core-private-label>
+        html`<glide-core-label>
           <label> ${'x'.repeat(500)} </label>
           <input slot="control" />
-        </glide-core-private-label>`,
+        </glide-core-label>`,
     );
 
     const tooltip = page.getByTestId('label-tooltip');
@@ -28,10 +28,10 @@ test(
   async ({ mount, page }) => {
     await mount(
       () =>
-        html`<glide-core-private-label>
+        html`<glide-core-label>
           <label> Label </label>
           <input slot="control" />
-        </glide-core-private-label>`,
+        </glide-core-label>`,
     );
 
     const tooltip = page.getByTestId('label-tooltip');

--- a/src/label.test.visuals.ts
+++ b/src/label.test.visuals.ts
@@ -1,0 +1,179 @@
+import { expect, test } from './playwright/test.js';
+import type Label from './label.js';
+import fetchStories from './playwright/fetch-stories.js';
+
+const stories = await fetchStories('Label');
+
+for (const story of stories) {
+  test.describe(story.id, () => {
+    for (const theme of story.themes) {
+      test.describe(theme, () => {
+        test('slot="description"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-label')
+            .evaluate<void, Label>((element) => {
+              const div = document.createElement('div');
+
+              div.textContent = 'Description';
+              div.slot = 'description';
+
+              element.append(div);
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('error', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-label')
+            .evaluate<void, Label>((element) => {
+              const div = document.createElement('div');
+
+              div.textContent = 'Description';
+              div.slot = 'description';
+
+              element.append(div);
+              element.error = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('hide-label', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-label')
+            .evaluate<void, Label>((element) => {
+              element.hideLabel = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('orientation="horizontal"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page.locator('glide-core-label').waitFor();
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('orientation="vertical"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-label')
+            .evaluate<void, Label>((element) => {
+              element.orientation = 'vertical';
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('slot="summary"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-label')
+            .evaluate<void, Label>((element) => {
+              const div = document.createElement('div');
+
+              div.textContent = 'Summary';
+              div.slot = 'summary';
+
+              element.append(div);
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('required', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-label')
+            .evaluate<void, Label>((element) => {
+              element.required = true;
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('split="left"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-label')
+            .evaluate<void, Label>((element) => {
+              element.split = 'left';
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('split="middle"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-label')
+            .evaluate<void, Label>((element) => {
+              element.split = 'middle';
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('split="right"', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-label')
+            .evaluate<void, Label>((element) => {
+              element.split = 'right';
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+
+        test('tooltip', async ({ page }, test) => {
+          await page.goto(`?id=${story.id}&globals=theme:${theme}`);
+
+          await page
+            .locator('glide-core-label')
+            .evaluate<void, Label>((element) => {
+              element.tooltip = 'Tooltip';
+            });
+
+          await expect(page).toHaveScreenshot(
+            `${test.titlePath.join('.')}.png`,
+          );
+        });
+      });
+    }
+  });
+}

--- a/src/label.ts
+++ b/src/label.ts
@@ -14,14 +14,14 @@ import final from './library/final.js';
 
 declare global {
   interface HTMLElementTagNameMap {
-    'glide-core-private-label': Label;
+    'glide-core-label': Label;
   }
 }
 
 /**
  * @attr {boolean} [disabled=false]
  * @attr {boolean} [error=false]
- * @attr {boolean} [hide=false]
+ * @attr {boolean} [hide-label=false]
  * @attr {string} [label]
  * @attr {'horizontal'|'vertical'} [orientation='horizontal']
  * @attr {boolean} [required=false]
@@ -33,7 +33,7 @@ declare global {
  * @slot {Element | string} [description] - Additional information or context
  * @slot {Element | string} [summary] - Additional information or context
  */
-@customElement('glide-core-private-label')
+@customElement('glide-core-label')
 @final
 export default class Label extends LitElement {
   /* v8 ignore start */
@@ -51,8 +51,8 @@ export default class Label extends LitElement {
   @property({ reflect: true, type: Boolean })
   error = false;
 
-  @property({ reflect: true, type: Boolean })
-  hide = false;
+  @property({ attribute: 'hide-label', reflect: true, type: Boolean })
+  hideLabel = false;
 
   @property({ reflect: true, useDefault: true })
   orientation: 'horizontal' | 'vertical' = 'horizontal';
@@ -98,13 +98,13 @@ export default class Label extends LitElement {
         left: this.split === 'left',
         middle: this.split === 'middle',
         right: this.split === 'right',
-        'hidden-label': this.hide,
+        'hidden-label': this.hideLabel,
       })}
     >
       <div
         class=${classMap({
           tooltips: true,
-          hidden: this.hide,
+          hidden: this.hideLabel,
           left: this.split === 'left',
           middle: this.split === 'middle',
           right: this.split === 'right',
@@ -175,7 +175,7 @@ export default class Label extends LitElement {
             disabled: this.disabled,
             vertical: this.orientation === 'vertical',
             summaryless: !this.hasSummarySlot,
-            'hidden-label': this.hide,
+            'hidden-label': this.hideLabel,
           })}
           name="control"
           ${assertSlot()}

--- a/src/radio-group.styles.ts
+++ b/src/radio-group.styles.ts
@@ -24,7 +24,7 @@ export default [
       }
     }
 
-    glide-core-private-label::part(private-tooltips) {
+    glide-core-label::part(private-tooltips) {
       align-items: flex-start;
     }
 

--- a/src/radio-group.ts
+++ b/src/radio-group.ts
@@ -320,14 +320,14 @@ export default class RadioGroup extends LitElement implements FormControl {
         @keydown=${this.#onComponentKeydown}
         ${ref(this.#componentElementRef)}
       >
-        <glide-core-private-label
+        <glide-core-label
           label=${ifDefined(this.label)}
           orientation=${this.orientation}
           split=${ifDefined(this.privateSplit ?? undefined)}
           tooltip=${ifDefined(this.tooltip)}
           ?disabled=${this.disabled}
           ?error=${this.#isShowValidationFeedback}
-          ?hide=${this.hideLabel}
+          ?hide-label=${this.hideLabel}
           ?required=${this.required}
         >
           <label id="label"> ${this.label} </label>
@@ -378,7 +378,7 @@ export default class RadioGroup extends LitElement implements FormControl {
                 </div>`,
             )}
           </div>
-        </glide-core-private-label>
+        </glide-core-label>
       </div>
     `;
   }

--- a/src/slider.styles.ts
+++ b/src/slider.styles.ts
@@ -7,7 +7,7 @@ export default [
   `,
   css`
     /* The designs call for a bit more spacing than the default when vertical. */
-    glide-core-private-label[orientation='vertical']::part(private-tooltips) {
+    glide-core-label[orientation='vertical']::part(private-tooltips) {
       margin-block-end: var(--glide-core-spacing-base-xxs);
     }
 

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -456,7 +456,7 @@ export default class Slider extends LitElement implements FormControl {
     //
     /*  eslint-disable lit-a11y/click-events-have-key-events */
     return html`
-      <glide-core-private-label
+      <glide-core-label
         class=${classMap({
           left: this.privateSplit === 'left',
           middle: this.privateSplit === 'middle',
@@ -467,7 +467,7 @@ export default class Slider extends LitElement implements FormControl {
         tooltip=${ifDefined(this.tooltip)}
         ?disabled=${this.disabled}
         ?error=${this.#isShowValidationFeedback}
-        ?hide=${this.hideLabel}
+        ?hide-label=${this.hideLabel}
         ?required=${this.required}
       >
         <label>${this.label}</label>
@@ -718,7 +718,7 @@ export default class Slider extends LitElement implements FormControl {
               >`,
           )}
         </div>
-      </glide-core-private-label>
+      </glide-core-label>
     `;
   }
 

--- a/src/textarea.styles.ts
+++ b/src/textarea.styles.ts
@@ -21,7 +21,7 @@ export default [
     ${visuallyHidden('.character-count .hidden')}
   `,
   css`
-    glide-core-private-label[orientation='horizontal']::part(private-tooltips) {
+    glide-core-label[orientation='horizontal']::part(private-tooltips) {
       align-items: flex-start;
       margin-block-start: var(--glide-core-spacing-base-sm);
     }

--- a/src/textarea.ts
+++ b/src/textarea.ts
@@ -204,7 +204,7 @@ export default class Textarea extends LitElement implements FormControl {
   }
 
   override render() {
-    return html`<glide-core-private-label
+    return html`<glide-core-label
       label=${ifDefined(this.label)}
       split=${ifDefined(this.privateSplit ?? undefined)}
       tooltip=${ifDefined(this.tooltip)}
@@ -212,7 +212,7 @@ export default class Textarea extends LitElement implements FormControl {
       ?disabled=${this.disabled}
       ?error=${this.#isShowValidationFeedback ||
       this.#isMaxCharacterCountExceeded}
-      ?hide=${this.hideLabel}
+      ?hide-label=${this.hideLabel}
       ?required=${this.required}
     >
       <label class="label" for="textarea">${this.label}</label>
@@ -295,7 +295,7 @@ export default class Textarea extends LitElement implements FormControl {
               >
             </div>`
           : nothing}
-      </div></glide-core-private-label
+      </div></glide-core-label
     >`;
   }
 

--- a/src/toggle.ts
+++ b/src/toggle.ts
@@ -83,13 +83,13 @@ export default class Toggle extends LitElement {
 
   override render() {
     return html`<div data-test="component">
-      <glide-core-private-label
+      <glide-core-label
         label=${ifDefined(this.label)}
         orientation=${this.orientation}
         split=${ifDefined(this.privateSplit ?? undefined)}
         tooltip=${ifDefined(this.tooltip)}
         ?disabled=${this.disabled}
-        ?hide=${this.hideLabel}
+        ?hide-label=${this.hideLabel}
       >
         <label for="input"> ${this.label} </label>
 
@@ -142,7 +142,7 @@ export default class Toggle extends LitElement {
             @type {Element | string}
           -->
         </slot>
-      </glide-core-private-label>
+      </glide-core-label>
     </div>`;
   }
 


### PR DESCRIPTION
## 🚀 Description

In moving Dropdown out of Core, everything private that it relies on either has to be adjusted or made public. 

The way we'd adjust Dropdown to not use our private Label component would be to inline Label's markup and styles into Dropdown. But consumers who create custom form controls other than Dropdown may need Label. So we may as well just make Label public.

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

1. Check out this branch.
2. Take a look at Label's story and verify everything looks correct.
3. Have a poke around Storybook and verify that our form controls work as they do in production.

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
