### PR TITLE
Close Dropdown when `readonly`

### DIFF
--- a/.changeset/every-sheep-slide.md
+++ b/.changeset/every-sheep-slide.md
@@ -1,0 +1,5 @@
+---
+'@crowdstrike/glide-core': patch
+---
+
+Dropdown now closes when `readonly` is set initially or programmatically.

--- a/src/dropdown.test.basics.ts
+++ b/src/dropdown.test.basics.ts
@@ -136,9 +136,20 @@ it('gives selected options precedence over `value`', async () => {
   expect(host.value).to.deep.equal(['one']);
 });
 
-it('cannot be open when disabled', async () => {
+it('does not open when open and disabled', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" open disabled>
+      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  const options = host?.shadowRoot?.querySelector('[data-test="options"]');
+  expect(options?.checkVisibility()).to.be.false;
+});
+
+it('does not open when open and readonly', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" open readonly>
       <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
     </glide-core-dropdown>`,
   );

--- a/src/dropdown.test.interactions.ts
+++ b/src/dropdown.test.interactions.ts
@@ -49,6 +49,36 @@ it('does not open when opened programmatically and there are no options', async 
   expect(options?.checkVisibility()).to.be.false;
 });
 
+it('does not open on click when disabled', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" disabled>
+      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await click(host);
+
+  const options = host.shadowRoot?.querySelector('[data-test="options"]');
+
+  expect(host.open).to.be.false;
+  expect(options?.checkVisibility()).to.not.be.ok;
+});
+
+it('does not open on click when `readonly`', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" readonly>
+      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await click(host);
+
+  const options = host.shadowRoot?.querySelector('[data-test="options"]');
+
+  expect(host.open).to.be.false;
+  expect(options?.checkVisibility()).to.not.be.ok;
+});
+
 it('opens on ArrowUp', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label">
@@ -63,38 +93,6 @@ it('opens on ArrowUp', async () => {
 
   expect(host.open).to.be.true;
   expect(options?.checkVisibility()).to.be.true;
-});
-
-it('does not open on ArrowUp when disabled', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" disabled>
-      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'ArrowUp' });
-
-  const options = host.shadowRoot?.querySelector('[data-test="options"]');
-
-  expect(host.open).to.be.false;
-  expect(options?.checkVisibility()).to.be.false;
-});
-
-it('does not open on ArrowUp when `readonly`', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" readonly>
-      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'ArrowUp' });
-
-  const options = host.shadowRoot?.querySelector('[data-test="options"]');
-
-  expect(host.open).to.be.false;
-  expect(options?.checkVisibility()).to.be.false;
 });
 
 it('opens on ArrowDown', async () => {
@@ -114,40 +112,6 @@ it('opens on ArrowDown', async () => {
   expect(options?.checkVisibility()).to.be.true;
 });
 
-it('does not open on ArrowDown when disabled', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" disabled>
-      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'ArrowDown' });
-
-  const options = host.shadowRoot?.querySelector('[data-test="options"]');
-
-  expect(host.open).to.be.false;
-  expect(options?.checkVisibility()).to.be.false;
-});
-
-it('does not open on ArrowDown when `readonly`', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" readonly>
-      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
-      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: 'ArrowDown' });
-
-  const options = host.shadowRoot?.querySelector('[data-test="options"]');
-
-  expect(host.open).to.be.false;
-  expect(options?.checkVisibility()).to.be.false;
-});
-
 it('opens on Space', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label">
@@ -165,38 +129,6 @@ it('opens on Space', async () => {
 
   expect(host.open).to.be.true;
   expect(options?.checkVisibility()).to.be.true;
-});
-
-it('does not open on Space when disabled', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" disabled>
-      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: ' ' });
-
-  const options = host.shadowRoot?.querySelector('[data-test="options"]');
-
-  expect(host.open).to.be.false;
-  expect(options?.checkVisibility()).to.be.false;
-});
-
-it('does not open on Space when `readonly`', async () => {
-  const host = await fixture<Dropdown>(
-    html`<glide-core-dropdown label="Label" readonly>
-      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
-    </glide-core-dropdown>`,
-  );
-
-  await sendKeys({ press: 'Tab' });
-  await sendKeys({ press: ' ' });
-
-  const options = host.shadowRoot?.querySelector('[data-test="options"]');
-
-  expect(host.open).to.be.false;
-  expect(options?.checkVisibility()).to.be.false;
 });
 
 // See the `document` click handler comment in `dropdown.ts` for an explanation.

--- a/src/dropdown.test.interactions.ts
+++ b/src/dropdown.test.interactions.ts
@@ -64,7 +64,7 @@ it('does not open on click when disabled', async () => {
   expect(options?.checkVisibility()).to.not.be.ok;
 });
 
-it('does not open on click when `readonly`', async () => {
+it('does not open on click when readonly', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" readonly>
       <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
@@ -230,6 +230,25 @@ it('opens when open and enabled programmatically', async () => {
   expect(options?.checkVisibility()).to.be.true;
 });
 
+it('opens when open and made not readonly programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" open readonly>
+      <glide-core-dropdown-option
+        label="Label"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  host.readonly = false;
+  await requestIdleCallback(); // Wait for Floating UI
+
+  const options = host?.shadowRoot?.querySelector('[data-test="options"]');
+  expect(options?.checkVisibility()).to.be.true;
+});
+
 it('closes when open and disabled programmatically', async () => {
   const host = await fixture<Dropdown>(
     html`<glide-core-dropdown label="Label" open>
@@ -244,6 +263,26 @@ it('closes when open and disabled programmatically', async () => {
 
   await requestIdleCallback(); // Wait for Floating UI
   host.disabled = true;
+
+  const options = host?.shadowRoot?.querySelector('[data-test="options"]');
+  expect(options?.checkVisibility()).to.be.false;
+});
+
+it('closes when open and made readonly programmatically', async () => {
+  const host = await fixture<Dropdown>(
+    html`<glide-core-dropdown label="Label" open>
+      <glide-core-dropdown-option
+        label="Label"
+        selected
+      ></glide-core-dropdown-option>
+
+      <glide-core-dropdown-option label="Label"></glide-core-dropdown-option>
+    </glide-core-dropdown>`,
+  );
+
+  await requestIdleCallback(); // Wait for Floating UI
+  host.readonly = true;
+  await requestIdleCallback(); // Wait for Floating UI
 
   const options = host?.shadowRoot?.querySelector('[data-test="options"]');
   expect(options?.checkVisibility()).to.be.false;

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -183,7 +183,7 @@ export default class Dropdown extends LitElement implements FormControl {
     const hasChanged = isOpen !== this.#isOpen;
     this.#isOpen = isOpen;
 
-    if (isOpen && hasChanged && !this.disabled) {
+    if (isOpen && hasChanged && !this.disabled && !this.readonly) {
       this.#show();
 
       this.dispatchEvent(
@@ -234,8 +234,23 @@ export default class Dropdown extends LitElement implements FormControl {
   @property()
   privateSplit?: 'left' | 'middle' | 'right';
 
+  /**
+   * @default false
+   */
   @property({ reflect: true, type: Boolean })
-  readonly = false;
+  get readonly(): boolean {
+    return this.#isReadOnly;
+  }
+
+  set readonly(isReadOnly: boolean) {
+    this.#isReadOnly = isReadOnly;
+
+    if (this.open && isReadOnly) {
+      this.#hide();
+    } else if (this.open) {
+      this.#show();
+    }
+  }
 
   @property({ attribute: 'select-all', reflect: true, type: Boolean })
   selectAll = false;
@@ -497,7 +512,7 @@ export default class Dropdown extends LitElement implements FormControl {
       this.#optionsAndFeedbackElementRef.value.popover = 'manual';
     }
 
-    if (this.open && !this.disabled) {
+    if (this.open && !this.disabled && !this.readonly) {
       this.#show();
     }
 
@@ -1358,6 +1373,8 @@ export default class Dropdown extends LitElement implements FormControl {
 
   // See `#setTagOverflowLimit()`.
   #isOverflowTest = false;
+
+  #isReadOnly = false;
 
   // Used in `#onOptionsSelectedChange()` to guard against, among other things,
   // resetting Select All back to its previous value after Select All is selected

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -103,7 +103,7 @@ export default class Dropdown extends LitElement implements FormControl {
     ...LitElement.shadowRootOptions,
     mode: window.navigator.webdriver ? 'open' : 'closed',
   };
-  /* c8 ignore end */
+  /* c8 ignore stop */
 
   static override styles = styles;
 
@@ -754,13 +754,13 @@ export default class Dropdown extends LitElement implements FormControl {
                                 slot="icon"
                               >
                                 <!--
-                                Icons for the selected Dropdown Option(s).
-                                Slot one icon per Dropdown Option.
-                                \`<value>\` should be equal to the \`value\` of each Dropdown Option.
+                                  Icons for the selected Dropdown Option(s).
+                                  Slot one icon per Dropdown Option.
+                                  \`<value>\` should be equal to the \`value\` of each Dropdown Option.
 
-                                @name icon:value
-                                @type {Element}
-                              -->
+                                  @name icon:value
+                                  @type {Element}
+                                -->
                               </slot>
                             `;
                           })}
@@ -1615,10 +1615,6 @@ export default class Dropdown extends LitElement implements FormControl {
   // options can receive focus via VoiceOver, and `.dropdown` won't emit a "keydown"
   // if an option is focused.
   #onDropdownAndOptionsKeydown(event: KeyboardEvent) {
-    if (this.disabled || this.readonly) {
-      return;
-    }
-
     // On Enter and Space, an "edit" event should be dispatched and Dropdown should
     // close. Both Enter and Space result in a "click" event. So no need to dispatch
     // "edit" here. It's dispatched in `#onDropdownClick`. And Dropdown is closed via


### PR DESCRIPTION
## 🚀 Description

<!--

  - Tell us about your changes and the motivation for them.
  - Write "N/A" if your changes are explained by the PR's title.

-->

> ### Patch
> 
> Dropdown now closes when `readonly` is set initially or programmatically.


## 📋 Checklist

<!-- Do the following before adding reviewers: -->

- I have followed the [Contributing Guidelines](https://github.com/crowdstrike/glide-core/blob/main/CONTRIBUTING.md).
- I have added tests to cover new or updated functionality.
- I have added or updated Storybook stories.
- I have [localized](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#translations-and-static-strings) new strings.
- I have followed the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) or met with the Accessibility Team.
- I have included a [changeset](https://github.com/CrowdStrike/glide-core/blob/main/CONTRIBUTING.md#versioning-a-package).
- I have scheduled a design review.
- I have reviewed the Storybook and Visual Test Report links below.

## 🔬 Manual Testing

1. Check out this branch.
2. Navigate to Dropdown in Storybook.
3. Set `readonly`.
4. Set `open`.
5. Verify Dropdown remains closed.

<!--

  Tell us how to manually verify your changes:

  1. Navigate to Checkbox in Storybook.
  1. Click the label.
  1. Verify Checkbox is checked.

  Write "N/A" if your changes can't be manually tested or don't benefit from manual testing.

-->
