### PR TITLE
Throw when Toast's `duration` is too short

### DIFF
--- a/.changeset/chubby-bats-bathe.md
+++ b/.changeset/chubby-bats-bathe.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': minor
+---
+
+Toast now throws when its `duration` is less than `3000`.

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -9757,7 +9757,7 @@
                 "text": "number"
               },
               "default": "5000",
-              "description": "Set to `Infinity` to make it persist until dismissed by the user",
+              "description": "Must be at least 3000. Set to `Infinity` to make Toast persist until dismissed by the user.",
               "attribute": "duration",
               "reflects": true
             },
@@ -9853,7 +9853,7 @@
                 "text": "number"
               },
               "default": "5000",
-              "description": "Set to `Infinity` to make it persist until dismissed by the user",
+              "description": "Must be at least 3000. Set to `Infinity` to make Toast persist until dismissed by the user.",
               "fieldName": "duration"
             },
             {

--- a/src/toast.stories.ts
+++ b/src/toast.stories.ts
@@ -92,7 +92,7 @@ const meta: Meta = {
         type: {
           summary: 'number',
           detail:
-            '// Set to `Infinity` to make it persist until dismissed by the user',
+            '// Must be at least `3000`. Set to `Infinity` to make Toast persist until dismissed by the user.',
         },
       },
     },

--- a/src/toast.toasts.ts
+++ b/src/toast.toasts.ts
@@ -157,6 +157,15 @@ export default class Toasts extends LitElement {
   }
 
   static async show(toast: Toast): Promise<void> {
+    // We throw here instead of in Toast so we don't throw twice: once when Toast
+    // is initially added to the page and again when it's added to Toasts below.
+
+    /* v8 ignore start - Tests often set a shorter duration so they finish quickly. */
+    if (toast.duration < 3000 && !window.navigator.webdriver) {
+      throw new RangeError('`duration` must be at least 3 seconds.');
+    }
+    /* v8 ignore stop */
+
     let toasts = document.querySelector('glide-core-private-toasts');
 
     if (!toasts) {

--- a/src/toast.ts
+++ b/src/toast.ts
@@ -17,7 +17,7 @@ declare global {
 
 /**
  * @attr {string} label
- * @attr {number} [duration=5000] - Set to `Infinity` to make it persist until dismissed by the user
+ * @attr {number} [duration=5000] - Must be at least 3000. Set to `Infinity` to make Toast persist until dismissed by the user.
  * @attr {'informational'|'success'|'error'} [variant='informational']
  *
  * @readonly
@@ -47,7 +47,7 @@ export default class Toast extends LitElement {
   privateDescription?: string;
 
   /**
-   * Set to `Infinity` to make it persist until dismissed by the user
+   * Must be at least 3000. Set to `Infinity` to make Toast persist until dismissed by the user.
    **/
   @property({ reflect: true, type: Number, useDefault: true })
   duration = 5000;


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Design wants us to put a floor on Toast's duration:

> ### Minor
>
> Toast now throws when its `duration` is less than `3000`.


## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

1. Check out this branch.
2. Navigate to Toast in Storybook.
3. Add a Toast.
4. Verify there's no error in the console.
5. Set `duration` to more than `3000`.
6. Add a Toast.
7. Verify there's no error in the console.
8. Set `duration` to less than `3000`.
9. Add a Toast.
10. Verify there's an error in the console.

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
