### PR TITLE
Fix Dropdown event bug

### DIFF
--- a/.changeset/petite-radios-design.md
+++ b/.changeset/petite-radios-design.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown, when multiselect and filterable, now dispatches "input" and "change" events when a selected Dropdown Option is deselected by pressing Backspace in Dropdown's input field.

--- a/src/dropdown.test.events.filterable.ts
+++ b/src/dropdown.test.events.filterable.ts
@@ -58,6 +58,128 @@ it('dispatches an "add" event on Add button selection via Enter', async () => {
   expect(spy.callCount).to.equal(1);
 });
 
+it('dispatches an "input" event when a tag is removed via Backspace', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable multiple>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('input', spy);
+
+  await sendKeys({ press: 'Tab' });
+  await sendKeys({ press: 'Tab' });
+  sendKeys({ press: 'Backspace' });
+
+  const event = await oneEvent(host, 'input');
+
+  expect(event instanceof Event).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches a "change" event when a tag is removed via Backspace', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable multiple>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Two"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('change', spy);
+
+  await sendKeys({ press: 'Tab' }); // "One" tag
+  await sendKeys({ press: 'Tab' }); // Input field
+  sendKeys({ press: 'Backspace' });
+
+  const event = await oneEvent(host, 'change');
+
+  expect(event instanceof Event).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches an "input" event when all tags are removed via Meta + Backspace', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable multiple>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('input', spy);
+
+  await sendKeys({ press: 'Tab' }); // "One" tag
+  await sendKeys({ press: 'Tab' }); // "Two" tag
+  await sendKeys({ press: 'Tab' }); // Input field
+  await sendKeys({ down: 'Meta' });
+  sendKeys({ press: 'Backspace' });
+
+  const event = await oneEvent(host, 'input');
+
+  await sendKeys({ up: 'Meta' });
+
+  expect(event instanceof Event).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
+  expect(spy.callCount).to.equal(1);
+});
+
+it('dispatches a "change" event when all tags are removed via Meta + Backspace', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" filterable multiple>
+      <glide-core-dropdown-option
+        label="One"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option
+        label="Two"
+        selected
+      ></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const spy = sinon.spy();
+  host.addEventListener('change', spy);
+
+  await sendKeys({ press: 'Tab' }); // "One" tag
+  await sendKeys({ press: 'Tab' }); // "Two" tag
+  await sendKeys({ press: 'Tab' }); // Input field
+  await sendKeys({ down: 'Meta' });
+  sendKeys({ press: 'Backspace' });
+
+  const event = await oneEvent(host, 'change');
+
+  await sendKeys({ up: 'Meta' });
+
+  expect(event instanceof Event).to.be.true;
+  expect(event.bubbles).to.be.true;
+  expect(event.composed).to.be.true;
+  expect(spy.callCount).to.equal(1);
+});
+
 it('does not dispatch "input" events on input', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" filterable>

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -2301,6 +2301,12 @@ export default class Dropdown extends LitElement implements FormControl {
       lastSelectedAndNotOverflowingOption.selected = false;
       this.#isEditingOrRemovingTag = false;
 
+      this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+
+      this.dispatchEvent(
+        new Event('change', { bubbles: true, composed: true }),
+      );
+
       return;
     }
 
@@ -2324,6 +2330,12 @@ export default class Dropdown extends LitElement implements FormControl {
       }
 
       this.#isEditingOrRemovingTag = false;
+
+      this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+
+      this.dispatchEvent(
+        new Event('change', { bubbles: true, composed: true }),
+      );
 
       return;
     }


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> 
> Dropdown, when multiselect and filterable, now dispatches "input" and "change" events when a selected Dropdown Option is deselected by pressing Backspace in Dropdown's input field.


## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

1. Check out this branch.
2. Navigate to Dropdown in Storybook.
3. Make Dropdown filterable and multiselect.
4. Select a Dropdown Option.
5. Press Backspace in Dropdown's input field.
6. Verify "input" and "change" events were dispatched.

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
