### PR TITLE
Remove Dropdown `aria-required`

### DIFF
--- a/src/dropdown.styles.ts
+++ b/src/dropdown.styles.ts
@@ -8,6 +8,7 @@ export default [
     ${opacityAndScaleAnimation('.options-and-feedback:popover-open')}
     ${skeleton('.loading-feedback')}
     ${visuallyHidden('.item-count')}
+    ${visuallyHidden('.required')}
     ${visuallyHidden('.selected-option-labels')}
   `,
   css`

--- a/src/dropdown.test.accessibility.ts
+++ b/src/dropdown.test.accessibility.ts
@@ -619,7 +619,11 @@ test('required', { tag: '@accessibility' }, async ({ page }) => {
   await page.getByRole('button').focus();
 
   await expect(page.locator('glide-core-dropdown')).toMatchAriaSnapshot(`
-    - text: Label
-    - button "Label"
+    - text: Label required
+    - button "Label required" [expanded]
+    - listbox:
+      - option "One"
+      - option "Two"
+      - option "Three"
   `);
 });

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -658,6 +658,9 @@ export default class Dropdown extends LitElement implements FormControl {
     // worse for screenreader users because they wouldn't discover the Add button until
     // they move focus off the input field.
 
+    // "ariaRequired" is included in the label because `aria-required` is invalid on a
+    // button.
+
     /* eslint-disable lit-a11y/mouse-events-have-key-events, lit-a11y/click-events-have-key-events */
     return html`<div
       class=${classMap({
@@ -679,7 +682,16 @@ export default class Dropdown extends LitElement implements FormControl {
         ?hide-label=${this.hideLabel}
         ?required=${this.required}
       >
-        <label for="primary-button" id="label"> ${this.label} </label>
+        <label for="primary-button" id="label">
+          ${this.label}
+          ${when(
+            this.required && !this.filterable && !this.isFilterable,
+            () =>
+              html`<span class="required">
+                ${this.#localize.term('ariaRequired')}
+              </span>`,
+          )}
+        </label>
 
         <div
           class="dropdown-and-options"
@@ -966,7 +978,6 @@ export default class Dropdown extends LitElement implements FormControl {
                   aria-haspopup="listbox"
                   aria-hidden=${this.filterable || this.isFilterable}
                   aria-labelledby="selected-option-labels label loading-feedback"
-                  aria-required=${this.required}
                   class="primary-button"
                   data-test="primary-button"
                   id="primary-button"

--- a/src/library/localize.ts
+++ b/src/library/localize.ts
@@ -37,6 +37,7 @@ export interface Translation extends DefaultTranslation {
   informational: string;
   loading: string;
   add: string;
+  ariaRequired: string;
 
   announcedCharacterCount: (current: number, maximum: number) => string;
   displayedCharacterCount: (current: number, maximum: number) => string;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -17,6 +17,7 @@
   "informational": "Informational:",
   "loading": "Loading",
   "add": "Add",
+  "ariaRequired": "required",
   "announcedCharacterCount": "Character count {current} of {maximum}",
   "displayedCharacterCount": "{current}/{maximum}",
   "clearEntry": "Clear {label} entry",

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -25,6 +25,7 @@ const translation: Translation = {
   informational: 'Informational:',
   loading: 'Loading',
   add: 'Add',
+  ariaRequired: 'required',
 
   announcedCharacterCount: (current: number, maximum: number) =>
     `Character count ${current} of ${maximum}`,

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1,6 +1,6 @@
 import type { Translation } from '../library/localize.js';
 
-export const PENDING_STRINGS = [] as const;
+export const PENDING_STRINGS = ['ariaRequired'] as const;
 
 type PendingTranslation = (typeof PENDING_STRINGS)[number];
 

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -1,6 +1,6 @@
 import type { Translation } from '../library/localize.js';
 
-export const PENDING_STRINGS = [] as const;
+export const PENDING_STRINGS = ['ariaRequired'] as const;
 
 type PendingTranslation = (typeof PENDING_STRINGS)[number];
 


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

Dropdown uses `aria-required` on its `<button>` so that it's required is announced to screenreaders. But `aria-required` is invalid on `<button>`. So I removed it and instead added some visually hidden "required" text to Dropdown's label.

## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

1. Check out this branch.
2. Navigate to Dropdown in Storybook.
3. Turn on VoiceOver.
4. Verify Dropdown isn't announced as required.
5. Set `required`.
6. Verify Dropdown is announced as required.

<img width="642" height="152" alt="image" src="https://github.com/user-attachments/assets/8164b1bd-25b4-44f2-b780-21b9578bb572" />


<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
